### PR TITLE
Fix lateinit crash when activity is recreated

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
@@ -52,7 +52,6 @@ class BackgroundSurfaceManager(
     fun onCreate(source: LifecycleOwner) {
         // clear surfaceTexture listeners
         photoEditorView.listeners.clear()
-        getStateFromBundle()
 
         // add fragments
         if (useCameraX) {
@@ -61,6 +60,9 @@ class BackgroundSurfaceManager(
             addHandlerFragmentOrFindByTag(CAMERA2)
         }
         addHandlerFragmentOrFindByTag(VIDEOPLAYER)
+
+        // important: only retrieve state after having restored fragments with addHandlerFragmentOrFindByTag as above
+        getStateFromBundle()
 
         if (isCameraVisible || isVideoPlayerVisible) { photoEditorView.toggleTextureView() }
     }


### PR DESCRIPTION
Fix #43 

This PR changes the order in which `getStateFromBundle()` is called, given it needs to tell `cameraBasicHandler()` to do stuff (for example, flip the camera or select the saved camera). 
This is of course not possible if the fragment state have not been restored yet so, changing the call order was needed.