### PR TITLE
Add app signing configurations to gradle build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,3 +79,17 @@ static def loadPropertiesFromFile(inputFile) {
     return properties
 }
 
+// For app signing
+if (["storeFile", "storePassword", "keyAlias", "keyPassword"].count { !project.hasProperty(it) } == 0) {
+    android {
+        signingConfigs {
+            release {
+                storeFile = file(project.storeFile.replaceFirst("^~", System.getProperty("user.home")))
+                storePassword = project.storePassword
+                keyAlias = project.keyAlias
+                keyPassword = project.keyPassword
+            }
+        }
+    }
+    android.buildTypes.release.signingConfig = android.signingConfigs.release
+}


### PR DESCRIPTION
Sets up app signing for release builds.

You'll need the signing secrets added to `gradle.properties`. Those can be obtained from the usual place.

### To test
1. `./gradlew clean`
2. `./gradlew assembleRelease`
3. Make sure the APK is generated successfully and you can run it