### PR TITLE
Added artificial wait to avoid a new capture request colliding previous request teardown

### DIFF
--- a/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
@@ -484,15 +484,15 @@ class ComposeLoopFrameActivity : AppCompatActivity() {
                         .into(photoEditorView.source)
                     showStaticBackground()
                     currentOriginalCapturedFile = file
+                    waitToReenableCapture()
                 }
 
                 showToast("IMAGE SAVED")
-                cameraOperationInCourse = false
             }
             override fun onError(message: String, cause: Throwable?) {
                 // TODO implement error handling
                 showToast("ERROR SAVING IMAGE")
-                cameraOperationInCourse = false
+                waitToReenableCapture()
             }
         })
     }
@@ -515,6 +515,7 @@ class ComposeLoopFrameActivity : AppCompatActivity() {
             return
         }
 
+        cameraOperationInCourse = true
         // force stop recording video after maximum time limit reached
         timesUpHandler.postDelayed(timesUpRunnable, CAMERA_VIDEO_RECORD_MAX_LENGTH_MS)
         // strat progressing animation
@@ -526,7 +527,7 @@ class ComposeLoopFrameActivity : AppCompatActivity() {
                     // now start playing the video we just recorded
                     showPlayVideo()
                 }
-                cameraOperationInCourse = false
+                waitToReenableCapture()
             }
 
             override fun onError(message: String?, cause: Throwable?) {
@@ -534,7 +535,7 @@ class ComposeLoopFrameActivity : AppCompatActivity() {
                 runOnUiThread {
                     showToast("Video could not be saved: " + message)
                 }
-                cameraOperationInCourse = false
+                waitToReenableCapture()
             }
         })
     }
@@ -573,6 +574,13 @@ class ComposeLoopFrameActivity : AppCompatActivity() {
                 showToast("VIDEO SAVED")
             }
         }
+    }
+
+    // artificial wait to re-enable capture mode
+    private fun waitToReenableCapture() {
+        timesUpHandler.postDelayed({
+            cameraOperationInCourse = false
+        }, CAMERA_STILL_PICTURE_WAIT_FOR_NEXT_CAPTURE_MS)
     }
 
     // this one saves one composed unit: ether an Image or a Video
@@ -974,6 +982,7 @@ class ComposeLoopFrameActivity : AppCompatActivity() {
         private const val SURFACE_MANAGER_READY_LAUNCH_DELAY = 500L
         private const val CAMERA_VIDEO_RECORD_MAX_LENGTH_MS = 10000L
         private const val CAMERA_STILL_PICTURE_ANIM_MS = 300L
+        private const val CAMERA_STILL_PICTURE_WAIT_FOR_NEXT_CAPTURE_MS = 1000L
         private const val STATE_KEY_CURRENT_ORIGINAL_CAPTURED_FILE = "key_current_original_captured_file"
         private const val VIBRATION_INDICATION_LENGTH_MS = 100L
         private const val SWIPE_MIN_DISTANCE = 120


### PR DESCRIPTION
Fixes #82 

In https://github.com/Automattic/portkey-android/pull/80/commits/01f9bbff78c4593b10f675814c6e6bde13a62f45 in #80 we introduced  a flag to make sure to not try processing a new capture request (by tapping on the capture button) until the success/error callbacks were called for the previous (current) request.
However, when tapping the button repeatedly (frantically) we could still incur into a crash, given CameraX handles requests asynchronously so it could happen that the current request already called the success/error callbacks from the host code and yet  was winding down buffers / camera attachment on its own CameraX ThreadPool.

Given we invariably do switch modes once we get a successful capture (that is, we switch from capture mode to the video play or static background modes in our `BackgroundSurfaceManager`), it's enough to introduce a long enough artificial wait time to reset the "capture button available" flag, as it will already be showing the composing screen by the time it happens.

This PR introduces such an artificial wait time of 1000 milliseconds to reset the flag.

