### PR TITLE
[DO NOT MERGE] Using TextViewSizeAwareTouchListener with Text views (scaling refactor part 4)

### DIFF
--- a/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
@@ -458,7 +458,7 @@ class ComposeLoopFrameActivity : AppCompatActivity() {
     }
 
     private fun addNewText() {
-        val dp = resources.getDimension(R.dimen.editor_initial_text_size) / resources.displayMetrics.density
+        val dp = resources.getDimension(R.dimen.textview_initial_text_size) / resources.displayMetrics.density
         photoEditor.addText(
             "",
             colorCodeTextView = ContextCompat.getColor(baseContext, R.color.text_color_white),

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -39,6 +39,8 @@
     <dimen name="save_button_total_height">40dp</dimen>
 
     <dimen name="editor_initial_text_size">40sp</dimen>
+
+    <!--    maximum sp to set for fontSize, will be re-rendered according to available space -->
     <dimen name="textview_initial_text_size">112sp</dimen>
     <dimen name="emoji_picker_initial_text_size">35sp</dimen>
 <!-- emoji_picker_initial_size can be anything, it needs be fixed but we are going to calculate it

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -39,6 +39,7 @@
     <dimen name="save_button_total_height">40dp</dimen>
 
     <dimen name="editor_initial_text_size">40sp</dimen>
+    <dimen name="textview_initial_text_size">112sp</dimen>
     <dimen name="emoji_picker_initial_text_size">35sp</dimen>
 <!-- emoji_picker_initial_size can be anything, it needs be fixed but we are going to calculate it
  on runtime later depending on screen size -->

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -32,6 +32,7 @@ import com.automattic.photoeditor.util.BitmapUtil
 import com.automattic.photoeditor.views.PhotoEditorView
 import com.automattic.photoeditor.views.ViewType
 import com.automattic.photoeditor.views.ViewType.EMOJI
+import com.automattic.photoeditor.views.ViewType.TEXT
 import com.automattic.photoeditor.views.added.AddedView
 import com.automattic.photoeditor.views.added.AddedViewList
 import com.automattic.photoeditor.views.brush.BrushDrawingView
@@ -246,38 +247,25 @@ class PhotoEditor private constructor(builder: Builder) :
             textInputTv.text = text
             textInputTv.setTextColor(colorCodeTextView)
             textInputTv.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSizeSp)
-//            textInputTv.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
             if (textTypeface != null) {
                 textInputTv.typeface = textTypeface
             }
 
-//            val multiTouchListenerInstance = newMultiTouchListener
-//            multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {
-//                override fun onClick() {
-//                    val textInput = textInputTv.text.toString()
-//                    val currentTextColor = textInputTv.currentTextColor
-//                    mOnPhotoEditorListener?.onEditTextChangeListener(this@apply, textInput, currentTextColor, false)
-//                }
-//
-//                override fun onLongClick() {
-//                    // TODO implement the DELETE action (hide every other view, allow this view to be dragged to the trash
-//                    // bin)
-//                }
-//            })
-//            setOnTouchListener(multiTouchListenerInstance)
+            val touchListenerInstance = newTextViewSizeAwareTouchListener
+            touchListenerInstance.setOnGestureControl(
+                object : TextViewSizeAwareTouchListener.OnGestureControl {
+                    override fun onClick() {
+                        val textInput = textInputTv.text.toString()
+                        val currentTextColor = textInputTv.currentTextColor
+                        mOnPhotoEditorListener?.onEditTextChangeListener(this@apply, textInput, currentTextColor, false)
+                    }
 
-            setOnTouchListener(newTextViewSizeAwareTouchListener)
-            newTextViewSizeAwareTouchListener.setOnGestureControl(object: TextViewSizeAwareTouchListener.OnGestureControl {
-                override fun onClick() {
-                    val textInput = textInputTv.text.toString()
-                    val currentTextColor = textInputTv.currentTextColor
-                    mOnPhotoEditorListener?.onEditTextChangeListener(this@apply, textInput, currentTextColor, false)
+                    override fun onLongClick() {
+                        // no op
+                    }
                 }
-
-                override fun onLongClick() {
-                    // no op
-                }
-            })
+            )
+            setOnTouchListener(touchListenerInstance)
             addViewToParent(this, ViewType.TEXT)
 
             // now open TextEditor right away
@@ -383,7 +371,8 @@ class PhotoEditor private constructor(builder: Builder) :
 //            })
 //            setOnTouchListener(multiTouchListenerInstance)
 
-            setOnTouchListener(newTextViewSizeAwareTouchListener)
+            val touchListenerInstance = newTextViewSizeAwareTouchListener
+            setOnTouchListener(touchListenerInstance)
             addViewToParent(this, ViewType.EMOJI)
         }
     }
@@ -394,7 +383,7 @@ class PhotoEditor private constructor(builder: Builder) :
      * @param rootView rootview of image,text and emoji
      */
     private fun addViewToParent(rootView: View, viewType: ViewType, sourceUri: Uri? = null) {
-        if (viewType != EMOJI) {
+        if (viewType != EMOJI && viewType != TEXT) {
             val params = RelativeLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT
             )

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -210,6 +210,9 @@ class PhotoEditor private constructor(builder: Builder) :
         getLayout(ViewType.IMAGE)?.apply {
             val imageView = findViewById<ImageView>(R.id.imgPhotoEditorImage)
 
+            val touchListenerInstance = newTextViewSizeAwareTouchListener
+            setOnTouchListener(touchListenerInstance)
+
             addViewToParent(this, if (isAnimated) ViewType.STICKER_ANIMATED else ViewType.IMAGE, uri)
 
             // now load the gif on this ImageView with Glide

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -2,6 +2,7 @@ package com.automattic.photoeditor.gesture
 
 import android.annotation.SuppressLint
 import android.graphics.Rect
+import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
 import com.automattic.photoeditor.OnPhotoEditorListener
@@ -29,6 +30,9 @@ class TextViewSizeAwareTouchListener(
     private var outRect: Rect? = null
     private val location = IntArray(2)
 
+    private var onGestureControl: OnGestureControl? = null
+    private val gestureListener: GestureDetector
+
     init {
         rotationDetector = RotationGestureDetector()
         if (deleteView != null) {
@@ -39,6 +43,7 @@ class TextViewSizeAwareTouchListener(
         } else {
             outRect = Rect(0, 0, 0, 0)
         }
+        gestureListener = GestureDetector(GestureListener())
     }
 
     interface OnDeleteViewListener {
@@ -46,9 +51,32 @@ class TextViewSizeAwareTouchListener(
         fun onRemoveViewReadyListener(removedView: View, ready: Boolean)
     }
 
+    interface OnGestureControl {
+        fun onClick()
+        fun onLongClick()
+    }
+
+    fun setOnGestureControl(onGestureControl: OnGestureControl) {
+        this.onGestureControl = onGestureControl
+    }
+
+    private inner class GestureListener : GestureDetector.SimpleOnGestureListener() {
+        override fun onSingleTapUp(e: MotionEvent): Boolean {
+            onGestureControl?.onClick()
+            return true
+        }
+
+        override fun onLongPress(e: MotionEvent) {
+            super.onLongPress(e)
+            onGestureControl?.onLongClick()
+        }
+    }
+
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouch(view: View, event: MotionEvent): Boolean {
         rotationDetector.onTouchEvent(view, event)
+        gestureListener.onTouchEvent(event)
+
         event.offsetLocation(event.rawX - event.x, event.rawY - event.y)
 
         when (event.actionMasked) {


### PR DESCRIPTION
Builds on top of #209.

Adding the new listener to be used with actual `TextView`s (already used for emoji at this point).

In this type of view we also need to detect taps (through `GestureDetector`)  so we can open the text editor dialog and fire up the keyboard for editing. 361f418

To test:
1. open the app and capture an image
2. tap on the Tt control to add text
3. insert some text
4. observe the text gets inserted and you can drag it around and resize (zoom in/out).
5. also try and insert some emji within the text, and observe it gets handled correctly.

Bonus test (to make sure other functionality is compatible):
1. somewhere in the code, call `testSticker()` in `ComposeLoopFrameActivity`, for example:
```
 text_add_button_group.setOnClickListener {
             addNewText()
           testSticker()
       }
```
2. run it
3. capture an image
4. in the composer screen, tap on the Tt button
5. observe the editor dialog is shown, dismiss it
6. observe an image with an animated gif has been added
7. move the image around, resize it, rotate it.


