### PR TITLE
Only try configureTransform on initialized and active surface

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/Camera2BasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/Camera2BasicHandling.kt
@@ -81,7 +81,13 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
         }
 
         override fun onSurfaceTextureSizeChanged(texture: SurfaceTexture, width: Int, height: Int) {
-            configureTransform(width, height)
+            // only try running configureTransform if the surface has already been initialized
+            // and it has changed its size while already live. configureTransform() can only
+            // be run once surface is stable so, on all other cases let's just wait for startUp()
+            // to run the full process.
+            if (textureView.isAvailable && active) {
+                configureTransform(width, height)
+            }
         }
 
         override fun onSurfaceTextureDestroyed(texture: SurfaceTexture) = true


### PR DESCRIPTION
The crash happened because `configureTransform()`  assumes `previewSizes`  has already been instantiated and calculated by the time it gets called. For this, the surface should be initialized and the camera should be active so, adding a safeguard check to only run it in the listener when these 2 conditions are met.
Also to take into account, the configureTransform() will be run anyway on startup in `openCamera()` so, we are sure it will run at least once.

To test:
1. set the `gradle.properties` property
```
portkey.use.cameraX = false
```
2. run the app
3. observe the camera preview is shown on the screen without the app crashing.

