### PR TITLE
WIP - Limit touchableArea to be resized down up to scale=1.0

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -359,7 +359,7 @@ class PhotoEditor private constructor(builder: Builder) :
      */
     private fun addViewToParent(rootView: View, viewType: ViewType, sourceUri: Uri? = null) {
         val params = RelativeLayout.LayoutParams(
-            ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
         )
         params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE)
         parentView.addView(rootView, params)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
@@ -8,6 +8,7 @@ import android.view.View.OnTouchListener
 import android.widget.ImageView
 import android.widget.RelativeLayout
 import com.automattic.photoeditor.OnPhotoEditorListener
+import com.automattic.photoeditor.R
 import com.automattic.photoeditor.gesture.ScaleGestureDetector.SimpleOnScaleGestureListener
 import com.automattic.photoeditor.views.ViewType
 
@@ -194,7 +195,16 @@ internal class MultiTouchListener(
             info.pivotY = mPivotY
             info.minimumScale = minimumScale
             info.maximumScale = maximumScale
-            move(view, info, onScaleChangedListener)
+            if (view.tag == ViewType.EMOJI) {
+                // this is the root view for EMOJI, let's copy movement on both TextView and touchable area
+                // so they move together
+                // the non-touchable area doesn't need to be limited in scale, so we don't pass onScaleChangedListener
+                move(view.findViewById(R.id.tvPhotoEditorText), info)
+                // the touchableArea needs be limited in scale, so here we pass onScaleChangedListener
+                move(view.findViewById(R.id.touchableArea), info, onScaleChangedListener)
+            } else {
+                move(view, info, onScaleChangedListener)
+            }
             return !mIsTextPinchZoomable
         }
     }
@@ -261,7 +271,7 @@ internal class MultiTouchListener(
             return degrees
         }
 
-        private fun move(view: View, info: TransformInfo, onScaleChangedListener: OnScaleChangedListener?) {
+        private fun move(view: View, info: TransformInfo, onScaleChangedListener: OnScaleChangedListener? = null) {
             computeRenderOffset(
                 view,
                 info.pivotX,

--- a/photoeditor/src/main/res/layout/view_photo_editor_text.xml
+++ b/photoeditor/src/main/res/layout/view_photo_editor_text.xml
@@ -2,8 +2,10 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    >
 
+    <!-- scale should affect this view-->
     <TextView
         android:id="@+id/tvPhotoEditorText"
         android:layout_width="@dimen/emoji_view_size"
@@ -11,16 +13,19 @@
         android:textColor="#000000"
         android:layout_centerInParent="true"
         android:textAlignment="center"
+        android:tag="@string/tag_view_area"
         tools:text="Burhanuddin"
         tools:textColor="@android:color/black" />
 
     <!-- transparent view that will be set the touch listener -->
+    <!-- should only be affected in scale up to a minimum-->
     <View
         android:id="@+id/touchableArea"
         android:layout_width="@dimen/emoji_view_touchable_area_size"
         android:layout_height="@dimen/emoji_view_touchable_area_size"
         android:background="#cc00dddd"
         android:layout_centerInParent="true"
+        android:tag="@string/tag_touchable_area"
         />
 
 </RelativeLayout>

--- a/photoeditor/src/main/res/values/strings.xml
+++ b/photoeditor/src/main/res/values/strings.xml
@@ -411,4 +411,7 @@
 
     <string name="request_permissions">This app needs camera and audio recording permissions.</string>
     <string name="camera_error">This device doesn\'t support Camera2 API.</string>
+
+    <string name="tag_touchable_area">tag_touchable_area</string>
+    <string name="tag_view_area">tag_view_area</string>
 </resources>


### PR DESCRIPTION
Fix #66

This PR adds an `onScaleChangedListener` to limit scaling down `touchableArea` introduced in #217 beyond a physically touchable size, attempting to allow users to reduce the view without losing ability to touch it anymore when it's too small.

Idea is that these should be two separate areas (the actual visible View and the touch area), and while I do intend to copy its positioning / rotation through the view hierarchy (as is the `mainView` containing the other views), this PR should limit copying its `scale` factor when it falls below `1.0f`

The behavior that copies the moving parameters on both internal views ( `touchableArea` and tvPhotoEditorText`) can be seen in c88b7d8, and this following video shows how it works:

https://cloudup.com/ciQlk7rwYnz

While this seems to be along the lines of what we want (scale the views while still keeping the touchable area big enough to be able to properly be operated with real fingers), it still has problems and I think it's  not worth spending more time on this particular issue. Leaving the PR here though in case we want to explore these options again in the future.
