### PR TITLE
Stories library part 8.1 - remember the composed file name for a StoryFrameItem

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
@@ -150,6 +150,7 @@ class FrameSaveManager(private val photoEditor: PhotoEditor) : CoroutineScope {
                 }
             }
         }
+        frame.composedFrameFile = frameFile
         return frameFile
     }
 

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameItem.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameItem.kt
@@ -11,7 +11,8 @@ data class StoryFrameItem(
     val source: BackgroundSource,
     val frameItemType: StoryFrameItemType = IMAGE,
     var addedViews: AddedViewList = AddedViewList(),
-    var saveResultReason: SaveResultReason = SaveSuccess
+    var saveResultReason: SaveResultReason = SaveSuccess,
+    var composedFrameFile: File? = null
 ) {
     sealed class BackgroundSource {
         data class UriBackgroundSource(var contentUri: Uri? = null) : BackgroundSource()


### PR DESCRIPTION
This PR builds on top of #353 

This just adds a new field so we can remember the composed resulting filename for each saved `StoryFrameItem`.

This way, once everything is saved, we can obtain the StoryIndex from at StorySaveResult, go and look into the StoryRepository which file it was for each of the StoryFrameItems for this Story. (to be used when uploading in WPAndroid)

To test: N/A.