### PR TITLE
Sets default maximum font size for emoji to 112sp

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -412,7 +412,6 @@ class PhotoEditor private constructor(builder: Builder) :
                         txtTextEmoji.typeface = mDefaultEmojiTypeface
                     }
                     txtTextEmoji.gravity = Gravity.CENTER
-                    txtTextEmoji.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
                     txtTextEmoji.textSize =
                         TypedValue.applyDimension(
                             TypedValue.COMPLEX_UNIT_SP,
@@ -1126,7 +1125,7 @@ class PhotoEditor private constructor(builder: Builder) :
         private const val TAG = "PhotoEditor"
         // idea taken from TextView's source code, setting maximum of 112sp for fontSize
         // see https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/TextView.java#891
-        private const val DEFAULT_AUTO_SIZE_MAX_TEXT_SIZE_IN_SP = 152f
+        private const val DEFAULT_AUTO_SIZE_MAX_TEXT_SIZE_IN_SP = 112f
 
         private fun convertEmoji(emoji: String): String {
             return try {


### PR DESCRIPTION
Fixes #205 

Builds on top of #204.

Inspired by `TextView`'s source code [here](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/TextView.java#891) and [here](https://androidx.tech/artifacts/appcompat/appcompat/1.1.0-rc01-source/androidx/appcompat/widget/AppCompatTextViewAutoSizeHelper.java.html):
```
    // Default maximum size for auto-sizing text in scaled pixels.
    private static final int DEFAULT_AUTO_SIZE_MAX_TEXT_SIZE_IN_SP = 112;
```

this PR sets a default maximum `fontSize` of `112sp` as well for emojis, given otherwise at some point these can't be rendered anymore with the error described in issue #205.

Given I haven't found a way to obtain the Font Family's  maximum supported font size, or even calculate this on runtime (*), I think going with `TextView`'s own defaults is conservative enough as to avoid having other problems.

To test:
1. capture an image
2. tap on the stickers option, top-right of the screen
3. choose any emoji
4. pinch to resize (zoom) and try to make the view as large as possible, observe the emoji stops resizing at some point but it never disappears on this branch.

**Note:** have in mind the current listener on this branch doens't support rotation or view scaling (it only changes the view's width/height to provoke `fontSize` to change accordingly). This means, rotating will not work on this branch, and that's expected.

**(*)EDIT** also note that I've tried other approaches for calculating the maximum renderable font size, for example using the approach [described here](https://stackoverflow.com/questions/50965784/canvas-drawtext-doesnt-render-large-emojis-on-android) but it still fails given the error looks to be a runtime problem related to rendering on the screen rather than figuring out supported font sizes for a given font. In fact, for the algorithm run there I also get 256.0 as per the maximum renderable fontSize. Code changes with this test [can be seen here](https://github.com/Automattic/portkey-android/compare/issue/153-textview-fontsize-cleanup...issue/205-emoji-max-text-size-calculation?expand=1) on branch [`issue/205-emoji-max-text-size-calculation`](https://github.com/Automattic/portkey-android/tree/issue/205-emoji-max-text-size-calculation)