### PR TITLE
WIP - Pinch to zoom TextView handling

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -29,6 +29,7 @@ import com.automattic.photoeditor.gesture.MultiTouchListener.OnMultiTouchListene
 import com.automattic.photoeditor.util.BitmapUtil
 import com.automattic.photoeditor.views.PhotoEditorView
 import com.automattic.photoeditor.views.ViewType
+import com.automattic.photoeditor.views.ViewType.EMOJI
 import com.automattic.photoeditor.views.added.AddedView
 import com.automattic.photoeditor.views.added.AddedViewList
 import com.automattic.photoeditor.views.brush.BrushDrawingView
@@ -309,7 +310,6 @@ class PhotoEditor private constructor(builder: Builder) :
         brushDrawingView.brushDrawingMode = false
         getLayout(ViewType.EMOJI)?.apply {
             val emojiTextView = findViewById<TextView>(R.id.tvPhotoEditorText)
-
             if (emojiTypeface != null) {
                 emojiTextView.typeface = emojiTypeface
                 emojiTextView.text = emojiName
@@ -359,11 +359,22 @@ class PhotoEditor private constructor(builder: Builder) :
      * @param rootView rootview of image,text and emoji
      */
     private fun addViewToParent(rootView: View, viewType: ViewType, sourceUri: Uri? = null) {
-        val params = RelativeLayout.LayoutParams(
-            ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT
-        )
-        params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE)
-        parentView.addView(rootView, params)
+        if (viewType != EMOJI) {
+            val params = RelativeLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+            params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE)
+            parentView.addView(rootView, params)
+        } else {
+            val params = RelativeLayout.LayoutParams(
+                context.resources.getDimensionPixelSize(R.dimen.autosize_tv_initial_height),
+                context.resources.getDimensionPixelSize(R.dimen.autosize_tv_initial_height)
+            )
+            params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE)
+            rootView.tvPhotoEditorText.layoutParams = params
+
+            parentView.addView(rootView, params)
+        }
         addedViews.add(AddedView(rootView, viewType, sourceUri))
         mOnPhotoEditorListener?.onAddViewListener(viewType, addedViews.size)
     }
@@ -389,14 +400,13 @@ class PhotoEditor private constructor(builder: Builder) :
             ViewType.IMAGE -> rootView = layoutInflater.inflate(R.layout.view_photo_editor_image, null)
             ViewType.EMOJI -> {
                 rootView = layoutInflater.inflate(R.layout.view_photo_editor_text, null)
-                val txtTextEmoji = rootView.tvPhotoEditorText
-                if (txtTextEmoji != null) {
-                    if (mDefaultEmojiTypeface != null) {
-                        txtTextEmoji.typeface = mDefaultEmojiTypeface
+                if (rootView.tvPhotoEditorText != null && mDefaultTextTypeface != null) {
+                    rootView.tvPhotoEditorText.gravity = Gravity.CENTER
+                    if (mDefaultTextTypeface != null) {
+                        rootView.tvPhotoEditorText.typeface = mDefaultTextTypeface
                     }
-                    txtTextEmoji.gravity = Gravity.CENTER
-                    txtTextEmoji.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
                 }
+                rootView.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
             }
         }
 

--- a/photoeditor/src/main/res/layout/view_photo_editor_text.xml
+++ b/photoeditor/src/main/res/layout/view_photo_editor_text.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/tvPhotoEditorText"
     android:layout_width="48dp"
     android:layout_height="48dp"
     android:layout_margin="4dp"
     android:textColor="#000000"
+    app:autoSizeTextType="uniform"
     tools:text="Burhanuddin"
     tools:textColor="@android:color/black" />

--- a/photoeditor/src/main/res/values/dimens.xml
+++ b/photoeditor/src/main/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="autosize_tv_margin">4dp</dimen>
+    <dimen name="autosize_tv_initial_width">96dp</dimen>
+    <dimen name="autosize_tv_initial_height">96dp</dimen>
+</resources>


### PR DESCRIPTION
Fixes #153 

This PR aims at responding to the pinch to zoom gesture on Emoji / TextView with a combination of `scale` and changing the view's `width` and `height`.

There's various parts to this PR:
- 204fb9e does some cleanup; removes no longer used `frmBorder` and `imgClose` handling on views, which were hidden and therefore lacked any specific use
- 253bb50 simplifies the `view_photo_editor_text` layout further and is now  just the minimum needed: a `TextView` with `app:autoSizeTextType="uniform"` to signal we want it to change it's font Size according to the view size
- e25ff09: contains work related to having a special treatment for Emoji (will be the same for `ViewType.TEXT` after we get Emoji right), as it's of particular interest that [`Autosizing TextViews`](https://developer.android.com/guide/topics/ui/look-and-feel/autosizing-textview) need the `width` and `height` to be set in a specific way (and that in turn as well depends on the layout where the views are being placed, in our case `photoEditorView` is a `RelativeLayout`, take a look into the `addViewToParent` method), special note on this comment:

> Note: If you set autosizing in an XML file, it is not recommended to use the value "wrap_content" for the layout_width or layout_height attributes of a TextView. It may produce unexpected results.

=============
**Issues found**
Known issues found with TextViewCompat's Autosizeable TextViews
https://issuetracker.google.com/issues/68787108
https://issuetracker.google.com/issues/38468964

The first one in particular is not good as I can see it's not working well when shrinking on width on emoji

https://cloudup.com/ccGNffHgmKZ
TextView’s autosizeable feature doesn’t seem to work well with emoji when shrinking on width (although it does work well when shrinking on height, as can be seen in the video)

This is work in progress.
