### PR TITLE
Normalize target video resolution passed to mp4composer

### DIFF
--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
@@ -71,6 +71,11 @@ class Mp4Composer {
         return this
     }
 
+    fun size(size: Size): Mp4Composer {
+        this.outputResolution = size
+        return this
+    }
+
     fun videoBitrate(bitrate: Int): Mp4Composer {
         this.bitrate = bitrate
         return this


### PR DESCRIPTION
Closes #299 

After reading and trying several things, decided to abandon any smart moves as per the approach in #322 and only normalize the target video resolution before it's passed to mp4composer. The approach in #322 would aim at recognizing the best video capability available for a given available encoder, but as per my tests I haven't seen finding the encoder would make it a reliable bet after setting the size as per the capabilities resolved by [`CodecInfo.getCapabilitiesForType`](https://developer.android.com/reference/android/media/MediaCodecInfo#getCapabilitiesForType(java.lang.String)). On some emulators or for different video sizes the behavior would be different depending on the selected encoder. For example on the actual Pixel 3 emulator, the capabilities would show no support for 1440p (1440x2560), however setting this resolution on mp4composer would end up in a perfectly fine video. The same happened for another resolution that is surely supported by the Pixel 3 such as 1920x1080.
Hence, I think for now the best bet to match both the WYSIWYG experience (where people can leave emoji / text anywhere on the screen's working area) and the output video is to find the closer match to a "known" video format, then let the platform just return the encoder for the mimetype and do the rest as usual.

Also this effectively fixes #299 which is the only bug observed so far in this regard so, the less logic we introduce, the better.

To test:
1. open the app on the Pixel 3 API29 emu, tap on the + FAB to get to capture mod
2. record a video by tapping the capture button and holding for a few seconds
3. add some text or emoji
4. tap NEXT to save
5. observe the video gets correctly saved and the app doesn't crash


