### PR TITLE
gitignore for stories module

### DIFF
--- a/stories/.gitignore
+++ b/stories/.gitignore
@@ -1,1 +1,24 @@
-/build
+
+# generated files
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+tools/deploy-mvn-artifact.conf
+
+# Intellij project files
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Gradle
+.gradle/
+gradle.properties
+
+# Idea
+.idea/workspace.xml
+*.iml
+
+# OS X
+.DS_Store


### PR DESCRIPTION

## Solution
Added `gitignore` to the repo so that unnecessary Android Studio related files don't get added to the unstaged changes. 

## Testing
1. Notice that when on a branch without this there are several `.idea` related files that are unstaged. 
2. Switch to this branch and notice that the working changes don't contain these files.

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 