### PR TITLE
[DO NOT MERGE] Introduce OnMaxMinFontSizeReached listener (scaling refactor part 5)

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -413,11 +413,10 @@ class PhotoEditor private constructor(builder: Builder) :
                     }
                     txtTextEmoji.gravity = Gravity.CENTER
                     txtTextEmoji.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
-                    val maxHeight = parentView.height
-                    rootView.tvPhotoEditorText.textSize =
+                    txtTextEmoji.textSize =
                         TypedValue.applyDimension(
                             TypedValue.COMPLEX_UNIT_SP,
-                            maxHeight.toFloat(),
+                            DEFAULT_AUTO_SIZE_MAX_TEXT_SIZE_IN_SP,
                             context.resources.displayMetrics
                         )
                 }
@@ -1125,6 +1124,9 @@ class PhotoEditor private constructor(builder: Builder) :
 
     companion object {
         private const val TAG = "PhotoEditor"
+        // idea taken from TextView's source code, setting maximum of 112sp for fontSize
+        // see https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/TextView.java#891
+        private const val DEFAULT_AUTO_SIZE_MAX_TEXT_SIZE_IN_SP = 152f
 
         private fun convertEmoji(emoji: String): String {
             return try {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -29,6 +29,7 @@ import com.automattic.photoeditor.gesture.MultiTouchListener.OnMultiTouchListene
 import com.automattic.photoeditor.gesture.TextViewSizeAwareTouchListener
 import com.automattic.photoeditor.gesture.TextViewSizeAwareTouchListener.OnDeleteViewListener
 import com.automattic.photoeditor.util.BitmapUtil
+import com.automattic.photoeditor.views.AutoResizeTextView
 import com.automattic.photoeditor.views.PhotoEditorView
 import com.automattic.photoeditor.views.ViewType
 import com.automattic.photoeditor.views.ViewType.EMOJI
@@ -245,7 +246,7 @@ class PhotoEditor private constructor(builder: Builder) :
     fun addText(text: String, colorCodeTextView: Int, textTypeface: Typeface? = null, fontSizeSp: Float = 18f) {
         brushDrawingView.brushDrawingMode = false
         getLayout(ViewType.TEXT)?.apply {
-            val textInputTv = findViewById<TextView>(R.id.tvPhotoEditorText)
+            val textInputTv = findViewById<AutoResizeTextView>(R.id.tvPhotoEditorText)
 
             textInputTv.text = text
             textInputTv.setTextColor(colorCodeTextView)
@@ -269,6 +270,7 @@ class PhotoEditor private constructor(builder: Builder) :
                 }
             )
             setOnTouchListener(touchListenerInstance)
+            textInputTv.setMaxMinFontSizeReachedListener(touchListenerInstance)
             addViewToParent(this, ViewType.TEXT)
 
             // now open TextEditor right away
@@ -333,7 +335,7 @@ class PhotoEditor private constructor(builder: Builder) :
     fun addEmoji(emojiTypeface: Typeface?, emojiName: String) {
         brushDrawingView.brushDrawingMode = false
         getLayout(ViewType.EMOJI)?.apply {
-            val emojiTextView = findViewById<TextView>(R.id.tvPhotoEditorText)
+            val emojiTextView = findViewById<AutoResizeTextView>(R.id.tvPhotoEditorText)
 
             if (emojiTypeface != null) {
                 emojiTextView.typeface = emojiTypeface
@@ -364,6 +366,7 @@ class PhotoEditor private constructor(builder: Builder) :
 
             val touchListenerInstance = newTextViewSizeAwareTouchListener
             setOnTouchListener(touchListenerInstance)
+            emojiTextView.setMaxMinFontSizeReachedListener(touchListenerInstance)
             addViewToParent(this, ViewType.EMOJI)
         }
     }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -362,18 +362,6 @@ class PhotoEditor private constructor(builder: Builder) :
                 })
             }
 
-//            val multiTouchListenerInstance = newMultiTouchListener
-//            multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {
-//                override fun onClick() {
-//                }
-//
-//                override fun onLongClick() {
-//                    // TODO implement the DELETE action (hide every other view, allow this view to be dragged to the trash
-//                    // bin)
-//                }
-//            })
-//            setOnTouchListener(multiTouchListenerInstance)
-
             val touchListenerInstance = newTextViewSizeAwareTouchListener
             setOnTouchListener(touchListenerInstance)
             addViewToParent(this, ViewType.EMOJI)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -412,7 +412,6 @@ class PhotoEditor private constructor(builder: Builder) :
                         txtTextEmoji.typeface = mDefaultEmojiTypeface
                     }
                     txtTextEmoji.gravity = Gravity.CENTER
-                    txtTextEmoji.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
                     txtTextEmoji.textSize =
                         TypedValue.applyDimension(
                             TypedValue.COMPLEX_UNIT_SP,
@@ -1126,7 +1125,7 @@ class PhotoEditor private constructor(builder: Builder) :
         private const val TAG = "PhotoEditor"
         // idea taken from TextView's source code, setting maximum of 112sp for fontSize
         // see https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/TextView.java#891
-        private const val DEFAULT_AUTO_SIZE_MAX_TEXT_SIZE_IN_SP = 152f
+        private const val DEFAULT_AUTO_SIZE_MAX_TEXT_SIZE_IN_SP = 112f
 
         private fun convertEmoji(emoji: String): String {
             return try {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -412,12 +412,10 @@ class PhotoEditor private constructor(builder: Builder) :
                         txtTextView.typeface = mDefaultTextTypeface
                     }
                     txtTextView.gravity = Gravity.CENTER
-                    // txtTextView.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
-                    val maxHeight = parentView.height
-                    rootView.tvPhotoEditorText.textSize =
+                    txtTextView.maxTextSize =
                         TypedValue.applyDimension(
                             TypedValue.COMPLEX_UNIT_SP,
-                            maxHeight.toFloat(),
+                            DEFAULT_AUTO_SIZE_MAX_TEXT_SIZE_IN_SP,
                             context.resources.displayMetrics
                         )
                 }
@@ -431,7 +429,7 @@ class PhotoEditor private constructor(builder: Builder) :
                         txtTextEmoji.typeface = mDefaultEmojiTypeface
                     }
                     txtTextEmoji.gravity = Gravity.CENTER
-                    txtTextEmoji.textSize =
+                    txtTextEmoji.maxTextSize =
                         TypedValue.applyDimension(
                             TypedValue.COMPLEX_UNIT_SP,
                             DEFAULT_AUTO_SIZE_MAX_TEXT_SIZE_IN_SP,

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/RotationGestureDetector.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/RotationGestureDetector.kt
@@ -26,15 +26,17 @@ class RotationGestureDetector {
             MotionEvent.ACTION_DOWN -> ptrID1 = event.getPointerId(event.actionIndex)
             MotionEvent.ACTION_POINTER_DOWN -> {
                 ptrID2 = event.getPointerId(event.actionIndex)
-                sX = event.getX(event.findPointerIndex(ptrID1))
-                sY = event.getY(event.findPointerIndex(ptrID1))
-                fX = event.getX(event.findPointerIndex(ptrID2))
-                fY = event.getY(event.findPointerIndex(ptrID2))
+                if (ptrID1 != INVALID_POINTER_ID && ptrID2 != INVALID_POINTER_ID) {
+                    sX = event.getX(event.findPointerIndex(ptrID1))
+                    sY = event.getY(event.findPointerIndex(ptrID1))
+                    fX = event.getX(event.findPointerIndex(ptrID2))
+                    fY = event.getY(event.findPointerIndex(ptrID2))
 
-                val pvx = fX - sX
-                val pvy = fY - sY
+                    val pvx = fX - sX
+                    val pvy = fY - sY
 
-                prevSpanVector.set(pvx, pvy)
+                    prevSpanVector.set(pvx, pvy)
+                }
             }
             MotionEvent.ACTION_MOVE -> if (ptrID1 != INVALID_POINTER_ID && ptrID2 != INVALID_POINTER_ID) {
                 val nfX: Float

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/RotationGestureDetector.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/RotationGestureDetector.kt
@@ -27,10 +27,14 @@ class RotationGestureDetector {
             MotionEvent.ACTION_POINTER_DOWN -> {
                 ptrID2 = event.getPointerId(event.actionIndex)
                 if (ptrID1 != INVALID_POINTER_ID && ptrID2 != INVALID_POINTER_ID) {
-                    sX = event.getX(event.findPointerIndex(ptrID1))
-                    sY = event.getY(event.findPointerIndex(ptrID1))
-                    fX = event.getX(event.findPointerIndex(ptrID2))
-                    fY = event.getY(event.findPointerIndex(ptrID2))
+                    if (event.findPointerIndex(ptrID1) > -1) {
+                        sX = event.getX(event.findPointerIndex(ptrID1))
+                        sY = event.getY(event.findPointerIndex(ptrID1))
+                    }
+                    if (event.findPointerIndex(ptrID2) > -1) {
+                        fX = event.getX(event.findPointerIndex(ptrID2))
+                        fY = event.getY(event.findPointerIndex(ptrID2))
+                    }
 
                     val pvx = fX - sX
                     val pvy = fY - sY

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -179,12 +179,12 @@ class TextViewSizeAwareTouchListener(
                             // also adjust view size to stay within the maximum view size allowed / found for the
                             // maximum fontSize set on the TextView
                             if (maxWidthForFontMeasured > 0) {
-                                if (newWidth + view.x > maxWidthForFontMeasured) {
+                                if (newWidth > maxWidthForFontMeasured) {
                                     newWidth = maxWidthForFontMeasured //  - view.x.toInt()
                                 }
                             }
                             if (maxHeightForFontMeasured > 0) {
-                                if (newHeight + view.y > maxHeightForFontMeasured) {
+                                if (newHeight > maxHeightForFontMeasured) {
                                     newHeight = maxHeightForFontMeasured // - view.y.toInt()
                                 }
                             }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -150,7 +150,6 @@ class TextViewSizeAwareTouchListener(
                     if (newWidth > minWidth && newHeight > minHeight) {
                         if (isZoomOutMovement(newWidth, newHeight, view) && !minFontSizeReached ||
                             !isZoomOutMovement(newWidth, newHeight, view) && !maxFontSizeReached) {
-//                        if (!isMinOrMaxFontSizeReached()) {
                             val parentWidth = (view.parent as View).width
                             val parentHeight = (view.parent as View).height
                             val params = view.layoutParams

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -2,7 +2,6 @@ package com.automattic.photoeditor.gesture
 
 import android.annotation.SuppressLint
 import android.graphics.Rect
-import android.util.Log
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
@@ -94,10 +93,6 @@ class TextViewSizeAwareTouchListener(
         maxFontSizeReached = false
     }
 
-    private fun isMinOrMaxFontSizeReached(): Boolean {
-        return minFontSizeReached || maxFontSizeReached
-    }
-
     private fun isZoomOutMovement(newWidth: Int, newHeight: Int, view: View): Boolean {
         val params = view.layoutParams
         return newWidth <= params.width || newHeight <= params.height
@@ -151,14 +146,6 @@ class TextViewSizeAwareTouchListener(
                     val diffY = Math.abs(event.getY(1) - event.getY(0))
                     var newWidth = (diffX * view.measuredWidth.toFloat() / lastDiffX).toInt()
                     var newHeight = (diffY * view.measuredHeight.toFloat() / lastDiffY).toInt()
-
-                    if (isZoomOutMovement(newWidth, newHeight, view)) {
-                        Log.d("PORTKEY", "is zoom out: " + " newWidth: " + newWidth + " newHeight: "+ newHeight)
-//                        Log.d("PORTKEY", "is zoom out: " + " diffX: " + diffX + " diffY: "+ diffY)
-                    } else {
-                        Log.d("PORTKEY", "is zoom IN: " + " newWidth: " + newWidth + " newHeight: "+ newHeight)
-//                        Log.d("PORTKEY", "is zoom IN: " + " diffX: " + diffX + " diffY: "+ diffY)
-                    }
 
                     if (newWidth > minWidth && newHeight > minHeight) {
                         if (isZoomOutMovement(newWidth, newHeight, view) && !minFontSizeReached ||

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/TextViewSizeAwareTouchListener.kt
@@ -166,12 +166,13 @@ class TextViewSizeAwareTouchListener(
                             // maximum fontSize set on the TextView
                             if (maxWidthForFontMeasured > 0) {
                                 if (newWidth > maxWidthForFontMeasured) {
-                                    newWidth = maxWidthForFontMeasured //  - view.x.toInt()
+                                    // keep width
+                                    newWidth = maxWidthForFontMeasured
                                 }
                             }
                             if (maxHeightForFontMeasured > 0) {
                                 if (newHeight > maxHeightForFontMeasured) {
-                                    newHeight = maxHeightForFontMeasured // - view.y.toInt()
+                                    newHeight = maxHeightForFontMeasured
                                 }
                             }
 
@@ -185,15 +186,17 @@ class TextViewSizeAwareTouchListener(
                                 newHeight = minHeight
                             }
 
-                            params.width = newWidth
-                            params.height = newHeight
+                            if (view.measuredWidth != newWidth && view.measuredHeight != newHeight) {
+                                params.width = newWidth
+                                params.height = newHeight
 
-                            setMaximumWidthAndHeightAfterFontMaxSizeReached(newWidth, newHeight)
+                                setMaximumWidthAndHeightAfterFontMaxSizeReached(newWidth, newHeight)
 
-                            view.layoutParams = params
-                            // note: requestLayout() is needed to get AutoResizeTextView to recalculate its fontSize after a
-                            // change in view's width/height is made
-                            view.requestLayout()
+                                view.layoutParams = params
+                                // note: requestLayout() is needed to get AutoResizeTextView to recalculate its fontSize after a
+                                // change in view's width/height is made
+                                view.requestLayout()
+                            }
                         }
                         lastDiffX = diffX
                         lastDiffY = diffY

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/AutoResizeTextView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/AutoResizeTextView.kt
@@ -20,7 +20,12 @@ import androidx.appcompat.widget.AppCompatTextView
  * It should work fine with most Android versions, but might have some issues on Android 3.1 - 4.04, as setTextSize will only work for the first time. <br></br>
  * More info here: https://code.google.com/p/android/issues/detail?id=22493 and here in case you wish to fix it: http://stackoverflow.com/a/21851239/878126
  */
-class AutoResizeTextView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyle: Int = android.R.attr.textViewStyle) : AppCompatTextView(context, attrs, defStyle) {
+class AutoResizeTextView @JvmOverloads
+constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = android.R.attr.textViewStyle
+) : AppCompatTextView(context, attrs, defStyle) {
     private val availableSpaceRect = RectF()
     private val sizeTester: SizeTester
     var maxTextSize: Float = 0.toFloat()
@@ -43,7 +48,7 @@ class AutoResizeTextView @JvmOverloads constructor(context: Context, attrs: Attr
 
     private interface SizeTester {
         /**
-         * @param suggestedSize  Size of text to be tested
+         * @param suggestedSize Size of text to be tested
          * @param availableSpace available space in which text must fit
          * @return an integer < 0 if after applying `suggestedSize` to
          * text, it takes less space than `availableSpace`, > 0
@@ -79,8 +84,11 @@ class AutoResizeTextView @JvmOverloads constructor(context: Context, attrs: Attr
                     textRect.right = textPaint!!.measureText(text)
                 } else {
                     val layout: StaticLayout = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                        StaticLayout.Builder.obtain(text, 0, text.length, textPaint!!, widthLimit).setLineSpacing(spacingAdd, spacingMult).setAlignment(Alignment.ALIGN_NORMAL).setIncludePad(true).build()
-                    } else StaticLayout(text, textPaint, widthLimit, Alignment.ALIGN_NORMAL, spacingMult, spacingAdd, true)
+                        StaticLayout.Builder.obtain(text, 0, text.length, textPaint!!, widthLimit)
+                            .setLineSpacing(spacingAdd, spacingMult)
+                            .setAlignment(Alignment.ALIGN_NORMAL).setIncludePad(true).build()
+                    } else
+                        StaticLayout(text, textPaint, widthLimit, Alignment.ALIGN_NORMAL, spacingMult, spacingAdd, true)
                     // return early if we have more lines
                     if (maxLines != NO_LINE_LIMIT && layout.lineCount > maxLines)
                         return 1
@@ -94,9 +102,6 @@ class AutoResizeTextView @JvmOverloads constructor(context: Context, attrs: Attr
                         if (maxWidth < layout.getLineRight(i) - layout.getLineLeft(i))
                             maxWidth = layout.getLineRight(i).toInt() - layout.getLineLeft(i).toInt()
                     }
-                    //for (int i = 0; i < layout.getLineCount(); i++)
-                    //    if (maxWidth < layout.getLineRight(i) - layout.getLineLeft(i))
-                    //        maxWidth = (int) layout.getLineRight(i) - (int) layout.getLineLeft(i);
                     textRect.right = maxWidth.toFloat()
                 }
                 textRect.offsetTo(0f, 0f)
@@ -214,13 +219,13 @@ class AutoResizeTextView @JvmOverloads constructor(context: Context, attrs: Attr
     private fun isBestFontSizeMatchCloseEnoughToMax(textSize: Int): Boolean {
         // binary search compares integer to float so there could be 1 point of roundup difference between maxFontSize
         // and the available space on screen in which the font actually fits
-        return textSize >= maxTextSize.toInt()-1
+        return textSize >= maxTextSize.toInt() - 1
     }
 
     private fun isBestFontSizeMatchCloseEnoughToMin(textSize: Int): Boolean {
         // binary search compares integer to float so there could be 1 point of roundup difference between minFontSize
         // and the available space on screen in which the font actually fits
-        return textSize <= minTextSize.toInt()+1
+        return textSize <= minTextSize.toInt() + 1
     }
 
     private fun binarySearch(start: Int, end: Int, sizeTester: SizeTester, availableSpace: RectF): Int {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/AutoResizeTextView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/AutoResizeTextView.kt
@@ -1,0 +1,242 @@
+package com.automattic.photoeditor.views
+
+import android.annotation.TargetApi
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.RectF
+import android.graphics.Typeface
+import android.os.Build
+import android.text.Layout.Alignment
+import android.text.StaticLayout
+import android.text.TextPaint
+import android.util.AttributeSet
+import android.util.TypedValue
+import androidx.appcompat.widget.AppCompatTextView
+
+/**
+ * a textView that is able to self-adjust its font size depending on the min and max size of the font, and its own size.<br></br>
+ * code is heavily based on this StackOverflow thread:
+ * http://stackoverflow.com/questions/16017165/auto-fit-textview-for-android/21851239#21851239 <br></br>
+ * It should work fine with most Android versions, but might have some issues on Android 3.1 - 4.04, as setTextSize will only work for the first time. <br></br>
+ * More info here: https://code.google.com/p/android/issues/detail?id=22493 and here in case you wish to fix it: http://stackoverflow.com/a/21851239/878126
+ */
+class AutoResizeTextView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyle: Int = android.R.attr.textViewStyle) : AppCompatTextView(context, attrs, defStyle) {
+    private val availableSpaceRect = RectF()
+    private val sizeTester: SizeTester
+    private var maxTextSize: Float = 0.toFloat()
+    private var spacingMult = 1.0f
+    private var spacingAdd = 0.0f
+    private var minTextSize: Float = 0.toFloat()
+    private var widthLimit: Int = 0
+    private var maxLines: Int = 0
+    private var initialized = false
+    private var textPaint: TextPaint? = null
+
+    private interface SizeTester {
+        /**
+         * @param suggestedSize  Size of text to be tested
+         * @param availableSpace available space in which text must fit
+         * @return an integer < 0 if after applying `suggestedSize` to
+         * text, it takes less space than `availableSpace`, > 0
+         * otherwise
+         */
+        fun onTestSize(suggestedSize: Int, availableSpace: RectF): Int
+    }
+
+    init {
+        // using the minimal recommended font size
+        minTextSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 12f, resources.displayMetrics)
+        maxTextSize = textSize
+        textPaint = TextPaint(paint)
+        if (maxLines == 0)
+        // no value was assigned during construction
+            maxLines = NO_LINE_LIMIT
+        // prepare size tester:
+        sizeTester = object : SizeTester {
+            internal val textRect = RectF()
+
+            @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+            override fun onTestSize(suggestedSize: Int, availableSpace: RectF): Int {
+                textPaint!!.textSize = suggestedSize.toFloat()
+                val transformationMethod = transformationMethod
+                val text: String
+                if (transformationMethod != null)
+                    text = transformationMethod.getTransformation(getText(), this@AutoResizeTextView).toString()
+                else
+                    text = getText().toString()
+                val singleLine = maxLines == 1
+                if (singleLine) {
+                    textRect.bottom = textPaint!!.fontSpacing
+                    textRect.right = textPaint!!.measureText(text)
+                } else {
+                    val layout: StaticLayout = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                        StaticLayout.Builder.obtain(text, 0, text.length, textPaint!!, widthLimit).setLineSpacing(spacingAdd, spacingMult).setAlignment(Alignment.ALIGN_NORMAL).setIncludePad(true).build()
+                    } else StaticLayout(text, textPaint, widthLimit, Alignment.ALIGN_NORMAL, spacingMult, spacingAdd, true)
+                    // return early if we have more lines
+                    if (maxLines != NO_LINE_LIMIT && layout.lineCount > maxLines)
+                        return 1
+                    textRect.bottom = layout.height.toFloat()
+                    var maxWidth = -1
+                    val lineCount = layout.lineCount
+                    for (i in 0 until lineCount) {
+                        val end = layout.getLineEnd(i)
+                        if (i < lineCount - 1 && end > 0 && !isValidWordWrap(text[end - 1], text[end]))
+                            return 1
+                        if (maxWidth < layout.getLineRight(i) - layout.getLineLeft(i))
+                            maxWidth = layout.getLineRight(i).toInt() - layout.getLineLeft(i).toInt()
+                    }
+                    //for (int i = 0; i < layout.getLineCount(); i++)
+                    //    if (maxWidth < layout.getLineRight(i) - layout.getLineLeft(i))
+                    //        maxWidth = (int) layout.getLineRight(i) - (int) layout.getLineLeft(i);
+                    textRect.right = maxWidth.toFloat()
+                }
+                textRect.offsetTo(0f, 0f)
+                return if (availableSpace.contains(textRect)) -1 else 1
+                // else, too big
+            }
+        }
+        initialized = true
+    }
+
+    fun isValidWordWrap(before: Char, after: Char): Boolean {
+        return before == ' ' || before == '-'
+    }
+
+    override fun setAllCaps(allCaps: Boolean) {
+        super.setAllCaps(allCaps)
+        adjustTextSize()
+    }
+
+    override fun setTypeface(tf: Typeface?) {
+        super.setTypeface(tf)
+        adjustTextSize()
+    }
+
+    override fun setTextSize(size: Float) {
+        maxTextSize = size
+        adjustTextSize()
+    }
+
+    override fun setMaxLines(maxLines: Int) {
+        super.setMaxLines(maxLines)
+        this.maxLines = maxLines
+        adjustTextSize()
+    }
+
+    override fun getMaxLines(): Int {
+        return maxLines
+    }
+
+    override fun setSingleLine() {
+        super.setSingleLine()
+        maxLines = 1
+        adjustTextSize()
+    }
+
+    override fun setSingleLine(singleLine: Boolean) {
+        super.setSingleLine(singleLine)
+        if (singleLine)
+            maxLines = 1
+        else
+            maxLines = NO_LINE_LIMIT
+        adjustTextSize()
+    }
+
+    override fun setLines(lines: Int) {
+        super.setLines(lines)
+        maxLines = lines
+        adjustTextSize()
+    }
+
+    override fun setTextSize(unit: Int, size: Float) {
+        val c = context
+        val r: Resources
+        r = if (c == null)
+            Resources.getSystem()
+        else
+            c.resources
+        maxTextSize = TypedValue.applyDimension(unit, size, r.displayMetrics)
+        adjustTextSize()
+    }
+
+    override fun setLineSpacing(add: Float, mult: Float) {
+        super.setLineSpacing(add, mult)
+        spacingMult = mult
+        spacingAdd = add
+    }
+
+    /**
+     * Set the lower text size limit and invalidate the view
+     *
+     * @param minTextSize
+     */
+    fun setMinTextSize(minTextSize: Float) {
+        this.minTextSize = minTextSize
+        adjustTextSize()
+    }
+
+    private fun adjustTextSize() {
+        // This is a workaround for truncated text issue on ListView, as shown here: https://github.com/AndroidDeveloperLB/AutoFitTextView/pull/14
+        // TODO think of a nicer, elegant solution.
+        //    post(new Runnable()
+        //    {
+        //    @Override
+        //    public void run()
+        //      {
+        if (!initialized)
+            return
+        val startSize = minTextSize.toInt()
+        val heightLimit = measuredHeight - compoundPaddingBottom - compoundPaddingTop
+        widthLimit = measuredWidth - compoundPaddingLeft - compoundPaddingRight
+        if (widthLimit <= 0)
+            return
+        textPaint = TextPaint(paint)
+        availableSpaceRect.right = widthLimit.toFloat()
+        availableSpaceRect.bottom = heightLimit.toFloat()
+        superSetTextSize(startSize)
+        //      }
+        //    });
+    }
+
+    private fun superSetTextSize(startSize: Int) {
+        val textSize = binarySearch(startSize, maxTextSize.toInt(), sizeTester, availableSpaceRect)
+        super.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize.toFloat())
+    }
+
+    private fun binarySearch(start: Int, end: Int, sizeTester: SizeTester, availableSpace: RectF): Int {
+        var lastBest = start
+        var lo = start
+        var hi = end - 1
+        var mid: Int
+        while (lo <= hi) {
+            mid = (lo + hi).ushr(1)
+            val midValCmp = sizeTester.onTestSize(mid, availableSpace)
+            if (midValCmp < 0) {
+                lastBest = lo
+                lo = mid + 1
+            } else if (midValCmp > 0) {
+                hi = mid - 1
+                lastBest = hi
+            } else
+                return mid
+        }
+        // make sure to return last best
+        // this is what should always be returned
+        return lastBest
+    }
+
+    override fun onTextChanged(text: CharSequence, start: Int, before: Int, after: Int) {
+        super.onTextChanged(text, start, before, after)
+        adjustTextSize()
+    }
+
+    override fun onSizeChanged(width: Int, height: Int, oldwidth: Int, oldheight: Int) {
+        super.onSizeChanged(width, height, oldwidth, oldheight)
+        if (width != oldwidth || height != oldheight)
+            adjustTextSize()
+    }
+
+    companion object {
+        private val NO_LINE_LIMIT = -1
+    }
+}

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/AutoResizeTextView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/AutoResizeTextView.kt
@@ -23,10 +23,18 @@ import androidx.appcompat.widget.AppCompatTextView
 class AutoResizeTextView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyle: Int = android.R.attr.textViewStyle) : AppCompatTextView(context, attrs, defStyle) {
     private val availableSpaceRect = RectF()
     private val sizeTester: SizeTester
-    private var maxTextSize: Float = 0.toFloat()
+    var maxTextSize: Float = 0.toFloat()
+        set(maxSize) {
+            field = maxSize
+            adjustTextSize()
+        }
+    var minTextSize: Float = 0.toFloat()
+        set(minSize) {
+            field = minSize
+            adjustTextSize()
+        }
     private var spacingMult = 1.0f
     private var spacingAdd = 0.0f
-    private var minTextSize: Float = 0.toFloat()
     private var widthLimit: Int = 0
     private var maxLines: Int = 0
     private var initialized = false
@@ -163,16 +171,6 @@ class AutoResizeTextView @JvmOverloads constructor(context: Context, attrs: Attr
         super.setLineSpacing(add, mult)
         spacingMult = mult
         spacingAdd = add
-    }
-
-    /**
-     * Set the lower text size limit and invalidate the view
-     *
-     * @param minTextSize
-     */
-    fun setMinTextSize(minTextSize: Float) {
-        this.minTextSize = minTextSize
-        adjustTextSize()
     }
 
     private fun adjustTextSize() {

--- a/photoeditor/src/main/res/layout/view_photo_editor_text.xml
+++ b/photoeditor/src/main/res/layout/view_photo_editor_text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.lb.auto_fit_textview.AutoResizeTextView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.automattic.photoeditor.views.AutoResizeTextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/tvPhotoEditorText"
     android:layout_width="@dimen/autosize_tv_initial_width"
     android:layout_height="@dimen/autosize_tv_initial_height"


### PR DESCRIPTION
This PR adds a listener so the emoji view resizes itself only within the minimum and maximum width/height allowed as per the minimum and maximum fontSize set on the `AutoResizeTextView` containing the emoji.

Before this PR, a view's size could be augmented and take as much as the whole screen (to the extent your fingers would allow to in a pinch-to-zoom gesture). With this PR, the `TextViewSizeAwareTouchListener`  (in charge of handling the touch gestures) will be notified when the `AutoResizeTextView` view used for emoji/text reaches its maximum/minimum allowed `fontSize`, so the `TextViewSizeAwareTouchListener` can check the view's `width`/`height` and stop growing the view (same for shrinking, with the inferior limit).

This detection mechanism will be used next in order to pivot between view resize / view scaling methods in a follow up PR.

Notes:
- This PR merges #206 as I needed to have the maximum fontSize const in place
- Built incrementally on top of #210 
- introduces the AutoResizeTextView class source in the project as we needed to modify it 
4a5f271
- adds a "maximum fontSize reached" listener, as well as a "minimum fontSize reached" listener. 7c5a523

To test:

0. enable developer options -> see layout bounds to see the view's "borders" on your screen
1. take a picture and add an emoji
2. pinch to zoom, observe once it reaches a maximum allowed fontSize (currently 112sp), the view stops growing.
3. if possible do the same when trying to shrink the view (feel free to use some other minimum value in `dimens.xml`  changing these two values to some other, greater ones so it's easier to test, for example 96dp):
```   
    <dimen name="autosize_tv_minimum_width">96dp</dimen>
    <dimen name="autosize_tv_minimum_height">96dp</dimen>
```

