### PR TITLE
Pinch to zoom TextView handling - part 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'https://jitpack.io' }
     }
 
     task checkstyle(type: Checkstyle) {

--- a/photoeditor/build.gradle
+++ b/photoeditor/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.9.0'
     kapt 'com.github.bumptech.glide:compiler:4.9.0'
 
+    implementation 'com.github.AndroidDeveloperLB:AutoFitTextView:8'
+
     implementation project(path: ':mp4compose')
 
     testImplementation 'junit:junit:4.12'

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -339,6 +339,7 @@ class PhotoEditor private constructor(builder: Builder) :
                 })
             }
 
+            // TODO: will uncomment and remove TextViewSizeAwareTouchListener class accordingly in a later PR
 //            val multiTouchListenerInstance = newMultiTouchListener
 //            multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {
 //                override fun onClick() {
@@ -420,7 +421,6 @@ class PhotoEditor private constructor(builder: Builder) :
                             context.resources.displayMetrics
                         )
                 }
-                // rootView.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
             }
         }
 
@@ -574,6 +574,7 @@ class PhotoEditor private constructor(builder: Builder) :
      */
     @UiThread
     fun clearHelperBox() {
+        // TODO will remove this method accordingly once imgCLose and frmBorder are removed from all views
 //        for (i in 0 until parentView.childCount) {
 //            val childAt = parentView.getChildAt(i)
 //            val frmBorder = childAt.findViewById<FrameLayout>(R.id.frmBorder)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -336,7 +336,6 @@ class PhotoEditor private constructor(builder: Builder) :
                     }
                 })
             }
-            emojiTextView.textSize = 56f
 
             val multiTouchListenerInstance = newMultiTouchListener
             multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -16,7 +16,6 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.RelativeLayout
 import android.widget.TextView
@@ -25,7 +24,6 @@ import androidx.annotation.IntRange
 import androidx.annotation.RequiresPermission
 import androidx.annotation.UiThread
 import androidx.emoji.text.EmojiCompat
-import androidx.emoji.text.EmojiCompat.InitCallback
 import com.automattic.photoeditor.gesture.MultiTouchListener
 import com.automattic.photoeditor.gesture.MultiTouchListener.OnMultiTouchListener
 import com.automattic.photoeditor.util.BitmapUtil
@@ -178,24 +176,8 @@ class PhotoEditor private constructor(builder: Builder) :
     fun addImage(desiredImage: Bitmap) {
         getLayout(ViewType.IMAGE)?.apply {
             val imageView = findViewById<ImageView>(R.id.imgPhotoEditorImage)
-            val frmBorder = findViewById<FrameLayout>(R.id.frmBorder)
-            val imgClose = findViewById<ImageView>(R.id.imgPhotoEditorClose)
 
             imageView.setImageBitmap(desiredImage)
-
-            val multiTouchListenerInstance = newMultiTouchListener
-            multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {
-                override fun onClick() {
-                    val isBackgroundVisible = frmBorder.tag != null && frmBorder.tag as Boolean
-                    frmBorder.setBackgroundResource(if (isBackgroundVisible) 0 else R.drawable.rounded_border_tv)
-                    imgClose.visibility = if (isBackgroundVisible) View.GONE else View.VISIBLE
-                    frmBorder.tag = !isBackgroundVisible
-                }
-
-                override fun onLongClick() {}
-            })
-
-            setOnTouchListener(multiTouchListenerInstance)
 
             addViewToParent(this, ViewType.IMAGE)
         }
@@ -204,22 +186,6 @@ class PhotoEditor private constructor(builder: Builder) :
     fun addNewImageView(isAnimated: Boolean, uri: Uri) {
         getLayout(ViewType.IMAGE)?.apply {
             val imageView = findViewById<ImageView>(R.id.imgPhotoEditorImage)
-            val frmBorder = findViewById<FrameLayout>(R.id.frmBorder)
-            val imgClose = findViewById<ImageView>(R.id.imgPhotoEditorClose)
-
-            val multiTouchListenerInstance = newMultiTouchListener
-            multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {
-                override fun onClick() {
-                    val isBackgroundVisible = frmBorder.tag != null && frmBorder.tag as Boolean
-                    frmBorder.setBackgroundResource(if (isBackgroundVisible) 0 else R.drawable.rounded_border_tv)
-                    imgClose.visibility = if (isBackgroundVisible) View.GONE else View.VISIBLE
-                    frmBorder.tag = !isBackgroundVisible
-                }
-
-                override fun onLongClick() {}
-            })
-
-            setOnTouchListener(multiTouchListenerInstance)
 
             addViewToParent(this, if (isAnimated) ViewType.STICKER_ANIMATED else ViewType.IMAGE, uri)
 
@@ -233,22 +199,6 @@ class PhotoEditor private constructor(builder: Builder) :
     fun addNewImageView(isAnimated: Boolean): ImageView? {
         getLayout(ViewType.IMAGE)?.apply {
             val imageView = findViewById<ImageView>(R.id.imgPhotoEditorImage)
-            val frmBorder = findViewById<FrameLayout>(R.id.frmBorder)
-            val imgClose = findViewById<ImageView>(R.id.imgPhotoEditorClose)
-
-            val multiTouchListenerInstance = newMultiTouchListener
-            multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {
-                override fun onClick() {
-                    val isBackgroundVisible = frmBorder.tag != null && frmBorder.tag as Boolean
-                    frmBorder.setBackgroundResource(if (isBackgroundVisible) 0 else R.drawable.rounded_border_tv)
-                    imgClose.visibility = if (isBackgroundVisible) View.GONE else View.VISIBLE
-                    frmBorder.tag = !isBackgroundVisible
-                }
-
-                override fun onLongClick() {}
-            })
-
-            setOnTouchListener(multiTouchListenerInstance)
 
             addViewToParent(this, if (isAnimated) ViewType.STICKER_ANIMATED else ViewType.IMAGE)
 
@@ -270,12 +220,6 @@ class PhotoEditor private constructor(builder: Builder) :
         brushDrawingView.brushDrawingMode = false
         getLayout(ViewType.TEXT)?.apply {
             val textInputTv = findViewById<TextView>(R.id.tvPhotoEditorText)
-            val imgClose = findViewById<ImageView>(R.id.imgPhotoEditorClose)
-            val frmBorder = findViewById<FrameLayout>(R.id.frmBorder)
-
-            // hide cross and background borders for now
-            imgClose.visibility = View.GONE
-            frmBorder.setBackgroundResource(0)
 
             textInputTv.text = text
             textInputTv.setTextColor(colorCodeTextView)
@@ -365,8 +309,6 @@ class PhotoEditor private constructor(builder: Builder) :
         brushDrawingView.brushDrawingMode = false
         getLayout(ViewType.EMOJI)?.apply {
             val emojiTextView = findViewById<TextView>(R.id.tvPhotoEditorText)
-            val frmBorder = findViewById<FrameLayout>(R.id.frmBorder)
-            val imgClose = findViewById<ImageView>(R.id.imgPhotoEditorClose)
 
             if (emojiTypeface != null) {
                 emojiTextView.typeface = emojiTypeface
@@ -395,10 +337,6 @@ class PhotoEditor private constructor(builder: Builder) :
                 })
             }
             emojiTextView.textSize = 56f
-
-            // hide cross and background borders for now
-            imgClose.visibility = View.GONE
-            frmBorder.setBackgroundResource(0)
 
             val multiTouchListenerInstance = newMultiTouchListener
             multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {
@@ -466,9 +404,6 @@ class PhotoEditor private constructor(builder: Builder) :
             // We are setting tag as ViewType to identify what type of the view it is
             // when we remove the view from stack i.e onRemoveViewListener(ViewType viewType, int numberOfAddedViews);
             rootView.tag = viewType
-            val imgClose = rootView.findViewById<ImageView>(R.id.imgPhotoEditorClose)
-            val finalRootView = rootView
-            imgClose?.setOnClickListener { viewUndo(finalRootView, viewType) }
         }
         return rootView
     }
@@ -479,7 +414,7 @@ class PhotoEditor private constructor(builder: Builder) :
      * @param brushDrawingMode true if mode is enabled
      */
     fun setBrushDrawingMode(brushDrawingMode: Boolean) {
-            brushDrawingView.brushDrawingMode = brushDrawingMode
+        brushDrawingView.brushDrawingMode = brushDrawingMode
     }
 
     /**
@@ -615,15 +550,15 @@ class PhotoEditor private constructor(builder: Builder) :
      */
     @UiThread
     fun clearHelperBox() {
-        for (i in 0 until parentView.childCount) {
-            val childAt = parentView.getChildAt(i)
-            val frmBorder = childAt.findViewById<FrameLayout>(R.id.frmBorder)
-            frmBorder?.setBackgroundResource(0)
-            val imgClose = childAt.findViewById<ImageView>(R.id.imgPhotoEditorClose)
-            if (imgClose != null) {
-                imgClose.visibility = View.GONE
-            }
-        }
+//        for (i in 0 until parentView.childCount) {
+//            val childAt = parentView.getChildAt(i)
+//            val frmBorder = childAt.findViewById<FrameLayout>(R.id.frmBorder)
+//            frmBorder?.setBackgroundResource(0)
+//            val imgClose = childAt.findViewById<ImageView>(R.id.imgPhotoEditorClose)
+//            if (imgClose != null) {
+//                imgClose.visibility = View.GONE
+//            }
+//        }
     }
 
     /**

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -1,0 +1,95 @@
+package com.automattic.photoeditor.gesture
+
+import android.annotation.SuppressLint
+import android.view.MotionEvent
+import android.view.View
+import android.widget.TextView
+
+class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : View.OnTouchListener {
+    private var originX = 0f
+    private var originY = 0f
+    private var secondOriginX = 0f
+    private var secondOriginY = 0f
+    private var lastDiffX = 0f
+    private var lastDiffY = 0f
+
+    private var originUp = false
+    private var secondOriginUp = false
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouch(view: View, event: MotionEvent): Boolean {
+        event.offsetLocation(event.rawX - event.x, event.rawY - event.y)
+
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                originUp = false
+                secondOriginUp = false
+                originX = view.x - event.getX(0)
+                originY = view.y - event.getY(0)
+            }
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                secondOriginX = view.x - event.getX(1)
+                secondOriginY = view.y - event.getY(1)
+
+                lastDiffX = Math.abs(secondOriginX - originX)
+                lastDiffY = Math.abs(secondOriginY - originY)
+            }
+            MotionEvent.ACTION_MOVE -> { // a pointer was moved
+                if (event.pointerCount == 2) {
+                    val diffX = Math.abs(event.getX(1) - event.getX(0))
+                    val diffY = Math.abs(event.getY(1) - event.getY(0))
+                    var newWidth = (diffX * view.measuredWidth.toFloat() / lastDiffX).toInt()
+                    var newHeight = (diffY * view.measuredHeight.toFloat() / lastDiffY).toInt()
+
+                    if (newWidth > minWidth && newHeight > minHeight) {
+                        val parentWidth = (view.parent as View).width
+                        val parentHeight = (view.parent as View).height
+                        val params = view.layoutParams
+
+                        if (newWidth + view.x > parentWidth) {
+                            newWidth = parentWidth - view.x.toInt()
+                        }
+                        if (newHeight + view.y > parentHeight) {
+                            newHeight = parentHeight - view.y.toInt()
+                        }
+
+                        params.width = newWidth
+                        params.height = newHeight
+
+                        view.layoutParams = params
+                        view.requestLayout()
+                        lastDiffX = diffX
+                        lastDiffY = diffY
+                    }
+                } else if (!originUp && !secondOriginUp) {
+                    var newX = event.getX(0) + originX
+                    var newY = event.getY(0) + originY
+
+                    if (newX < 0) {
+                        newX = 0f
+                    }
+                    if (newY < 0) {
+                        newY = 0f
+                    }
+
+                    if (newX + view.measuredWidth > (view.parent as View).width) {
+                        newX = (view.parent as View).width.toFloat() - view.measuredWidth
+                    }
+                    if (newY + view.measuredHeight > (view.parent as View).height) {
+                        newY = (view.parent as View).height.toFloat() - view.measuredHeight
+                    }
+
+                    view.x = newX
+                    view.y = newY
+                }
+            }
+            MotionEvent.ACTION_UP -> {
+                originUp = true
+            }
+            MotionEvent.ACTION_POINTER_UP -> {
+                secondOriginUp = true
+            }
+        }
+        return true
+    }
+}

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -3,7 +3,6 @@ package com.automattic.photoeditor.gesture
 import android.annotation.SuppressLint
 import android.view.MotionEvent
 import android.view.View
-import android.widget.TextView
 
 class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : View.OnTouchListener {
     private var originX = 0f

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -57,6 +57,8 @@ class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : Vi
                         params.height = newHeight
 
                         view.layoutParams = params
+                        // note: requestLayout() is needed to get AutoResizeTextView to recalculate its fontSize after a
+                        // change in view's width/height is made
                         view.requestLayout()
                         lastDiffX = diffX
                         lastDiffY = diffY

--- a/photoeditor/src/main/res/layout/view_photo_editor_text.xml
+++ b/photoeditor/src/main/res/layout/view_photo_editor_text.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.lb.auto_fit_textview.AutoResizeTextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/tvPhotoEditorText"
-    android:layout_width="96dp"
-    android:layout_height="96dp"
-    android:layout_margin="4dp"
-    android:padding="4dp"
+    android:layout_width="@dimen/autosize_tv_initial_width"
+    android:layout_height="@dimen/autosize_tv_initial_height"
+    android:layout_margin="@dimen/autosize_tv_margin"
+    android:padding="@dimen/autosize_tv_margin"
     android:textColor="#000000" />
 

--- a/photoeditor/src/main/res/layout/view_photo_editor_text.xml
+++ b/photoeditor/src/main/res/layout/view_photo_editor_text.xml
@@ -2,33 +2,15 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
-
-    <FrameLayout
-        android:id="@+id/frmBorder"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="8dp"
-        android:background="@drawable/rounded_border_tv">
-
-        <TextView
-            android:id="@+id/tvPhotoEditorText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="4dp"
-            android:textColor="#000000"
-            android:textSize="18sp"
-            tools:text="Burhanuddin"
-            tools:textColor="@android:color/black" />
-
-    </FrameLayout>
-
-    <ImageView
-        android:id="@+id/imgPhotoEditorClose"
-        android:layout_width="15dp"
-        android:layout_height="15dp"
-        android:layout_gravity="top|start"
-        android:elevation="1dp"
-        android:src="@drawable/ic_remove" />
-
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <TextView
+        android:id="@+id/tvPhotoEditorText"
+        android:layout_width="108dp"
+        android:layout_height="108dp"
+        android:layout_margin="4dp"
+        android:textColor="#000000"
+        app:autoSizeTextType="uniform"
+        tools:text="Burhanuddin"
+        tools:textColor="@android:color/black" />
 </FrameLayout>

--- a/photoeditor/src/main/res/layout/view_photo_editor_text.xml
+++ b/photoeditor/src/main/res/layout/view_photo_editor_text.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<com.lb.auto_fit_textview.AutoResizeTextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/tvPhotoEditorText"
-    android:layout_width="48dp"
-    android:layout_height="48dp"
+    android:layout_width="96dp"
+    android:layout_height="96dp"
     android:layout_margin="4dp"
-    android:textColor="#000000"
-    tools:text="Burhanuddin"
-    tools:textColor="@android:color/black" />
+    android:padding="4dp"
+    android:textColor="#000000" />
+

--- a/photoeditor/src/main/res/layout/view_photo_editor_text.xml
+++ b/photoeditor/src/main/res/layout/view_photo_editor_text.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <TextView
-        android:id="@+id/tvPhotoEditorText"
-        android:layout_width="108dp"
-        android:layout_height="108dp"
-        android:layout_margin="4dp"
-        android:textColor="#000000"
-        app:autoSizeTextType="uniform"
-        tools:text="Burhanuddin"
-        tools:textColor="@android:color/black" />
-</FrameLayout>
+    android:id="@+id/tvPhotoEditorText"
+    android:layout_width="48dp"
+    android:layout_height="48dp"
+    android:layout_margin="4dp"
+    android:textColor="#000000"
+    tools:text="Burhanuddin"
+    tools:textColor="@android:color/black" />

--- a/photoeditor/src/main/res/values/arrays.xml
+++ b/photoeditor/src/main/res/values/arrays.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <array name="autosize_text_sizes">
+        <item>10sp</item>
+        <item>12sp</item>
+        <item>20sp</item>
+        <item>40sp</item>
+        <item>100sp</item>
+    </array>
+</resources>

--- a/photoeditor/src/main/res/values/dimens.xml
+++ b/photoeditor/src/main/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="autosize_tv_margin">4dp</dimen>
+    <dimen name="autosize_tv_initial_width">96dp</dimen>
+    <dimen name="autosize_tv_initial_height">96dp</dimen>
+</resources>


### PR DESCRIPTION
Fixes #153 

Note: builds on part of #202, but uses a different library (https://github.com/AndroidDeveloperLB/AutoFitTextView, licensed under Apache 2.0) that correctly handles `fontSize` calculations for both `height` and `width` changes.
Also, cherry-picks some of changes resulting from the explorations in #203.

This approach seems to work well as can be seen on this video:
https://cloudup.com/c22NSjjGLW0

**Copying from original PR**
This PR aims at responding to the pinch to zoom gesture on Emoji / TextView with a combination of `scale` and changing the view's `width` and `height`.

There's various parts to this PR:
- 2f4fd0c and ad5187e do some cleanup; removes no longer used `frmBorder` and `imgClose` handling on views, which were hidden and therefore lacked any specific use
- e91450c: introduces the `AutoFitTextView` library (but not [Google's Autosizing TextViews](https://developer.android.com/guide/topics/ui/look-and-feel/autosizing-textview) given [problems found with cropping on width changes](https://github.com/Automattic/portkey-android/pull/202#issuecomment-557560742)), and  contains work related to having a special treatment for Emoji  when adding views (will be the same for `ViewType.TEXT` after we get Emoji right), as it's of particular interest that need the `width` and `height` to be set in a specific way (and that in turn as well depends on the layout where the views are being placed, in our case `photoEditorView` is a `RelativeLayout`, take a look into the `addViewToParent` method).
- e91450c also: introduces a helper touch listener that comes in handy to only work on width/height treatment for now (needed for the fontSize to get changed accordingly). Will either probably remove this listener down the line or add scaling / rotation handling to it, we'll see.

