### PR TITLE
Save frame refactor part 6 (8) - fix glitch on static background frames

### DIFF
--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveManager.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveManager.kt
@@ -45,8 +45,8 @@ class FrameSaveManager(val photoEditor: PhotoEditor) : CoroutineScope {
     ): List<File?> {
         // first, launch all frame save processes async
         return frames.mapIndexed { index, frame ->
-            async {
-                withContext(coroutineContext) {
+            withContext(coroutineContext) {
+                async {
                     yield()
                     saveLoopFrame(context, frame, index)
                 }


### PR DESCRIPTION
This builds on #255.

This PR fixes a problem when the currently selected frame is a static background frame, and pressing SAVE (Next) would make the added Views disappear and not appear again until the user switches to another frame and then switches back again to that frame.

Internally, the `saveFrame()` algorithm removes and adds the user-added Views to each ghost offscreen `PhotoEditorView`, and finally removes the addedViews so these can be added back to the actual PhotoEditorView being shown on the screen. But, the `FrameSaveManager` is never passed the actual screen's `PhotoEditorView`, so we can't really re-add the views for the selected frame once things are finished (as a matter of fact the `FrameSaveManager` doesn't even know which frame is selected, as that's responsibility of the `StoryViewModel`).

So, this PR introduces a small workaround to refresh the selected frame and re-add the views by calling `storyViewModel.setSelectedFrameByUser()` on the current index once the saveStory() method has returned.

To test:
1. add a few static image based frames
2. add a text / emoji to each
3. select any one
4. tap NEXT to save the story
5. observe once the story is finished saving, the added views for the selected frame are still there (as opposed to having disappeared) 
