### PR TITLE
WYSIWYG: Use letterbox aspect ratio instead of crop center

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -838,7 +838,11 @@ class PhotoEditor private constructor(builder: Builder) :
 
         Mp4Composer(videoInputPath, videoOutputPath)
             .with(context)
-            .size(width, height)
+//            .size(width, height)
+            // IMPORTANT: as we aim at a WYSIWYG UX, we need to produce a video of size equal to that of the phone
+            // screen, given the user may be seeing a letterbox landscape video and placing emoji / text around
+            // the black parts of the screen.
+            .size(widthParent, heightParent)
             .fillMode(FillMode.PRESERVE_ASPECT_FIT)
             .filter(GlFilterGroup(filterCollection))
             .listener(object : Mp4Composer.Listener {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
@@ -52,7 +52,8 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
 
         override fun onSurfaceTextureSizeChanged(texture: SurfaceTexture, width: Int, height: Int) {
             if (currentExternalUri != null && videoHeight > 0 && videoWidth > 0) {
-                updateTextureViewSizeForCropping(width, height)
+//                updateTextureViewSizeForCropping(width, height)
+                updateTextureViewSizeForLetterbox(videoWidth.toInt(), videoHeight.toInt())
             }
         }
 
@@ -158,7 +159,8 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
             currentExternalUri?.let {
                 textureView.setTransform(originalMatrix)
                 calculateVideoSize(it)
-                updateTextureViewSizeForCropping(textureView.measuredWidth, textureView.measuredHeight)
+                // updateTextureViewSizeForCropping(textureView.measuredWidth, textureView.measuredHeight)
+                updateTextureViewSizeForLetterbox(videoWidth.toInt(), videoHeight.toInt())
                 mediaPlayer = MediaPlayer().apply {
                     setDataSource(context!!, currentExternalUri!!)
                     setSurface(s)
@@ -239,6 +241,38 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
         matrix.setScale(scaleX, scaleY, pivotPointX.toFloat(), pivotPointY.toFloat())
 
         textureView.setTransform(matrix)
+    }
+
+    private fun updateTextureViewSizeForLetterbox(videoWidth: Int, videoHeight: Int) {
+        val viewWidth = textureView.getWidth()
+        val viewHeight = textureView.getHeight()
+        val aspectRatio = videoHeight.toDouble() / videoWidth
+
+        val newWidth: Int
+        val newHeight: Int
+        if (viewHeight > (viewWidth * aspectRatio).toInt()) {
+            // limited by narrow width; restrict height
+            newWidth = viewWidth
+            newHeight = (viewWidth * aspectRatio).toInt()
+        } else {
+            // limited by short height; restrict width
+            newWidth = (viewHeight / aspectRatio).toInt()
+            newHeight = viewHeight
+        }
+        val xoff = (viewWidth - newWidth) / 2
+        val yoff = (viewHeight - newHeight) / 2
+        Log.v(
+            TAG, "video=" + videoWidth + "x" + videoHeight +
+                    " view=" + viewWidth + "x" + viewHeight +
+                    " newView=" + newWidth + "x" + newHeight +
+                    " off=" + xoff + "," + yoff
+        )
+
+        val txform = Matrix()
+        textureView.getTransform(txform)
+        txform.setScale(newWidth.toFloat() / viewWidth, newHeight.toFloat() / viewHeight)
+        txform.postTranslate(xoff.toFloat(), yoff.toFloat())
+        textureView.setTransform(txform)
     }
 
     companion object {


### PR DESCRIPTION
This PR changes things a bit in that we now use letterbox instead of cropping for viewing landscape videos (or for the case, any video that doesn't fit the device screen).

Also given the user can freely lay emoji and text out on the screen, decided to make the output video respect what the user sees following along a WYSIWYG approach, and so we end up having a composed video  that looks like what they were seeing while editing / composing, as much as possible. 

For example the following editing screen:
![Screenshot_20190907-191734](https://user-images.githubusercontent.com/6597771/64480776-5ad10400-d1a4-11e9-94a8-ee372ef4c482.png)

Corresponds to the following end result (composed video using the app):
https://cloudup.com/cIxdxwqFSVi
![portkey](https://user-images.githubusercontent.com/6597771/64480791-b00d1580-d1a4-11e9-9bb1-df473a669541.gif)

