### PR TITLE
WIP - Xiaomi not showing added views

### DIFF
--- a/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
@@ -471,13 +471,6 @@ class ComposeLoopFrameActivity : AppCompatActivity() {
         )
     }
 
-    private fun testEmoji() {
-        val emojisList = PhotoEditor.getEmojis(this)
-        // get some random emoji
-        val randomEmojiPos = (0..emojisList.size).shuffled().first()
-        photoEditor.addEmoji(emojisList.get(randomEmojiPos))
-    }
-
     private fun testSticker() {
         photoEditor.addNewImageView(true, Uri.parse("https://i.giphy.com/Ok4HaWlYrewuY.gif"))
     }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
@@ -7,6 +7,7 @@ import android.graphics.SurfaceTexture
 import android.os.Build
 import android.util.AttributeSet
 import android.util.Log
+import android.view.Choreographer
 import android.view.TextureView
 import android.view.TextureView.SurfaceTextureListener
 import android.view.View
@@ -14,6 +15,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.RelativeLayout
 import androidx.annotation.RequiresApi
+import androidx.core.view.children
 import com.automattic.photoeditor.views.filter.CustomEffect
 import com.automattic.photoeditor.OnSaveBitmap
 import com.automattic.photoeditor.R.styleable
@@ -171,6 +173,25 @@ class PhotoEditorView : RelativeLayout {
 
         // Add brush view
         addView(brushDrawingView, brushParam)
+
+        addLayoutListener()
+    }
+
+    fun addLayoutListener() {
+        Choreographer.getInstance().postFrameCallback(object : Choreographer.FrameCallback {
+            override fun doFrame(p0: Long) {
+                for (child in children) {
+                    if (child.tag == ViewType.EMOJI || child.tag == ViewType.TEXT) {
+                        child.measure(MeasureSpec.makeMeasureSpec(getMeasuredWidth(), MeasureSpec.EXACTLY),
+                            MeasureSpec.makeMeasureSpec(getMeasuredHeight(), MeasureSpec.EXACTLY))
+                        child.layout(0, 0, child.getMeasuredWidth(), child.getMeasuredHeight())
+                    }
+                }
+
+                viewTreeObserver.dispatchOnGlobalLayout()
+                Choreographer.getInstance().postFrameCallback(this)
+            }
+        })
     }
 
     // added this method as a helper due to the reasons outlined here:

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
@@ -265,8 +265,16 @@ class PhotoEditorView : RelativeLayout {
     }
 
     internal fun toggleTextureView(): Boolean {
-        backgroundImage.visibility = autoFitTextureView.visibility.also {
-            autoFitTextureView.visibility = backgroundImage.visibility
+        if (autoFitTextureView.visibility == View.VISIBLE) {
+            autoFitTextureView.visibility = View.GONE // TextureView needs be gone
+        } else {
+            autoFitTextureView.visibility = View.VISIBLE
+        }
+
+        if (backgroundImage.visibility == View.VISIBLE) {
+            backgroundImage.visibility = View.INVISIBLE // but backgroundImage needs be INVISIBLE so its dimens are kept
+        } else {
+            backgroundImage.visibility = View.VISIBLE
         }
         return autoFitTextureView.visibility == View.VISIBLE
     }


### PR DESCRIPTION
**NOTE: THIS IS WIP**

This fixes a weird bug that only appeared on a Xiaomi  Mi 8 with Android 8.1 phone, where adding emojis would just not appear, even though the views were added to the hierarchy these would simply not be displayed.
The views would immediately appear once the TextEditorDialog got displayed, which was weird. At first I thought the Dialog was doing something, and thought of the insets and window handling we're doing to keep things full screen, but figured out it wasn't the case.
I found the same problem in an issue in the React Native repo here https://github.com/facebook/react-native/issues/17968 (look into the “Actual Behavior” subtitle in the description). A few comments down there’s a workaround using Choreographer. Been reading a bit about [Choreographer](https://developer.android.com/reference/android/view/Choreographer) and how views are measured and how it plays a role with updating the hardware display, and it sounded like worth trying.

Right now it misplaces the emoji at top/left corner of the screen, and the "delete" area button doesn't appear (haven't figured out why yet).

![IMG_20190914_104428](https://user-images.githubusercontent.com/6597771/64909649-13cf9b00-d6dd-11e9-9430-c91a4d8fd113.jpg)

Note: if you try this code on a Pixel 2, there are noticeable artifacts such as the emoji will flicker and change position very quickly so, still need to make sure and work more on it.

