### PR TITLE
Stories library part 11  - add isRetry and elapsedTime to SaveResult for tracking purposes

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveTimeTracker.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveTimeTracker.kt
@@ -1,0 +1,18 @@
+package com.wordpress.stories.compose.frame
+
+class FrameSaveTimeTracker {
+    private var startTime: Long = 0
+    private var endTime: Long = 0
+
+    fun start() {
+        startTime = System.currentTimeMillis()
+    }
+
+    fun end() {
+        endTime = System.currentTimeMillis()
+    }
+
+    fun elapsedTime(): Long {
+        return endTime - startTime
+    }
+}

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
@@ -14,6 +14,7 @@ class StorySaveEvents {
         var storyIndex: StoryIndex = 0,
         val frameSaveResult: MutableList<FrameSaveResult> = mutableListOf(),
         val isRetry: Boolean = false,
+        var elapsedTime: Long = 0,
         val metadata: Bundle? = null
     ) : Parcelable {
         fun isSuccess(): Boolean {


### PR DESCRIPTION
This PR builds on top of #362 

Related WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/12074

Title hast it - this PR adds a `isRetry` boolean flag so SaveResult can keep information about whether this result comes from a retry or not, for tracking purposes only.
Along the same lines, it adds a `FrameSaveTimeTracker` utility class to keep track of the time it takes to save a Story, and packages that into the `StorySaveResult` so it can be tracked.

To test:
1. inject an artificial error, for example add a `throw Exception("test")` statement when saving an image frame in PhotoEditor's `saveImageFromPhotoEditorViewAsLoopFrameFile` method
2. launch the demo app and create a frame with an image and some text
3. tap PUBLISH
4. debug and observe the `isRetry` flag is set to `false`
5. when the error notification appear, tap on it
6. on the error handling screen, tap on PUBLISH again
7. observe the `isRetry` flag is now `true` 
8. also observe StorySaveResult is set the elapsedTime to the amount of time taken by the Save process, in millis.

