### PR TITLE
Default to add entered text if any when dismissing keyboard and edittext

### DIFF
--- a/app/src/main/java/com/automattic/portkey/compose/text/TextEditorDialogFragment.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/text/TextEditorDialogFragment.kt
@@ -1,5 +1,6 @@
 package com.automattic.portkey.compose.text
 
+import android.content.DialogInterface
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -72,6 +73,12 @@ class TextEditorDialogFragment : DialogFragment() {
             val inputText = add_text_edit_text?.text.toString()
             textEditor?.onDone(inputText, colorCode)
         }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        val inputText = add_text_edit_text?.text.toString()
+        textEditor?.onDone(inputText, colorCode)
+        super.onDismiss(dialog)
     }
 
     // Callback to listener if user is done with text editing


### PR DESCRIPTION
Fix #223 

Overriding the `onDismiss()` method so it calls the listener `onDone` and adds the text, as it seems to be the most straightforward in this case. See gif below:

![addtextonbacktwice](https://user-images.githubusercontent.com/6597771/70719575-053f5280-1cd1-11ea-9d38-8420b6666712.gif)
