### PR TITLE
Fixing portrait mode for all activities

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         <activity
                 android:name="com.automattic.portkey.MainActivity"
                 android:label="@string/app_name"
+                android:screenOrientation="portrait"
                 android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
@@ -50,6 +51,7 @@
         <activity
             android:name=".compose.photopicker.PhotoPickerActivity"
             android:label="@string/photo_picker_title"
+            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar"
             />
 


### PR DESCRIPTION
This makes sure to have all activities set to portrait only orientation, given it was seen on a Moto E5 that would then let the ComposeLoopFrameActivity be also rotated when coming back from the MediaPicker and rotating it.

1. Tap +
2. Select “Upload”
3. Select a photo and tap the checkmark
4. On the editing screen, rotate the device. (Note the image disappears.)
5. Tap the Save button

Result: Black screen.

 

