### PR TITLE
Introducing Frame Saving process into a Service

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.9.0'
     kapt 'com.github.bumptech.glide:compiler:4.9.0'
 
+    implementation 'org.greenrobot:eventbus:3.1.1'
+
     implementation 'io.sentry:sentry-android:1.7.27'
     // this dependency is not required if you are already using your own
     // slf4j implementation

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,11 @@
             android:theme="@style/AppTheme.NoActionBar"
             />
 
+        <!-- Services -->
+        <service
+            android:name=".compose.frame.FrameSaveService"
+            android:label="Frame Save Service" />
+
         <!-- FileProvider used to share photos with other apps -->
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
@@ -82,9 +82,6 @@ import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.activity_composer.*
 import kotlinx.android.synthetic.main.content_composer.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode

--- a/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
@@ -129,7 +129,6 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
     private var isEditingText: Boolean = false
 
     private lateinit var storyViewModel: StoryViewModel
-    private lateinit var frameSaveManager: FrameSaveManager
     private lateinit var transition: LayoutTransition
 
     private lateinit var frameSaveService: FrameSaveService
@@ -140,7 +139,10 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
             Log.d("ComposeLoopFrame", "onServiceConnected()")
             val binder = service as FrameSaveService.FrameSaveServiceBinder
             frameSaveService = binder.getService()
-            frameSaveService.saveStoryFrames(0, frameSaveManager, StoryRepository.getImmutableCurrentStoryFrames())
+            frameSaveService.saveStoryFrames(0,
+                FrameSaveManager(photoEditor),
+                StoryRepository.getImmutableCurrentStoryFrames()
+            )
             saveServiceBound = true
         }
 
@@ -230,8 +232,6 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
                 delete_view.setReadyForDelete(ready)
             }
         })
-
-        frameSaveManager = FrameSaveManager(photoEditor)
 
         backgroundSurfaceManager = BackgroundSurfaceManager(
             savedInstanceState,
@@ -324,7 +324,6 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
 
     override fun onDestroy() {
         doUnbindService()
-        frameSaveManager.onCancel()
         EventBus.getDefault().unregister(this)
         super.onDestroy()
     }

--- a/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
@@ -323,8 +323,8 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
     }
 
     override fun onDestroy() {
-        frameSaveManager.onCancel()
         doUnbindService()
+        frameSaveManager.onCancel()
         EventBus.getDefault().unregister(this)
         super.onDestroy()
     }
@@ -556,10 +556,7 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
             if (storyViewModel.getCurrentStorySize() > 0) {
                 // save all composed frames
                 if (PermissionUtils.checkAndRequestPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                    CoroutineScope(Dispatchers.Main).launch {
-                        showLoading(getString(R.string.label_saving))
-                        saveStory()
-                    }
+                    saveStory()
                 }
             }
         }
@@ -578,6 +575,7 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
     }
 
     private fun saveStoryPreHook() {
+        showLoading(getString(R.string.label_saving))
         // disable layout change animations, we need this to make added views immediately visible, otherwise
         // we may end up capturing a Bitmap of a backing drawable that still has not been updated
         // (i.e. no visible added Views)

--- a/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
@@ -55,7 +55,6 @@ import com.automattic.portkey.BuildConfig
 import com.automattic.portkey.R
 import com.automattic.portkey.compose.emoji.EmojiPickerFragment
 import com.automattic.portkey.compose.emoji.EmojiPickerFragment.EmojiListener
-import com.automattic.portkey.compose.frame.FrameSaveManager
 import com.automattic.portkey.compose.frame.FrameSaveService
 import com.automattic.portkey.compose.frame.FrameSaveService.StorySaveResult
 import com.automattic.portkey.compose.photopicker.MediaBrowserType
@@ -136,10 +135,7 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
             Log.d("ComposeLoopFrame", "onServiceConnected()")
             val binder = service as FrameSaveService.FrameSaveServiceBinder
             frameSaveService = binder.getService()
-            frameSaveService.saveStoryFrames(0,
-                FrameSaveManager(photoEditor),
-                StoryRepository.getImmutableCurrentStoryFrames()
-            )
+            frameSaveService.saveStoryFrames(0, photoEditor, StoryRepository.getImmutableCurrentStoryFrames())
             saveServiceBound = true
         }
 

--- a/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
@@ -1,17 +1,21 @@
 package com.automattic.portkey.compose
 
 import android.Manifest
+import android.animation.LayoutTransition
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.ActivityOptions
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.ServiceConnection
 import android.hardware.Camera
 import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
+import android.os.IBinder
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.text.TextUtils
@@ -52,6 +56,8 @@ import com.automattic.portkey.R
 import com.automattic.portkey.compose.emoji.EmojiPickerFragment
 import com.automattic.portkey.compose.emoji.EmojiPickerFragment.EmojiListener
 import com.automattic.portkey.compose.frame.FrameSaveManager
+import com.automattic.portkey.compose.frame.FrameSaveService
+import com.automattic.portkey.compose.frame.FrameSaveService.StorySaveResult
 import com.automattic.portkey.compose.photopicker.MediaBrowserType
 import com.automattic.portkey.compose.photopicker.PhotoPickerActivity
 import com.automattic.portkey.compose.photopicker.PhotoPickerFragment
@@ -79,6 +85,9 @@ import kotlinx.android.synthetic.main.content_composer.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 import java.io.File
 import java.io.IOException
 import kotlin.math.abs
@@ -121,10 +130,30 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
 
     private lateinit var storyViewModel: StoryViewModel
     private lateinit var frameSaveManager: FrameSaveManager
+    private lateinit var transition: LayoutTransition
+
+    private lateinit var frameSaveService: FrameSaveService
+    private var saveServiceBound: Boolean = false
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(className: ComponentName, service: IBinder) {
+            Log.d("ComposeLoopFrame", "onServiceConnected()")
+            val binder = service as FrameSaveService.FrameSaveServiceBinder
+            frameSaveService = binder.getService()
+            frameSaveService.saveStoryFrames(0, frameSaveManager, StoryRepository.getImmutableCurrentStoryFrames())
+            saveServiceBound = true
+        }
+
+        override fun onServiceDisconnected(arg0: ComponentName) {
+            Log.d("ComposeLoopFrame", "onServiceDisconnected()")
+            saveServiceBound = false
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_composer)
+        EventBus.getDefault().register(this)
 
         topControlsBaseTopMargin = getLayoutTopMarginBeforeInset(edit_mode_controls.layoutParams)
         ViewCompat.setOnApplyWindowInsetsListener(compose_loop_frame_layout) { view, insets ->
@@ -295,6 +324,8 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
 
     override fun onDestroy() {
         frameSaveManager.onCancel()
+        doUnbindService()
+        EventBus.getDefault().unregister(this)
         super.onDestroy()
     }
 
@@ -528,8 +559,6 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
                     CoroutineScope(Dispatchers.Main).launch {
                         showLoading(getString(R.string.label_saving))
                         saveStory()
-                        hideLoading()
-                        showToast("READY")
                     }
                 }
             }
@@ -540,20 +569,24 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
         }
     }
 
-    private suspend fun saveStory() {
+    private fun saveStory() {
+        saveStoryPreHook()
+        // Bind to FrameSaveService
+        FrameSaveService.startServiceAndGetSaveStoryIntent(this).also { intent ->
+            bindService(intent, connection, Context.BIND_AUTO_CREATE)
+        }
+    }
+
+    private fun saveStoryPreHook() {
         // disable layout change animations, we need this to make added views immediately visible, otherwise
         // we may end up capturing a Bitmap of a backing drawable that still has not been updated
         // (i.e. no visible added Views)
-        val transition = photoEditorView.getLayoutTransition()
+        transition = photoEditorView.getLayoutTransition()
         photoEditorView.layoutTransition = null
+    }
 
-        val frameFileList =
-            frameSaveManager.saveStory(
-                this@ComposeLoopFrameActivity,
-                storyViewModel.getImmutableCurrentStoryFrames()
-            )
-        // once all frames have been saved, issue a broadcast so the system knows these frames are ready
-        sendNewStoryReadyBroadcast(frameFileList)
+    private fun saveStoryPostHook() {
+        doUnbindService()
 
         // given saveStory for static images works with a ghost off screen buffer by removing / adding views to it,
         // we need to refresh the selection so added views get properly re-added after frame iteration ends
@@ -561,6 +594,9 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
 
         // re-enable layout change animations
         photoEditorView.layoutTransition = transition
+
+        hideLoading()
+        showToast("READY")
     }
 
     private fun refreshStoryFrameSelection() {
@@ -1260,6 +1296,19 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
             }
             return super.onFling(e1, e2, velocityX, velocityY)
         }
+    }
+
+    private fun doUnbindService() {
+        if (saveServiceBound) {
+            unbindService(connection)
+            saveServiceBound = false
+        }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onStorySaveResult(event: StorySaveResult) {
+        // TODO do something to treat the errors here
+        saveStoryPostHook()
     }
 
     companion object {

--- a/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
@@ -323,7 +323,6 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
     }
 
     override fun onDestroy() {
-        frameSaveManager.onCancel()
         doUnbindService()
         EventBus.getDefault().unregister(this)
         super.onDestroy()

--- a/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/ComposeLoopFrameActivity.kt
@@ -1115,7 +1115,7 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
         // level >= 24, so if you only target 24+ you can remove this statement
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             @Suppress("DEPRECATION")
-            if (mediaFile.extension.startsWith("jpg")) {
+            if (mediaFile.extension == "jpg") {
                 sendBroadcast(Intent(Camera.ACTION_NEW_PICTURE, Uri.fromFile(mediaFile)))
             } else {
                 sendBroadcast(Intent(Camera.ACTION_NEW_VIDEO, Uri.fromFile(mediaFile)))
@@ -1138,7 +1138,7 @@ class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTapped
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             @Suppress("DEPRECATION")
             for (mediaFile in mediaFileList) {
-                if (mediaFile.extension.startsWith("jpg")) {
+                if (mediaFile.extension == "jpg") {
                     sendBroadcast(Intent(Camera.ACTION_NEW_PICTURE, Uri.fromFile(mediaFile)))
                 } else {
                     sendBroadcast(Intent(Camera.ACTION_NEW_VIDEO, Uri.fromFile(mediaFile)))

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveManager.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.net.Uri
+import android.util.Log
 import android.view.ViewGroup.LayoutParams
 import android.widget.RelativeLayout
 import com.automattic.photoeditor.PhotoEditor
@@ -27,6 +28,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import java.io.File
 import kotlin.coroutines.CoroutineContext
+import kotlin.system.measureTimeMillis
 
 class FrameSaveManager(private val photoEditor: PhotoEditor) : CoroutineScope {
     private val job = Job()
@@ -60,22 +62,26 @@ class FrameSaveManager(private val photoEditor: PhotoEditor) : CoroutineScope {
         sequenceId: Int
     ): File? {
         var frameFile: File? = null
-        when (frame.frameItemType) {
-            VIDEO -> {
-                frameFile = saveVideoFrame(frame, sequenceId)
-            }
-            IMAGE -> {
-                // check whether there are any GIF stickers - if there are, we need to produce a video instead
-                if (frame.addedViews.containsAnyAddedViewsOfType(STICKER_ANIMATED)) {
-                    // TODO make saveVideoWithStaticBackground return File
-                    // saveVideoWithStaticBackground()
-                } else {
-                    // create ghost PhotoEditorView to be used for saving off-screen
-                    val ghostPhotoEditorView = createGhostPhotoEditor(context, photoEditor.composedCanvas)
-                    frameFile = saveImageFrame(frame, ghostPhotoEditorView, sequenceId)
+        Log.d("PORTKEY", "START SAVE: " + sequenceId)
+        val time = measureTimeMillis {
+            when (frame.frameItemType) {
+                VIDEO -> {
+                    frameFile = saveVideoFrame(frame, sequenceId)
+                }
+                IMAGE -> {
+                    // check whether there are any GIF stickers - if there are, we need to produce a video instead
+                    if (frame.addedViews.containsAnyAddedViewsOfType(STICKER_ANIMATED)) {
+                        // TODO make saveVideoWithStaticBackground return File
+                        // saveVideoWithStaticBackground()
+                    } else {
+                        // create ghost PhotoEditorView to be used for saving off-screen
+                        val ghostPhotoEditorView = createGhostPhotoEditor(context, photoEditor.composedCanvas)
+                        frameFile = saveImageFrame(frame, ghostPhotoEditorView, sequenceId)
+                    }
                 }
             }
         }
+        Log.d("PORTKEY", "END SAVE: " + sequenceId + " time: " + time)
         return frameFile
     }
 

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveManager.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveManager.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import java.io.File
@@ -44,16 +45,19 @@ class FrameSaveManager(private val photoEditor: PhotoEditor) : CoroutineScope {
     suspend fun saveStory(
         context: Context,
         frames: List<StoryFrameItem>
-    ): List<File?> {
+    ): List<File?>? {
+        var result: List<File?>? = null
+        Log.d("FrameSaveService", "saveStory() core 1")
         // first, launch all frame save processes async
-        return frames.mapIndexed { index, frame ->
-            withContext(coroutineContext) {
-                async {
-                    yield()
-                    saveLoopFrame(context, frame, index)
-                }
+        result = frames.mapIndexed { index, frame ->
+            async {
+                yield()
+                Log.d("FrameSaveService", "saveStory() core 2")
+                saveLoopFrame(context, frame, index)
             }
         }.awaitAll()
+        Log.d("FrameSaveService", "saveStory() core 3")
+        return result
     }
 
     private suspend fun saveLoopFrame(

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import android.webkit.MimeTypeMap
+import com.automattic.photoeditor.PhotoEditor
 import com.automattic.portkey.compose.story.StoryFrameItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -51,9 +52,9 @@ class FrameSaveService : Service() {
         return START_NOT_STICKY
     }
 
-    fun saveStoryFrames(storyIndex: Int, frameSaveManager: FrameSaveManager, frames: List<StoryFrameItem>) {
+    fun saveStoryFrames(storyIndex: Int, photoEditor: PhotoEditor, frames: List<StoryFrameItem>) {
         this.storyIndex = storyIndex
-        this.frameSaveManager = frameSaveManager
+        this.frameSaveManager = FrameSaveManager(photoEditor)
         CoroutineScope(Dispatchers.Default).launch {
             saveStoryFramesAndDispatchNewFileBroadcast(frameSaveManager, frames)
             stopSelf()

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
@@ -35,7 +35,7 @@ class FrameSaveService : Service() {
     }
 
     // we won't really use intents to start the Service but we need it to be a started Service so we can make it
-    // a forergorund Service as well. Hence, here we override onStartCommand() as well.
+    // a foreground Service as well. Hence, here we override onStartCommand() as well.
     // So basically we're using a bound Service to be able to pass the FrameSaveManager instance to it, which in turn
     // has an instance of PhotoEditor, which is needed to save each frame.
     // And, we're making it a started Service so we can also make it a foreground Service (bound services alone

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
@@ -75,7 +75,7 @@ class FrameSaveService : Service() {
         sendNewMediaReadyBroadcast(frameFileList)
 
         // TODO collect all the errors somehow before posting the SaveResult for the whole Story
-        EventBus.getDefault().post(StorySaveResult(true, storyIndex, null))
+        EventBus.getDefault().post(StorySaveResult(true, storyIndex))
     }
 
     private fun sendNewMediaReadyBroadcast(rawMediaFileList: List<File?>) {

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
@@ -85,7 +85,7 @@ class FrameSaveService : Service() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             @Suppress("DEPRECATION")
             for (mediaFile in mediaFileList) {
-                if (mediaFile.extension.startsWith("jpg")) {
+                if (mediaFile.extension == "jpg") {
                     sendBroadcast(Intent(Camera.ACTION_NEW_PICTURE, Uri.fromFile(mediaFile)))
                 } else {
                     sendBroadcast(Intent(Camera.ACTION_NEW_VIDEO, Uri.fromFile(mediaFile)))

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
@@ -1,0 +1,135 @@
+package com.automattic.portkey.compose.frame
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.hardware.Camera
+import android.media.MediaScannerConnection
+import android.net.Uri
+import android.os.Binder
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import android.webkit.MimeTypeMap
+import com.automattic.portkey.compose.story.StoryFrameItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.File
+import org.greenrobot.eventbus.EventBus
+
+class FrameSaveService : Service() {
+    private val binder = FrameSaveServiceBinder()
+    private var storyIndex: Int = 0
+
+    override fun onCreate() {
+        super.onCreate()
+        // TODO add logging
+        Log.d("FrameSaveService", "onCreate()")
+    }
+
+    override fun onBind(p0: Intent?): IBinder? {
+        Log.d("FrameSaveService", "onBind()")
+        return binder
+    }
+
+    // we won't really use intents to start the Service but we need it to be a started Service so we can make it
+    // a forergorund Service as well. Hence, here we override onStartCommand() as well.
+    // So basically we're using a bound Service to be able to pass the FrameSaveManager instance to it, which in turn
+    // has an instance of PhotoEditor, which is needed to save each frame.
+    // And, we're making it a started Service so we can also make it a foreground Service (bound services alone
+    // can't be foreground services, and serializing a FrameSaveManager or a PhotoEditor instance seems way too
+    // for something that will need to live on the screen anyway, at least for the time being).
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d("FrameSaveService", "onStartCommand()")
+        // Skip this request if no items to upload were given
+        if (intent == null) { // || !intent.hasExtra(KEY_MEDIA_LIST) && !intent.hasExtra(KEY_LOCAL_POST_ID)) {
+            // AppLog.e(T.MAIN, "UploadService > Killed and restarted with an empty intent")
+            stopSelf()
+        }
+        return START_NOT_STICKY
+    }
+
+    fun saveStoryFrames(storyIndex: Int, frameSaveManager: FrameSaveManager, frames: List<StoryFrameItem>) {
+        Log.d("FrameSaveService", "saveStoryFrames()")
+        this.storyIndex = storyIndex
+        CoroutineScope(Dispatchers.Default).launch {
+            saveStoryFramesAndDispatchNewFileBroadcast(frameSaveManager, frames)
+            stopSelf()
+        }
+    }
+
+    private suspend fun saveStoryFramesAndDispatchNewFileBroadcast(
+        frameSaveManager: FrameSaveManager,
+        frames: List<StoryFrameItem>
+    ) {
+        val frameFileList =
+            frameSaveManager.saveStory(
+                this,
+                // TODO don't assume the `current` storyFrames in the Repository but rather take it from the passed
+                // index in the intent extras bundle
+                frames
+            )
+
+        // once all frames have been saved, issue a broadcast so the system knows these frames are ready
+        sendNewStoryReadyBroadcast(frameFileList)
+
+        // TODO collect all the errors somehow before posting the SaveResult for the whole Story
+        EventBus.getDefault().post(StorySaveResult(true, storyIndex, null))
+    }
+
+    private fun sendNewStoryReadyBroadcast(rawMediaFileList: List<File?>) {
+        // Implicit broadcasts will be ignored for devices running API
+        // level >= 24, so if you only target 24+ you can remove this statement
+        val mediaFileList = rawMediaFileList.filterNotNull()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            @Suppress("DEPRECATION")
+            for (mediaFile in mediaFileList) {
+                if (mediaFile.extension.startsWith("jpg")) {
+                    sendBroadcast(Intent(Camera.ACTION_NEW_PICTURE, Uri.fromFile(mediaFile)))
+                } else {
+                    sendBroadcast(Intent(Camera.ACTION_NEW_VIDEO, Uri.fromFile(mediaFile)))
+                }
+            }
+        }
+
+        val arrayOfmimeTypes = arrayOfNulls<String>(mediaFileList.size)
+        val arrayOfPaths = arrayOfNulls<String>(mediaFileList.size)
+        for ((index, mediaFile) in mediaFileList.withIndex()) {
+            arrayOfmimeTypes[index] = MimeTypeMap.getSingleton()
+                .getMimeTypeFromExtension(mediaFile.extension)
+            arrayOfPaths[index] = mediaFile.absolutePath
+        }
+
+        // If the folder selected is an external media directory, this is unnecessary
+        // but otherwise other apps will not be able to access our images unless we
+        // scan them using [MediaScannerConnection]
+        MediaScannerConnection.scanFile(
+            applicationContext, arrayOfPaths, arrayOfmimeTypes, null)
+    }
+
+    override fun onDestroy() {
+        Log.d("FrameSaveService", "onDestroy()")
+        super.onDestroy()
+    }
+
+    inner class FrameSaveServiceBinder : Binder() {
+        fun getService(): FrameSaveService = this@FrameSaveService
+    }
+
+    data class StorySaveResult(
+        var success: Boolean,
+        var storyIndex: Int,
+        var frameSaveResult: List<FrameSaveResult>? = null
+    )
+    data class FrameSaveResult(val success: Boolean, val frameIndex: Int)
+
+    companion object {
+        fun startServiceAndGetSaveStoryIntent(context: Context): Intent {
+            Log.d("FrameSaveService", "startServiceAndGetSaveStoryIntent()")
+            val intent = Intent(context, FrameSaveService::class.java)
+            context.startService(intent)
+            return intent
+        }
+    }
+}

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
@@ -66,8 +66,6 @@ class FrameSaveService : Service() {
         val frameFileList =
             frameSaveManager.saveStory(
                 this,
-                // TODO don't assume the `current` storyFrames in the Repository but rather take it from the passed
-                // index in the intent extras bundle
                 frames
             )
 

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
@@ -72,13 +72,13 @@ class FrameSaveService : Service() {
             )
 
         // once all frames have been saved, issue a broadcast so the system knows these frames are ready
-        sendNewStoryReadyBroadcast(frameFileList)
+        sendNewMediaReadyBroadcast(frameFileList)
 
         // TODO collect all the errors somehow before posting the SaveResult for the whole Story
         EventBus.getDefault().post(StorySaveResult(true, storyIndex, null))
     }
 
-    private fun sendNewStoryReadyBroadcast(rawMediaFileList: List<File?>) {
+    private fun sendNewMediaReadyBroadcast(rawMediaFileList: List<File?>) {
         // Implicit broadcasts will be ignored for devices running API
         // level >= 24, so if you only target 24+ you can remove this statement
         val mediaFileList = rawMediaFileList.filterNotNull()

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
@@ -21,6 +21,7 @@ import org.greenrobot.eventbus.EventBus
 class FrameSaveService : Service() {
     private val binder = FrameSaveServiceBinder()
     private var storyIndex: Int = 0
+    private lateinit var frameSaveManager: FrameSaveManager
 
     override fun onCreate() {
         super.onCreate()
@@ -53,6 +54,7 @@ class FrameSaveService : Service() {
     fun saveStoryFrames(storyIndex: Int, frameSaveManager: FrameSaveManager, frames: List<StoryFrameItem>) {
         Log.d("FrameSaveService", "saveStoryFrames()")
         this.storyIndex = storyIndex
+        this.frameSaveManager = frameSaveManager
         CoroutineScope(Dispatchers.Default).launch {
             saveStoryFramesAndDispatchNewFileBroadcast(frameSaveManager, frames)
             stopSelf()
@@ -108,6 +110,7 @@ class FrameSaveService : Service() {
 
     override fun onDestroy() {
         Log.d("FrameSaveService", "onDestroy()")
+        frameSaveManager.onCancel()
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
+++ b/app/src/main/java/com/automattic/portkey/compose/frame/FrameSaveService.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.File
 import org.greenrobot.eventbus.EventBus
+import kotlin.system.measureTimeMillis
 
 class FrameSaveService : Service() {
     private val binder = FrameSaveServiceBinder()
@@ -63,17 +64,20 @@ class FrameSaveService : Service() {
         frameSaveManager: FrameSaveManager,
         frames: List<StoryFrameItem>
     ) {
-        val frameFileList =
-            frameSaveManager.saveStory(
-                this,
-                frames
-            )
+        val time = measureTimeMillis {
+            val frameFileList =
+                frameSaveManager.saveStory(
+                    this,
+                    frames
+                )
 
-        // once all frames have been saved, issue a broadcast so the system knows these frames are ready
-        sendNewMediaReadyBroadcast(frameFileList)
+            // once all frames have been saved, issue a broadcast so the system knows these frames are ready
+            sendNewMediaReadyBroadcast(frameFileList)
 
-        // TODO collect all the errors somehow before posting the SaveResult for the whole Story
-        EventBus.getDefault().post(StorySaveResult(true, storyIndex, null))
+            // TODO collect all the errors somehow before posting the SaveResult for the whole Story
+            EventBus.getDefault().post(StorySaveResult(true, storyIndex, null))
+        }
+        Log.d("PORTKEY", "TOTAL TIME: " + time)
     }
 
     private fun sendNewMediaReadyBroadcast(rawMediaFileList: List<File?>) {


### PR DESCRIPTION
Closes #273 

### Intro
This PR takes the former work done in order to implement a Story Frames Save architecture (see #257 and related PRs) and encapsulate the work into a Service.

This is needed given sometimes, saving a Story's frames may take time (especially if they have video-background in one or more of their Story frames), and we don't want to block the user on a screen, waiting for things to get processed.

### Services
The Android documentation describes a few of the possibilities we have for performing [background work](https://developer.android.com/guide/background). We're going to use a Foreground Service given that's the mechanism that best fits the description of our use case as explained here.

> For user-initiated work that need to run immediately and must execute to completion, use a foreground service. Using a foreground service tells the system that the app is doing something important and it shouldn’t be killed. Foreground services are visible to users via a non-dismissible notification in the notification tray.

In our case, the user taps on `Save` button and makes it explicit that they want their Story and Story frames to get saved. Hence, it makes sense to encapsulate this work in a Foreground Service.

In our specific case, we can roughly say there are 2 big parts to finishing a Story:
1. Saving the composed Story frames to disk so these are available for upload
2. upload the frames and Story to a server.

For now, this PR will start with part 1, and move the already existing code from being carelessly called from the Activity (in the click listener for the `Next` button) into a foreground Service, as this operation can potentially be lengthy depending on hardware and amount of frames to be saved. 
For the upload part we're going to delegate that to the existing WordPress Android `UploadService`, which will manage both the adding of images and uploading a custom typed Post to an existing site (to be covered in further PRs when integration of the functionality into WPAndroid is planned).

### How it works
There's a problem I found while doing this: a [started Service](https://developer.android.com/guide/components/services#CreatingAService) is passed parameters with an Intent extras bundle, and our parameters here would be a list of images with their added Views, so unless we access the `ViewModel`'s `Repository` from the `Service` (with the Repository actually persisting the data, which is not our case right now as we just keep these in memory) then we can't pass the frames with their added views if we don't first serialize this information (that is, positioning, rotation and scale information for each of the added views). 

Given our Service is actually triggered from an Activity and is quite related to it (it's a user initiated action), looks like this is a good candidate for a [bound service](https://developer.android.com/guide/components/bound-services#Creating), thus allowing us to bypass the serialization process which among other things would also incur into some time penalty (both for execution and development time). In this case, for the reasons outlined above we also need to making it both a bound Service _and_ a foreground service (as we need the background saving process to exist even if the user navigates away from the Activity or even further, away from the app itself). This PR only tackled the bound Service part, and leaves the foreground Service for an upcoming PR so to keep things simpler and easier to review.

Once the processing is ready, it can either have a successful ending, or some of the frames may have not been saved successfully. The error collection strategy will be tackled on another PR, for now we're introducing EventBus here just as a means to signal the saving process has ended (either successfully or not, it doesn't matter for now in this PR), so the event listener can properly do the cleanup they want.

### Next steps (to be tackled in subsequent PRs):
- [x] implement foreground service (with foreground notification) https://github.com/Automattic/portkey-android/pull/279
- [ ] implement error collection strategy
- [ ] implement error collection UI

### A word on future WPAndroid integration
Before tackling this PR, I studied how other services were implemented, particularly [SiteCreationService](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationService.kt) as a model for a well written Service using the latest guidelines and good stuff Kotlin brings (such as corroutines) and the [UploadService](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java) given our process output here will be fed into the UploadService afterwards. We followed the same pattern as used for other Services in WPAndroid, which will make it easier later when we integrate this functionality there:
- the new class extends Service
- we make it a foreground Service, like the UploadService is. Although a Story can be saved in just a few seconds (while this depends, it's generally less than 2 seconds for ~14 frames as per our tests), we could also improve this part later when integrating with WPAndroid and make use of `AutoForeground` which is implemented there for the `SiteCreationService`.


#### To test:
1. open portkey
2. tap on the + FAB
3. either capture pictures or hold the big button on the bottom to start recording a video, several times
4. add some text / emoji to your frames (this makes processing harder, just 1 added view should be fine for this PR purposes)
5. once you're ready, tap NEXT
6. observe a "Saving..." scrim appears (navigating away from this will probably break stuff as this is just introducing a bound Service, so please just stay there for now :) )
7. once the process ends, the "Saving" scrim disappears
8. got to the Photos app and find your newly created frames (videos, pictures) with your added text / emoji there.

