### PR TITLE
Initialize originalMatrix from BackgroundSurfaceManager

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
@@ -65,7 +65,7 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
      * An [AutoFitTextureView] for camera preview.
      */
     lateinit var textureView: AutoFitTextureView
-    private lateinit var originalMatrix: Matrix
+    lateinit var originalMatrix: Matrix
 
     private var active: Boolean = false
 

--- a/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
@@ -334,6 +334,7 @@ class BackgroundSurfaceManager(
                     videoPlayerHandling = videoPlayerFragment as VideoPlayingBasicHandling
                     // the photoEditorView layout has been recreated so, re-assign its TextureView
                     videoPlayerHandling.textureView = photoEditorView.textureView
+                    videoPlayerHandling.originalMatrix = photoEditorView.textureView.getTransform(null)
                 }
                 // add video player texture listener
                 photoEditorView.listeners.add(videoPlayerHandling.surfaceTextureListener)


### PR DESCRIPTION
Fixes #102 

The crash was happening when showing the camera preview, then revoking permissions. The crash was happening when showing the camera preview, then revoking permissions. `originalMatrix` in VideoPlayingBasicHandler wasn't initialized when retrieved from saved state so, this fix initializes it from `BackgroundSurfaceManager` when `VideoPlayingBasicHandler` fragment is restored from saved state (the same was as `textureView` is also initialized at that moment as well).