### PR TITLE
[DO NOT MERGE] Detecting rotation gesture (AutoResizeTextView-based scaling refactor part 2)

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -339,7 +339,6 @@ class PhotoEditor private constructor(builder: Builder) :
                 })
             }
 
-            // TODO: will uncomment and remove TextViewSizeAwareTouchListener class accordingly in a later PR
 //            val multiTouchListenerInstance = newMultiTouchListener
 //            multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {
 //                override fun onClick() {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/RotationGestureDetector.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/RotationGestureDetector.kt
@@ -1,0 +1,80 @@
+package com.automattic.photoeditor.gesture
+
+import android.view.MotionEvent
+import android.view.View
+
+class RotationGestureDetector(private val mListener: OnRotationGestureListener?) {
+    private var fX: Float = 0.toFloat()
+    private var fY: Float = 0.toFloat()
+    private var sX: Float = 0.toFloat()
+    private var sY: Float = 0.toFloat()
+    private var ptrID1: Int = 0
+    private var ptrID2: Int = 0
+    var angle: Float = 0.toFloat()
+        private set
+
+    init {
+        ptrID1 = INVALID_POINTER_ID
+        ptrID2 = INVALID_POINTER_ID
+    }
+
+    fun onTouchEvent(view: View, event: MotionEvent): Boolean {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> ptrID1 = event.getPointerId(event.actionIndex)
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                ptrID2 = event.getPointerId(event.actionIndex)
+                sX = event.getX(event.findPointerIndex(ptrID1))
+                sY = event.getY(event.findPointerIndex(ptrID1))
+                fX = event.getX(event.findPointerIndex(ptrID2))
+                fY = event.getY(event.findPointerIndex(ptrID2))
+            }
+            MotionEvent.ACTION_MOVE -> if (ptrID1 != INVALID_POINTER_ID && ptrID2 != INVALID_POINTER_ID) {
+                val nfX: Float
+                val nfY: Float
+                val nsX: Float
+                val nsY: Float
+                nsX = event.getX(event.findPointerIndex(ptrID1))
+                nsY = event.getY(event.findPointerIndex(ptrID1))
+                nfX = event.getX(event.findPointerIndex(ptrID2))
+                nfY = event.getY(event.findPointerIndex(ptrID2))
+
+                angle = angleBetweenLines(fX, fY, sX, sY, nfX, nfY, nsX, nsY)
+                mListener?.onRotation(view, angle)
+            }
+            MotionEvent.ACTION_UP -> ptrID1 = INVALID_POINTER_ID
+            MotionEvent.ACTION_POINTER_UP -> ptrID2 = INVALID_POINTER_ID
+            MotionEvent.ACTION_CANCEL -> {
+                ptrID1 = INVALID_POINTER_ID
+                ptrID2 = INVALID_POINTER_ID
+            }
+        }
+        return true
+    }
+
+    private fun angleBetweenLines(
+        fX: Float,
+        fY: Float,
+        sX: Float,
+        sY: Float,
+        nfX: Float,
+        nfY: Float,
+        nsX: Float,
+        nsY: Float
+    ): Float {
+        val angle1 = Math.atan2((fY - sY).toDouble(), (fX - sX).toDouble()).toFloat()
+        val angle2 = Math.atan2((nfY - nsY).toDouble(), (nfX - nsX).toDouble()).toFloat()
+
+        var angle = Math.toDegrees((angle1 - angle2).toDouble()).toFloat() % 360
+        if (angle < -180f) angle += 360.0f
+        if (angle > 180f) angle -= 360.0f
+        return angle
+    }
+
+    interface OnRotationGestureListener {
+        fun onRotation(view: View, angle: Float)
+    }
+
+    companion object {
+        private val INVALID_POINTER_ID = -1
+    }
+}

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/RotationGestureDetector.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/RotationGestureDetector.kt
@@ -3,7 +3,7 @@ package com.automattic.photoeditor.gesture
 import android.view.MotionEvent
 import android.view.View
 
-class RotationGestureDetector(private val mListener: OnRotationGestureListener?) {
+class RotationGestureDetector {
     private var fX: Float = 0.toFloat()
     private var fY: Float = 0.toFloat()
     private var sX: Float = 0.toFloat()
@@ -56,7 +56,8 @@ class RotationGestureDetector(private val mListener: OnRotationGestureListener?)
                     currentSpanVector
                 )
 
-                mListener?.onRotation(view, angle)
+                // set calculated rotation on view
+                view.rotation += angle
             }
             MotionEvent.ACTION_UP -> ptrID1 = INVALID_POINTER_ID
             MotionEvent.ACTION_POINTER_UP -> ptrID2 = INVALID_POINTER_ID
@@ -66,10 +67,6 @@ class RotationGestureDetector(private val mListener: OnRotationGestureListener?)
             }
         }
         return true
-    }
-
-    interface OnRotationGestureListener {
-        fun onRotation(view: View, angle: Float)
     }
 
     companion object {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -3,8 +3,10 @@ package com.automattic.photoeditor.gesture
 import android.annotation.SuppressLint
 import android.view.MotionEvent
 import android.view.View
+import com.automattic.photoeditor.gesture.RotationGestureDetector.OnRotationGestureListener
 
-class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : View.OnTouchListener {
+class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : View.OnTouchListener,
+    OnRotationGestureListener {
     private var originX = 0f
     private var originY = 0f
     private var secondOriginX = 0f
@@ -14,9 +16,19 @@ class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : Vi
 
     private var originUp = false
     private var secondOriginUp = false
+    private var rotationDetector: RotationGestureDetector
+
+    init {
+        rotationDetector = RotationGestureDetector(this)
+    }
+
+    override fun onRotation(view: View, angle: Float) {
+        view.rotation = angle
+    }
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouch(view: View, event: MotionEvent): Boolean {
+        rotationDetector.onTouchEvent(view, event)
         event.offsetLocation(event.rawX - event.x, event.rawY - event.y)
 
         when (event.actionMasked) {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -23,7 +23,7 @@ class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : Vi
     }
 
     override fun onRotation(view: View, angle: Float) {
-        view.rotation = angle
+        view.rotation += angle
     }
 
     @SuppressLint("ClickableViewAccessibility")

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -3,10 +3,8 @@ package com.automattic.photoeditor.gesture
 import android.annotation.SuppressLint
 import android.view.MotionEvent
 import android.view.View
-import com.automattic.photoeditor.gesture.RotationGestureDetector.OnRotationGestureListener
 
-class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : View.OnTouchListener,
-    OnRotationGestureListener {
+class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : View.OnTouchListener {
     private var originX = 0f
     private var originY = 0f
     private var secondOriginX = 0f
@@ -19,11 +17,7 @@ class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : Vi
     private var rotationDetector: RotationGestureDetector
 
     init {
-        rotationDetector = RotationGestureDetector(this)
-    }
-
-    override fun onRotation(view: View, angle: Float) {
-        view.rotation += angle
+        rotationDetector = RotationGestureDetector()
     }
 
     @SuppressLint("ClickableViewAccessibility")

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -78,20 +78,6 @@ class TextViewSizeAwareTouchListener(val minWidth: Int, val minHeight: Int) : Vi
                     var newX = event.getX(0) + originX
                     var newY = event.getY(0) + originY
 
-                    if (newX < 0) {
-                        newX = 0f
-                    }
-                    if (newY < 0) {
-                        newY = 0f
-                    }
-
-                    if (newX + view.measuredWidth > (view.parent as View).width) {
-                        newX = (view.parent as View).width.toFloat() - view.measuredWidth
-                    }
-                    if (newY + view.measuredHeight > (view.parent as View).height) {
-                        newY = (view.parent as View).height.toFloat() - view.measuredHeight
-                    }
-
                     view.x = newX
                     view.y = newY
                 }


### PR DESCRIPTION
Builds on top of #204 

Trying to detect a rotation gesture and applying it to the `TextView` accordingly.

~**Known issue:** currently this PR has an obvious issue: the coordinate system on the View is changed as we move our fingers so, on each iteration in the stream of MotionEvent the width/height may end up changing. Moving slow enough is useful to get an idea of how the effect is working.~
Fixed in https://github.com/Automattic/portkey-android/pull/208/commits/8aac73bcb925208e5ff7a63a23d236de1ce8df60

To test:
1. open the app, take a picture and add an emoji
2. observe you can pinch to zoom and rotate the emoji accordingly
Note: the emoji will disappear as per #205 until #206 gets merged so, it's expected. Also note, the delete view will not appear while handling the emoji; this is a toDo item in #207