### PR TITLE
WP Stories: allow choosing initial screen mode from intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # portkey-android
 Portkey concept app
 
+WordPress stories library
+
 # Code style
 
 Our code style guidelines are based on the [Android Code Style Guidelines for Contributors](https://source.android.com/source/code-style.html). We only changed a few rules:
@@ -51,3 +53,15 @@ Implement these:
 - MediaPickerProvider
 - call `setMediaPickerProvider()` as in the example Portkey demo app.
 - remember to override `setupRequestCodes()` and set the right request codes as per the host app so it works seamlessly and media can be fed into the Composer by the externally provided MediaPicker.
+
+## Build Instructions ##
+
+1. Make sure you've installed [Android Studio](https://developer.android.com/studio/index.html).
+1. `git clone git@github.com:Automattic/portkey-android.git` in the folder of your preference.
+1. `cd portkey-android` to enter the working directory.
+1. `cp gradle.properties-example gradle.properties` to set up the sample app properties file. Specifically, you can use `portkey.use.cameraX = true` to use the CameraX underlying implementation, or `false` to use the Camera2 implementation
+1. In Android Studio, open the project from the local repository. This will auto-generate `local.properties` with the SDK location.
+1. Go to Tools → AVD Manager and create an emulated device.
+1. Run.
+
+

--- a/app/src/main/java/com/automattic/portkey/MainActivity.kt
+++ b/app/src/main/java/com/automattic/portkey/MainActivity.kt
@@ -109,6 +109,9 @@ class MainActivity : AppCompatActivity(), MainFragment.OnFragmentInteractionList
                 // here go to the StoryComposerActivity, passing the SaveResult
                 val intent = Intent(this@MainActivity, StoryComposerActivity::class.java)
                 intent.putExtra(KEY_STORY_SAVE_RESULT, event)
+                // TODO add SITE param later when integrating with WPAndroid
+                // notificationIntent.putExtra(WordPress.SITE, site)
+
                 // we need to have a way to cancel the related error notification when the user comes
                 // from tapping on MANAGE on the snackbar (otherwise they'll be able to discard the
                 // errored story but the error notification will remain existing in the system dashboard)

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ ext {
     coroutinesVersion = '1.3.3'
     constraintLayoutVersion = '1.1.3'
     appCompatVersion = '1.0.2'
-    coreVersion = '1.0.2'
+    coreVersion = '1.2.0'
     navComponentVersion = '2.0.0'
 }
 

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
@@ -78,6 +78,11 @@ class Mp4Composer {
         return this
     }
 
+    fun size(size: Size): Mp4Composer {
+        this.outputResolution = size
+        return this
+    }
+
     fun videoBitrate(bitrate: Int): Mp4Composer {
         this.bitrate = bitrate
         return this

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -10,6 +10,7 @@ import android.graphics.Typeface
 import android.net.Uri
 import android.text.TextUtils
 import android.util.Log
+import android.util.Size
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -760,7 +761,9 @@ class PhotoEditor private constructor(builder: Builder) :
             // IMPORTANT: as we aim at a WYSIWYG UX, we need to produce a video of size equal to that of the phone
             // screen, given the user may be seeing a letterbox landscape video and placing emoji / text around
             // the black parts of the screen.
-            .size(originalCanvasWidth, originalCanvasHeight)
+            // .size(originalCanvasWidth, originalCanvasHeight)
+            // normalize output video size if actual screen size does not match a "normal" video size
+            .size(normalizeTargetVideoSize(originalCanvasWidth, originalCanvasHeight))
             .fillMode(FillMode.PRESERVE_ASPECT_FIT)
             .filter(if (customAddedViews.isNotEmpty()) GlFilterGroup(filterCollection) else null)
             .mute(muteAudio)
@@ -786,6 +789,54 @@ class PhotoEditor private constructor(builder: Builder) :
                 }
             })
             .start()
+    }
+
+    private fun normalizeTargetVideoSize(
+        requestedWidth: Int,
+        requestedHeight: Int
+    ): Size {
+        var adjustedSize = Size(requestedWidth, requestedHeight)
+        // As per CDD, all android devices running API level 21 (our minSdk) with H.264 codec must support 720 x 480 px.
+        // see https://source.android.com/compatibility/5.0/android-5.0-cdd#5_2_video_encoding
+        // MUST
+        // - 320 x 240 px
+        // - 720 x 480 px
+        // SHOULD (when hardware available)
+        // - 1280 x 720 px
+        // - 1920 x 1080 px
+
+        // the other formats (2160p, 1440p, 1080p etc) are "popular" ones found on many devices
+        // note we reverse the width/height given we support portrait mode only.
+        when {
+            // 2160p = 3840x2160
+            (requestedWidth % 2160 == 0) -> {
+                adjustedSize = Size(2160, 3840)
+            }
+
+            // 1440p = 2560x1440
+            (requestedWidth % 1440 == 0) -> {
+                adjustedSize = Size(1440, 2560)
+            }
+
+            // 1080p = 1920x1080
+            (requestedWidth % 1080 == 0) -> {
+                adjustedSize = Size(1080, 1920)
+            }
+
+            // 720p = 1280x720
+            (requestedWidth % 720 == 0) -> {
+                adjustedSize = Size(720, 1280)
+            }
+
+            (requestedWidth % 480 == 0) -> {
+                adjustedSize = Size(480, 720)
+            }
+
+            (requestedWidth % 240 == 0) -> {
+                adjustedSize = Size(240, 320)
+            }
+        }
+        return adjustedSize
     }
 
     /**

--- a/stories/.gitignore
+++ b/stories/.gitignore
@@ -1,1 +1,24 @@
-/build
+
+# generated files
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+tools/deploy-mvn-artifact.conf
+
+# Intellij project files
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Gradle
+.gradle/
+gradle.properties
+
+# Idea
+.idea/workspace.xml
+*.iml
+
+# OS X
+.DS_Store

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -474,15 +474,15 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         })
 
         storyViewModel.onSelectedFrameIndex.observe(this, Observer { selectedFrameIndexChange ->
-            updateContentUiStateSelection(selectedFrameIndexChange.first, selectedFrameIndexChange.second)
+            updateSelectedFrameControls(selectedFrameIndexChange.first, selectedFrameIndexChange.second)
         })
 
         storyViewModel.erroredItemUiState.observe(this, Observer { uiStateFrame ->
             updateContentUiStateFrame(uiStateFrame)
         })
 
-        storyViewModel.itemAtIndexChangedMuteAudioUiState.observe(this, Observer { uiStateFrameIndex ->
-            updateUiStateForAudioMuted(uiStateFrameIndex)
+        storyViewModel.muteFrameAudioUiState.observe(this, Observer { frameIndex ->
+            updateUiStateForAudioMuted(frameIndex)
         })
     }
 
@@ -493,7 +493,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     @Suppress("unused")
-    private fun updateContentUiStateSelection(oldSelection: Int, newSelection: Int) {
+    private fun updateSelectedFrameControls(oldSelection: Int, newSelection: Int) {
         if (storyViewModel.getCurrentStorySize() > newSelection) {
             val selectedFrame = storyViewModel.getCurrentStoryFrameAt(newSelection)
             updateSoundControl()

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
@@ -24,8 +24,8 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
     private val _itemAtIndexChangedUiState = SingleLiveEvent<Int>()
     val itemAtIndexChangedUiState = _itemAtIndexChangedUiState
 
-    private val _itemAtIndexChangedMuteAudioUiState = SingleLiveEvent<Int>()
-    val itemAtIndexChangedMuteAudioUiState = _itemAtIndexChangedMuteAudioUiState
+    private val _muteFrameAudioUiState = SingleLiveEvent<Int>()
+    val muteFrameAudioUiState = _muteFrameAudioUiState
 
     private val _onSelectedFrameIndex: MutableLiveData<Pair<Int, Int>> by lazy {
         MutableLiveData<Pair<Int, Int>>().also {
@@ -247,7 +247,7 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
                 it.muteAudio = muteAudio
             }
         }
-        _itemAtIndexChangedMuteAudioUiState.value = selectedIndex
+        _muteFrameAudioUiState.value = selectedIndex
     }
 
     private fun updateUiStateForItemSwap(oldIndex: Int, newIndex: Int) {


### PR DESCRIPTION
THIS PR BUILDS ON TOP OF #378  (stacking PRs again for quicker alpha)

Closes #368 

Changes in this PR:
- allow to create a Story from passing MEDIA_URIs in Intent
- `onLoadFromIntent`. We now rely more on this method to check what the intent request was about, and act accordingly, instead of assuming too much (for example we had the camera preview mode as a default when we landed on a ComposeLoopFrameActivity). We'll load the intent and check the requests there, giving more control / command over the behavior of CompoeseLoopFrameActivity to the consumer of the class.
- for this to be possible, this PR introduces the `BackgroundSurfaceManagerReadyListener` interface, which will get called exactly after the TextureView surface becomes ready / available, and not before. We were using an artificial wait of 500ms (that could be a problem on lower end devices). Now this is deterministic, and most of the time is quicker and avoids some of the blank screen issues spotted every now and then. With the introduction of this interface we also gain the ability to process the intent only when we know we can go in any direction without a problem (want to add a video frame?  no problem it'll get added and start playing. Same with static background or when launching the camera live preview).
- fixed a problem with CameraX where we need to remove/re-add the TextureView to the view hierarchy when deactivating it so it's ready for next use. For the first time it's used, given we no longer have the camera live preview as the default first state to start with, we don't need to do this remove/re-add. So we prevent a deactivation from happening by checking whether the surface is `isActive()` before attempting to deactivate it.

#### known issues: 
- not an issue, but current behavior to be aware of: if  you have several frames but didn't add text or emoji, tapping on the X will fall back to the camera capture screen. let's check perhaps we want to fall back on the WPAndroid main screen? let me know 

To test:
- use the WPANdorid PR https://github.com/wordpress-mobile/WordPress-Android/pull/12264
- follow instructions there

