### PR TITLE
Stories library part 8 - MetaDataProvider

### DIFF
--- a/app/src/main/java/com/automattic/portkey/MainActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/MainActivity.kt
@@ -3,9 +3,12 @@ package com.automattic.portkey
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.Navigation
 import com.automattic.photoeditor.util.PermissionUtils
+import com.automattic.portkey.StoryComposerActivity.Companion.KEY_EXAMPLE_METADATA
+import com.automattic.portkey.StoryComposerActivity.Companion.KEY_STORY_INDEX
 import com.automattic.portkey.intro.IntroActivity
 import com.google.android.material.snackbar.Snackbar
 import com.wordpress.stories.compose.frame.FrameSaveNotifier
@@ -66,6 +69,17 @@ class MainActivity : AppCompatActivity(), MainFragment.OnFragmentInteractionList
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     fun onStorySaveResult(event: StorySaveResult) {
         EventBus.getDefault().removeStickyEvent(event)
+
+        // check the metadata we've put is effectively there in the StorySaveResult event
+        event.metadata?.let {
+            val payloadString = it.getString(KEY_EXAMPLE_METADATA)
+            val storyIndex = it.getInt(KEY_STORY_INDEX)
+            Toast.makeText(
+                this, "Payload is: " + payloadString + " - index: " + storyIndex,
+                Toast.LENGTH_SHORT)
+                .show()
+        }
+
         if (event.isSuccess()) {
             // TODO will remove this snackbar when integrating to WPAndroid as at this successful saving point we''l
             // want to enqueue the Story post and media to be uploaded to the user's site.

--- a/app/src/main/java/com/automattic/portkey/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/StoryComposerActivity.kt
@@ -15,8 +15,10 @@ import com.automattic.portkey.photopicker.RequestCodes
 import com.google.android.material.snackbar.Snackbar
 import com.wordpress.stories.compose.ComposeLoopFrameActivity
 import com.wordpress.stories.compose.MediaPickerProvider
+import com.wordpress.stories.compose.MetadataProvider
 import com.wordpress.stories.compose.NotificationIntentLoader
 import com.wordpress.stories.compose.SnackbarProvider
+import com.wordpress.stories.compose.story.StoryIndex
 
 fun Snackbar.config(context: Context) {
     this.view.background = context.getDrawable(R.drawable.snackbar_background)
@@ -29,12 +31,14 @@ fun Snackbar.config(context: Context) {
 class StoryComposerActivity : ComposeLoopFrameActivity(),
     SnackbarProvider,
     MediaPickerProvider,
-    NotificationIntentLoader {
+    NotificationIntentLoader,
+    MetadataProvider {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setSnackbarProvider(this)
         setMediaPickerProvider(this)
         setNotificationExtrasLoader(this)
+        setMetadataProvider(this)
     }
 
     override fun showProvidedSnackbar(message: String, actionLabel: String?, callback: () -> Unit) {
@@ -81,5 +85,18 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         return notificationIntent
+    }
+
+    override fun loadMetadataForStory(index: StoryIndex): Bundle? {
+        // this is optional, external metadata that will be returned to you after the FrameSaveService finishes
+        val bundle = Bundle()
+        bundle.putString(KEY_EXAMPLE_METADATA, "example metadata")
+        bundle.putInt(KEY_STORY_INDEX, index)
+        return bundle
+    }
+
+    companion object {
+        const val KEY_EXAMPLE_METADATA = "key_example_metadata"
+        const val KEY_STORY_INDEX = "key_story_index"
     }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -8,6 +8,7 @@ import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Binder
 import android.os.Build
+import android.os.Bundle
 import android.os.IBinder
 import android.util.Log
 import android.webkit.MimeTypeMap
@@ -35,6 +36,7 @@ class FrameSaveService : Service() {
     private lateinit var frameSaveNotifier: FrameSaveNotifier
     private val storySaveProcessors = ArrayList<StorySaveProcessor>()
     private lateinit var notificationIntent: Intent
+    private var optionalMetadata: Bundle? = null // keeps optional metadata about the Story
 
     override fun onCreate() {
         super.onCreate()
@@ -71,6 +73,14 @@ class FrameSaveService : Service() {
 
     fun getNotificationIntent(): Intent {
         return notificationIntent
+    }
+
+    fun setMetadata(bundle: Bundle?) {
+        optionalMetadata = bundle
+    }
+
+    fun getMetadata(): Bundle? {
+        return optionalMetadata
     }
 
     fun saveStoryFrames(
@@ -134,7 +144,8 @@ class FrameSaveService : Service() {
             storyIndex,
             frameIndex,
             frameSaveNotifier,
-            FrameSaveManager(photoEditor)
+            FrameSaveManager(photoEditor),
+            metadata = optionalMetadata
         )
     }
 
@@ -225,9 +236,10 @@ class FrameSaveService : Service() {
         private val storyIndex: StoryIndex,
         private val frameIndexOverride: FrameIndex = StoryRepository.DEFAULT_NONE_SELECTED,
         private val frameSaveNotifier: FrameSaveNotifier,
-        private val frameSaveManager: FrameSaveManager
+        private val frameSaveManager: FrameSaveManager,
+        private val metadata: Bundle? = null
     ) : FrameSaveProgressListener {
-        val storySaveResult = StorySaveResult()
+        val storySaveResult = StorySaveResult(metadata = metadata)
         val title =
             StoryRepository.getStoryAtIndex(storyIndex).title ?: context.getString(R.string.story_saving_untitled)
 

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
@@ -1,5 +1,6 @@
 package com.wordpress.stories.compose.frame
 
+import android.os.Bundle
 import android.os.Parcelable
 import com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason.SaveError
 import com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason.SaveSuccess
@@ -11,7 +12,8 @@ class StorySaveEvents {
     @Parcelize
     data class StorySaveResult(
         var storyIndex: StoryIndex = 0,
-        val frameSaveResult: MutableList<FrameSaveResult> = mutableListOf()
+        val frameSaveResult: MutableList<FrameSaveResult> = mutableListOf(),
+        val metadata: Bundle? = null
     ) : Parcelable {
         fun isSuccess(): Boolean {
             return frameSaveResult.all { it.resultReason == SaveSuccess }


### PR DESCRIPTION
This PR builds on top of #351

This PR adds the  `MetadataProvider` interface so payload can be injected to the service and returned when a `StorySaveResult` is ready and broadcasted through EventBus.

In general, the host app may need to set some state variable values in a Bundle that it can retrieve later when a Story is finished saving. For example in WPAndroid, it may be useful to set the currently selected `SiteModel` the Story is supposed to be uploaded to, and as such once a SaveResult is received even if context has changed (i.e. even if the user saved a Story and then switched to work on another site), so it can properly proceed and do whatever it needs to correctly interpret the results once these are received.

To test:
1. open the demo app
2. add a frame and some text / emoji
3. tap PUBLISH
4. once it's saved, we've added a new listener with payload that shows in a toast in the demo `Payload is: example metadata`

