### PR TITLE
Query CamcorderProfile to see which one is available

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/Camera2BasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/Camera2BasicHandling.kt
@@ -761,7 +761,7 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
         mediaRecorder.prepare()
     }
 
-    private fun findCamcorderProfile() : CamcorderProfile {
+    private fun findCamcorderProfile(): CamcorderProfile {
         for (quality in CAMCORDER_QUALITIES) {
             if (CamcorderProfile.hasProfile(cameraId.toInt(), quality)) {
                 return CamcorderProfile.get(quality)


### PR DESCRIPTION
Fixes #20 

This PR tries to find the best available CamcorderProfile quality instead of attempting to get the `CamcorderProfile.QUALITY_480P` compulsively.

The idea of iterating over a few known profiles taken from CameraX[ implementation here](https://android.googlesource.com/platform/frameworks/support/+/fe4b6d14c2d6cd430a335628871eb2abf40fd82a/camera/core/src/main/java/androidx/camera/core/VideoCapture.java#799), commented in https://github.com/Automattic/portkey-android/issues/20#issuecomment-519894136.

To test:

0. make sure to set `portkey.use.cameraX = false` in `gradle.properties`, so the Camera2 implementation is used.
1. on an API 22 emulator (Android 5.1.1), open the app
2. tap on the FAB button to open camera preview
3. start recording
4. observe this crash doesn't happen anymore (another crash happens a few seconds later, but not related to this fix)

