### PR TITLE
WIP - Adjust selectable area

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
@@ -174,8 +174,8 @@ internal class MultiTouchListener(
         // let's now offset once more to bring the size of the view down by a percentage
         val currentDx = view.right - view.left
         val currentDy = view.bottom - view.top
-        val percentageOnX = (currentDx * -0.2).toInt()
-        val percentageOnY = (currentDy * -0.2).toInt()
+        val percentageOnX = (currentDx * TOUCH_IGNORE_AREA_PERCENTAGE).toInt()
+        val percentageOnY = (currentDy * TOUCH_IGNORE_AREA_PERCENTAGE).toInt()
         viewRect.offset(percentageOnX, percentageOnY)
         return viewRect.contains(event.rawX.toInt(), event.rawY.toInt())
     }
@@ -258,6 +258,7 @@ internal class MultiTouchListener(
 
     companion object {
         private val INVALID_POINTER_ID = -1
+        private val TOUCH_IGNORE_AREA_PERCENTAGE = 0.2f
 
         private fun adjustAngle(origDegrees: Float): Float {
             var degrees = origDegrees

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
@@ -61,7 +61,7 @@ internal class MultiTouchListener(
 
     override fun onTouch(view: View, event: MotionEvent): Boolean {
         mGestureListener.onTouchEvent(event)
-        // filter out touch events on transparent points
+        // filter out touch events that fall around the edges of the view
         if (!touchIsWellWithinView(view, event)) {
             return true
         }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/ScaleGestureDetector.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/ScaleGestureDetector.kt
@@ -254,7 +254,7 @@ internal class ScaleGestureDetector(private val mListener: OnScaleGestureListene
         currentSpanVector = Vector2D()
     }
 
-    fun onTouchEvent(view: View, event: MotionEvent): Boolean {
+    fun onTouchEvent(view: View, event: MotionEvent, isTouchEventWellWithinView: Boolean): Boolean {
         val action = event.actionMasked
 
         if (action == MotionEvent.ACTION_DOWN) {
@@ -291,7 +291,10 @@ internal class ScaleGestureDetector(private val mListener: OnScaleGestureListene
 
                     setContext(view, event)
 
-                    isInProgress = mListener.onScaleBegin(view, this)
+                    // filter out touch events that fall around the edges of the view
+                    if (isTouchEventWellWithinView) {
+                        isInProgress = mListener.onScaleBegin(view, this)
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
Fixes #152 

The problem here is especially seen on emoji, which are rounded images held by square (rectangular) views. When scaling up (zoom in), it is perfectly possible that the user touches a transparent area of the view and the gesture would get interpreted as if the user was touching the emoji, giving the impression things were being moved without being that the users' intention.

I had several approaches in mind for tackling this. At first I thought of reading the transparency for the pixel area on and surrounding the touch event coordinate, but it's too expensive as we first need to create a Bitmap out of the View, then transform it according to its matrix and then figure out whether the area is transparent (to which level, as well), and only then decide whether or not to discard the event.

In order to be as light as possible, this current PR tackles the problem by filtering out (simply not paying attention to) those events that belong to a surface that is slightly (20%) smaller than the original view.

WIP. 