### PR TITLE
Determine video best size

### DIFF
--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
@@ -2,7 +2,7 @@ package com.daasuu.mp4compose.composer
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.media.MediaCodecList
+import android.media.MediaCodec
 import android.media.MediaFormat
 import android.media.MediaMetadataRetriever
 import android.net.Uri
@@ -143,9 +143,9 @@ class Mp4Composer {
                 object : OutputFormatAdjustCallback {
                     override fun onAdjustOutputSize(
                         outputFormat: MediaFormat,
-                        availableCodecList: MediaCodecList
+                        codec: MediaCodec
                     ) {
-                        listener?.onAdjustOutputSize(outputFormat, availableCodecList)
+                        listener?.onAdjustOutputSize(outputFormat, codec)
                     }
                 }
             )
@@ -291,7 +291,7 @@ class Mp4Composer {
 
         fun onFailed(exception: Exception)
 
-        fun onAdjustOutputSize(outputFormat: MediaFormat, availableCodecList: MediaCodecList)
+        fun onAdjustOutputSize(outputFormat: MediaFormat, encoder: MediaCodec)
     }
 
     private fun initializeUriDataSource(engine: Mp4ComposerEngine) {

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
@@ -2,6 +2,8 @@ package com.daasuu.mp4compose.composer
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.media.MediaCodecList
+import android.media.MediaFormat
 import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.util.Log
@@ -11,6 +13,7 @@ import com.daasuu.mp4compose.FillMode
 import com.daasuu.mp4compose.FillModeCustomItem
 import com.daasuu.mp4compose.Rotation
 import com.daasuu.mp4compose.composer.Mp4ComposerEngine.ProgressCallback
+import com.daasuu.mp4compose.composer.VideoComposer.OutputFormatAdjustCallback
 import com.daasuu.mp4compose.filter.GlFilter
 
 import java.util.concurrent.ExecutorService
@@ -132,6 +135,17 @@ class Mp4Composer {
                 object : ProgressCallback {
                     override fun onProgress(progress: Double) {
                         listener?.onProgress(progress)
+                    }
+                }
+            )
+
+            engine.setAdjustOutputFormatCallback(
+                object : OutputFormatAdjustCallback {
+                    override fun onAdjustOutputSize(
+                        outputFormat: MediaFormat,
+                        availableCodecList: MediaCodecList
+                    ) {
+                        listener?.onAdjustOutputSize(outputFormat, availableCodecList)
                     }
                 }
             )
@@ -259,7 +273,7 @@ class Mp4Composer {
 
     interface Listener {
         /**
-         * Called to notify progress.
+         * Called to notify progress and adjust output size if first option not supported.
          *
          * @param progress Progress in [0.0, 1.0] range, or negative value if progress is unknown.
          */
@@ -276,6 +290,8 @@ class Mp4Composer {
         fun onCanceled()
 
         fun onFailed(exception: Exception)
+
+        fun onAdjustOutputSize(outputFormat: MediaFormat, availableCodecList: MediaCodecList)
     }
 
     private fun initializeUriDataSource(engine: Mp4ComposerEngine) {

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.kt
@@ -20,6 +20,7 @@ import java.io.IOException
 import android.media.MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420SemiPlanar
 import android.media.MediaFormat.MIMETYPE_VIDEO_AVC
 import android.net.Uri
+import com.daasuu.mp4compose.composer.VideoComposer.OutputFormatAdjustCallback
 
 // Refer: https://github.com/ypresto/android-transcoder/blob/master/lib/src/main/java/net/ypresto/androidtranscoder/engine/MediaTranscoderEngine.java
 
@@ -33,6 +34,7 @@ internal class Mp4ComposerEngine {
     private var mediaExtractor: MediaExtractor? = null
     private var mediaMuxer: MediaMuxer? = null
     private var progressCallback: ProgressCallback? = null
+    private var outputFormatAdjustCallback: OutputFormatAdjustCallback? = null
     private var durationUs: Long = 0
     private var mediaMetadataRetriever: MediaMetadataRetriever? = null
 
@@ -46,6 +48,10 @@ internal class Mp4ComposerEngine {
 
     fun setProgressCallback(progressCallback: ProgressCallback) {
         this.progressCallback = progressCallback
+    }
+
+    fun setAdjustOutputFormatCallback(outputAdjustCallback: OutputFormatAdjustCallback) {
+        this.outputFormatAdjustCallback = outputAdjustCallback
     }
 
     @Throws(IOException::class)
@@ -160,8 +166,14 @@ internal class Mp4ComposerEngine {
                 }
 
                 // setup video composer
-                videoComposer =
-                    VideoComposer(mediaExtractor!!, videoTrackIndex, videoOutputFormat, muxRender, timeScale)
+                videoComposer = VideoComposer(
+                                    mediaExtractor!!,
+                                    videoTrackIndex,
+                                    videoOutputFormat,
+                                    muxRender,
+                                    timeScale,
+                                    outputFormatAdjustCallback
+                                )
                 videoComposer!!.setUp(
                     filter,
                     rotation,
@@ -205,7 +217,13 @@ internal class Mp4ComposerEngine {
                 videoOutputFormat.setInteger(MediaFormat.KEY_COLOR_FORMAT, COLOR_FormatYUV420SemiPlanar)
 
                 // setup video composer for static background image
-                videoComposer = VideoComposer(bkgBitmap!!, videoOutputFormat, muxRender, timeScale)
+                videoComposer = VideoComposer(
+                    bkgBitmap!!,
+                    videoOutputFormat,
+                    muxRender,
+                    timeScale,
+                    outputFormatAdjustCallback
+                )
                 videoComposer!!.setUp(
                     filter,
                     rotation,

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/VideoComposer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/VideoComposer.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.media.MediaCodec
 import android.media.MediaExtractor
 import android.media.MediaFormat
+import android.os.Build
 import android.util.Size
 
 import com.daasuu.mp4compose.FillMode
@@ -82,6 +83,16 @@ internal class VideoComposer {
         flipVertical: Boolean,
         flipHorizontal: Boolean
     ) {
+        // patch according to documentation on LOLLIPOP we need to set the KEY_FRAME_RATE to null
+        // https://developer.android.com/reference/android/media/MediaCodec.html#creation
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP && outputFormat.containsKey(MediaFormat.KEY_FRAME_RATE)) {
+            /* Note: On Build.VERSION_CODES.LOLLIPOP, the format to MediaCodecList.findDecoder/EncoderForFormat must not
+                contain a MediaFormat#KEY_FRAME_RATE. Use format.setString(MediaFormat.KEY_FRAME_RATE, null) to clear any
+                existing frame rate setting in the format
+             */
+            outputFormat.setString(MediaFormat.KEY_FRAME_RATE, null)
+        }
+
         try {
             encoder = MediaCodec.createEncoderByType(outputFormat.getString(MediaFormat.KEY_MIME)!!)
         } catch (e: IOException) {

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/VideoComposer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/VideoComposer.kt
@@ -18,8 +18,6 @@ import java.io.IOException
 import java.nio.ByteBuffer
 import android.media.MediaCodecInfo
 
-
-
 // Refer: https://android.googlesource.com/platform/cts/+/lollipop-release/tests/tests/media/src/android/media/cts/ExtractDecodeEditEncodeMuxTest.java
 // Refer: https://github.com/ypresto/android-transcoder/blob/master/lib/src/main/java/net/ypresto/androidtranscoder/engine/VideoTrackTranscoder.java
 internal class VideoComposer {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -8,7 +8,6 @@ import android.graphics.Canvas
 import android.graphics.Typeface
 import android.media.MediaCodec
 import android.media.MediaCodecInfo.CodecProfileLevel
-import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.media.MediaMetadataRetriever
 import android.net.Uri
@@ -717,7 +716,7 @@ class PhotoEditor private constructor(builder: Builder) :
 
             // .size(originalCanvasWidth, originalCanvasHeight)
             .size(1088, 1920)
-            //.size(720, 1280)
+            // .size(720, 1280)
             .fillMode(FillMode.PRESERVE_ASPECT_FIT)
             .filter(GlFilterGroup(filterCollection))
             .listener(object : Mp4Composer.Listener {


### PR DESCRIPTION
This is WIP

Closes #299

The Grafika app, this site (https://bigflake.com/mediacodec/) and the MediaCodec android reference (https://developer.android.com/reference/android/media/MediaCodec) are cited as to-go places for media processing learning.
The documentation for [`createEncoderByType`](https://developer.android.com/reference/android/media/MediaCodec#createEncoderByType(java.lang.String) ) being used in the mp4Composer library recommends to use `findEncoderForFormat` and `createByCodecName` to ensure that the resulting codec can handle a given format.
Hence, we're first using that method by passing the desired output format to it, and then if no codec has been found that can handle this, then we just fall back to selecting the codec using the snippet shown in [`MediaCodecInfo`](https://developer.android.com/reference/android/media/MediaCodecInfo.html) , and then creating the codec using  `createByName`. This gives us an encoder that can handle the MIME type. We now have to figure out the codec's capabilities and try to find what the best output format supported by this codec is, that matches or resembles as closely as possible the desired output format and size.

Having read everything I could here and there, decided to take advantage of the CTS source code availability and take [this portion of code](https://android.googlesource.com/platform/cts/+/313007f/tests/tests/hardware/src/android/hardware/camera2/cts/RecordingTest.java#722) to decide on which the best size is for each media codec available on a device.

The Pixel 3 has a 1440x2792 screen, which fails because there is no encoder available to support such a size. But, using 1440x2560 (the closest value to a known format, 1440p) works ok.

But I also found out using a multiple like 720x1280 when the source video uses the same measurers works well, and weighs way less of course.

For example citing this [support page for Youtube ](https://support.google.com/youtube/answer/6375112?co=GENIE.Platform%3DDesktop&hl=en) recommends using / encoding at the following standard resolutions for a 16:9 aspect ratio (which [we are setting](https://github.com/Automattic/portkey-android/blob/develop/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt#L186) as per default as well in photoEditor):

```
For the default 16:9 aspect ratio, encode at these resolutions:

2160p: 3840x2160
1440p: 2560x1440
1080p: 1920x1080
720p: 1280x720
480p: 854x480
360p: 640x360
240p: 426x240
````

Furthermore, the source video used in my tests was recorded with the "native" camera app and its resolution is 720x1280 (which is exactly half of 1440x2560). The results are pretty much the same using one or the other resolution, whlie using the encoder best supported size (1088x1920) results in a bigger filesize (1.5M as opposed to 6Megs for a 0.6 seconds file shot with the emu's  moving camera).

Having then all this information I came up with a way to determine the best possible size that can be used without trying to be super smart about it:

- If the screen size is a multiple of the source video size, then choose the original source video size as per the target size, and check whether the codec is capable of handling it. If not, degrade and fall back to the next possible one.
- else, find out the best supported [profile level](https://developer.android.com/reference/android/media/MediaCodecInfo.CodecProfileLevel) by codec, and use it. This may not be sometimes the best in terms of video size, but is the best guess we may have for a given device.


Notes:
- An interesting part found as well here [`setParameters()`](https://android.googlesource.com/platform/cts/+/jb-mr2-release/tests/tests/media/src/android/media/cts/EncodeDecodeTest.java#208
) in here checks for values that should be a multiple of 16 for height and width. In the case informed in #299 the height is 2792 which is not a multiple of 16, so this gave me a hint about this not being a supported size.

