### PR TITLE
Add Java source arguments to stories project

### DIFF
--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -25,6 +25,10 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Adds Java source/target compatibility arguments to the `stories` subproject. This fixes an issue I was having where Android sources weren't resolving from within that project, and an "Unsupported Modules Detected" warning was shown on build. Might be specific to my setup but the declaration is present in our other libraries so, seems reasonable to add.