### PR TITLE
Save frame refactor part 4 (6) - remove no longer used code

### DIFF
--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveManager.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveManager.kt
@@ -42,8 +42,8 @@ class FrameSaveManager : CoroutineScope {
     ): List<File> {
         // first, launch all frame save processes async
         return frames.mapIndexed { index, frame ->
-            async {
-                withContext(coroutineContext) {
+            withContext(coroutineContext) {
+                async {
                     yield()
                     // create ghost PhotoEditorView to be used for saving off-screen
                     val ghostPhotoEditorView = createGhostPhotoEditor(context, originalPhotoEditorView)


### PR DESCRIPTION
This PR builds on top of #253.

After implementing coroutines and migrating the image saving mechanism from AsyncTask to coroutines in #253, this PR removes unused `saveImage()` and related set of functions from PhotoEditor, given we've now moved the responsibility of image frame saving to the app's `FrameSaveManager`.