### PR TITLE
[DO NOT MERGE] TextViewSizeAwareTouchListener deleteView behavior support (scaling refactor part 3)

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -354,7 +354,8 @@ class PhotoEditor private constructor(builder: Builder) :
 
             setOnTouchListener(
                 TextViewSizeAwareTouchListener(
-                    50, 50,
+                    resources.getDimensionPixelSize(R.dimen.autosize_tv_minimum_width),
+                    resources.getDimensionPixelSize(R.dimen.autosize_tv_minimum_height),
                     deleteView,
                     object : OnDeleteViewListener {
                         override fun onRemoveViewListener(removedView: View) {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -27,6 +27,7 @@ import androidx.emoji.text.EmojiCompat
 import com.automattic.photoeditor.gesture.MultiTouchListener
 import com.automattic.photoeditor.gesture.MultiTouchListener.OnMultiTouchListener
 import com.automattic.photoeditor.gesture.TextViewSizeAwareTouchListener
+import com.automattic.photoeditor.gesture.TextViewSizeAwareTouchListener.OnDeleteViewListener
 import com.automattic.photoeditor.util.BitmapUtil
 import com.automattic.photoeditor.views.PhotoEditorView
 import com.automattic.photoeditor.views.ViewType
@@ -351,7 +352,23 @@ class PhotoEditor private constructor(builder: Builder) :
 //            })
 //            setOnTouchListener(multiTouchListenerInstance)
 
-            setOnTouchListener(TextViewSizeAwareTouchListener(50, 50))
+            setOnTouchListener(
+                TextViewSizeAwareTouchListener(
+                    50, 50,
+                    deleteView,
+                    object : OnDeleteViewListener {
+                        override fun onRemoveViewListener(removedView: View) {
+                            // here do actually remove the view
+                            val viewType = removedView.tag as ViewType
+                            viewUndo(removedView, viewType)
+                        }
+                        override fun onRemoveViewReadyListener(removedView: View, ready: Boolean) {
+                            mOnPhotoEditorListener?.onRemoveViewReadyListener(removedView, ready)
+                        }
+                    },
+                    mOnPhotoEditorListener
+                )
+            )
 
             addViewToParent(this, ViewType.EMOJI)
         }

--- a/photoeditor/src/main/res/values/dimens.xml
+++ b/photoeditor/src/main/res/values/dimens.xml
@@ -3,4 +3,6 @@
     <dimen name="autosize_tv_margin">4dp</dimen>
     <dimen name="autosize_tv_initial_width">96dp</dimen>
     <dimen name="autosize_tv_initial_height">96dp</dimen>
+    <dimen name="autosize_tv_minimum_width">36dp</dimen>
+    <dimen name="autosize_tv_minimum_height">36dp</dimen>
 </resources>


### PR DESCRIPTION
Builds on top of #208 

Adds the `DeleteView` behavior support to the new `TextViewSizeAwareTouchListener`.

To test:
1. capture an image
2. add emoji
3. as you operate on the emoji (drag / rotate / pinch to zoom) the rest of the controls should hide, while the `DeleteView` at the bottom should appear.
4. Dragging the emoji to the `delete` area should make it a bit more transparent and then if you lift your finger there, the emoji should be removed from the screen.
