### PR TITLE
Media picker corrections

### DIFF
--- a/app/src/main/java/com/automattic/portkey/compose/photopicker/MediaBrowserType.java
+++ b/app/src/main/java/com/automattic/portkey/compose/photopicker/MediaBrowserType.java
@@ -22,8 +22,11 @@ public enum MediaBrowserType {
     public boolean isSingleImagePicker() {
         return this == FEATURED_IMAGE_PICKER
                || this == GRAVATAR_IMAGE_PICKER
-               || this == SITE_ICON_PICKER
-               || this == PORTKEY_PICKER;
+               || this == SITE_ICON_PICKER;
+    }
+
+    public boolean isSingleMediaItemPicker() {
+        return isSingleImagePicker() || this == PORTKEY_PICKER;
     }
 
     public boolean canMultiselect() {

--- a/app/src/main/java/com/automattic/portkey/compose/photopicker/PhotoPickerAdapter.java
+++ b/app/src/main/java/com/automattic/portkey/compose/photopicker/PhotoPickerAdapter.java
@@ -232,6 +232,15 @@ public class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.
         return mMediaList.get(position);
     }
 
+    public boolean isSelectedSingleItemVideo() {
+        PhotoPickerItem item = getItemAtPosition(getSelectedPositions().get(0));
+        if (item != null) {
+            return item.mIsVideo;
+        } else {
+            return false;
+        }
+    }
+
     private boolean isValidPosition(int position) {
         return position >= 0 && position < mMediaList.size();
     }
@@ -471,9 +480,7 @@ public class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.
             addMedia(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, false);
 
             // videos
-            if (!mBrowserType.isSingleImagePicker()) {
-                addMedia(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, true);
-            }
+            addMedia(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, true);
 
             // sort by id in reverse (newest first)
             Collections.sort(mTmpList, new Comparator<PhotoPickerItem>() {

--- a/app/src/main/java/com/automattic/portkey/compose/photopicker/PhotoPickerFragment.java
+++ b/app/src/main/java/com/automattic/portkey/compose/photopicker/PhotoPickerFragment.java
@@ -273,16 +273,14 @@ public class PhotoPickerFragment extends Fragment {
             }
         });
 
-        if (!mBrowserType.isSingleImagePicker()) {
-            MenuItem itemVideo = popup.getMenu().add(R.string.photo_picker_choose_video);
-            itemVideo.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
-                @Override
-                public boolean onMenuItemClick(MenuItem item) {
-                    doIconClicked(PhotoPickerIcon.ANDROID_CHOOSE_VIDEO);
-                    return true;
-                }
-            });
-        }
+        MenuItem itemVideo = popup.getMenu().add(R.string.photo_picker_choose_video);
+        itemVideo.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                doIconClicked(PhotoPickerIcon.ANDROID_CHOOSE_VIDEO);
+                return true;
+            }
+        });
 
 //        if (mSite != null) {
 //            MenuItem itemStock = popup.getMenu().add(R.string.photo_picker_stock_media);
@@ -359,7 +357,7 @@ public class PhotoPickerFragment extends Fragment {
                 if (mActionMode == null) {
                     ((AppCompatActivity) getActivity()).startSupportActionMode(new ActionModeCallback());
                 }
-                updateActionModeTitle();
+                updateActionModeTitle(mAdapter.isSelectedSingleItemVideo());
             }
         }
 
@@ -439,13 +437,17 @@ public class PhotoPickerFragment extends Fragment {
         }
     }
 
-    private void updateActionModeTitle() {
+    private void updateActionModeTitle(boolean selectedItemIsVideo) {
         if (mActionMode == null) {
             return;
         }
         String title;
-        if (mBrowserType.isSingleImagePicker()) {
-            mActionMode.setTitle(R.string.photo_picker_use_photo);
+        if (mBrowserType.isSingleMediaItemPicker()) {
+            if (selectedItemIsVideo) {
+                mActionMode.setTitle(R.string.photo_picker_use_video);
+            } else {
+                mActionMode.setTitle(R.string.photo_picker_use_photo);
+            }
         } else {
             int numSelected = getAdapter().getNumSelected();
             title = String.format(getString(R.string.cab_selected), numSelected);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="photo_picker_choose_photo">Choose photo from device</string>
     <string name="confirm">Confirm</string>
     <string name="photo_picker_use_photo">Use this photo</string>
+    <string name="photo_picker_use_video">Use this video</string>
     <string name="cab_selected">%d selected</string>
     <string name="media_empty_list">You don\'t have any media</string>
     <string name="photo_picker_soft_ask_allow">Allow</string>


### PR DESCRIPTION
Fix #151 

This PR tackles the action items outlined in #151:

- [x] 888ba00 hide video overlay
- [x] a79e8f1 single picker
- [x] f853019 long press listener removed

Also, added a small improvement to show a different title depending on whether the user has selected an image or a video in ec92668

To tetst:
1. open portkey and tap on the + icon to go to the composer screen
2. in camera preview mode, tap on the upload picture icon (left of the shutter icon)
3. the media picker is shown
4. tap on any item, it should show "Use this photo" or "Use this video" up as the toolbar title
5. tapping on the checkmark (right top corner of the screen) should set that selected media item as the background.

![mediapicker](https://user-images.githubusercontent.com/6597771/70644889-a3c0aa80-1c22-11ea-86c0-9d87a40d6911.gif)


Note: while this does not eliminate the 2 steps described in the issue, I think it better aligns with what was asked during tests. Also, if you mistakingly tapped on an item it would immediately become the background for your portkey frame, and you'd have more clicks to make to choose another background image / video otherwise. So, while this is debatable, I think it should be enough for now (the entire media picking experience could be re-thought down the line).


