### PR TITLE
Save exception for dataretriever

### DIFF
--- a/app/src/main/java/com/automattic/portkey/compose/photopicker/PhotoPickerAdapter.java
+++ b/app/src/main/java/com/automattic/portkey/compose/photopicker/PhotoPickerAdapter.java
@@ -446,7 +446,6 @@ public class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.
             durationUs = -1;
         } catch (Exception ex) {
             // catch every other exception... we don't want to crash for this for god's sake
-
         } finally {
             mediaMetadataRetriever.release();
         }


### PR DESCRIPTION
Fix #104 

Title has it - we're catching the exception, not worth it running any risk just to obtain the video duration.