### PR TITLE
Stories library part 5 - media picker interface changes for WP media

### DIFF
--- a/app/src/main/java/com/automattic/portkey/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/StoryComposerActivity.kt
@@ -66,4 +66,8 @@ class StoryComposerActivity : ComposeLoopFrameActivity(), SnackbarProvider, Medi
             RequestCodes.PHOTO_PICKER,
             ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
     }
+
+    override fun providerHandlesOnActivityResult(): Boolean {
+        return false
+    }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -123,6 +123,7 @@ interface SnackbarProvider {
 interface MediaPickerProvider {
     fun setupRequestCodes(requestCodes: ExternalMediaPickerRequestCodesAndExtraKeys)
     fun showProvidedMediaPicker()
+    fun providerHandlesOnActivityResult(): Boolean
 }
 
 abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTappedListener {
@@ -605,7 +606,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
         when (requestCode) {
             requestCodes.PHOTO_PICKER -> if (resultCode == Activity.RESULT_OK && data != null) {
-                if (data.hasExtra(requestCodes.EXTRA_MEDIA_URIS)) {
+                val providerHandlesMediaPickerResult = mediaPickerProvider?.providerHandlesOnActivityResult() ?: false
+                if (data.hasExtra(requestCodes.EXTRA_MEDIA_URIS) && !providerHandlesMediaPickerResult) {
                     val uriList: List<Uri> = convertStringArrayIntoUrisList(
                         data.getStringArrayExtra(requestCodes.EXTRA_MEDIA_URIS)
                     )
@@ -618,7 +620,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         }
     }
 
-    private fun convertStringArrayIntoUrisList(stringArray: Array<String>): List<Uri> {
+    protected fun convertStringArrayIntoUrisList(stringArray: Array<String>): List<Uri> {
         val uris: ArrayList<Uri> = ArrayList(stringArray.size)
         for (stringUri in stringArray) {
             uris.add(Uri.parse(stringUri))
@@ -626,19 +628,19 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         return uris
     }
 
-    private fun setDefaultSelectionAndUpdateBackgroundSurfaceUI() {
+    protected fun setDefaultSelectionAndUpdateBackgroundSurfaceUI() {
         val defaultSelectedFrameIndex = storyViewModel.getLastFrameIndexInCurrentStory()
         storyViewModel.setSelectedFrame(defaultSelectedFrameIndex)
         updateBackgroundSurfaceUIWithStoryFrame(defaultSelectedFrameIndex)
     }
 
-    private fun addFramesToStoryFromMediaUriList(uriList: List<Uri>) {
+    protected fun addFramesToStoryFromMediaUriList(uriList: List<Uri>) {
         for (mediaUri in uriList) {
             addFrameToStoryFromMediaUri(mediaUri)
         }
     }
 
-    private fun addFrameToStoryFromMediaUri(mediaUri: Uri) {
+    protected fun addFrameToStoryFromMediaUri(mediaUri: Uri) {
         storyViewModel
             .addStoryFrameItemToCurrentStory(StoryFrameItem(
                 UriBackgroundSource(contentUri = Uri.parse(mediaUri.toString())),
@@ -1268,12 +1270,12 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         }
     }
 
-    private fun showLoading() {
+    protected fun showLoading() {
         editModeHideAllUIControls(true)
         blockTouchOnPhotoEditor(BLOCK_TOUCH_MODE_FULL_SCREEN)
     }
 
-    private fun hideLoading() {
+    protected fun hideLoading() {
         editModeRestoreAllUIControls()
         releaseTouchOnPhotoEditor(BLOCK_TOUCH_MODE_FULL_SCREEN)
     }


### PR DESCRIPTION
This PR builds on top of #348 
Related WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/11953

- Changed visibility of show/hideLoading and addFrame(s)ToStoryFrom... methods
- added `providerHandlesOnActivityResult` fun to `MediaPickerProvider` interface to signal ComposeLoopFameActivity whether it should handle media fed from picker in onActivityResult itself. In WPAndroid, this is all handled by EditorMedia, which will finally call `appendMedia` on the listener, hence adding these interfaces here so these can be properly handled.

To test:
- Verify the demo app works as expected and allows you to pick media from the device