### PR TITLE
Remove upload icon in camera capture mode

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -59,7 +59,6 @@ import com.automattic.photoeditor.views.ViewType.TEXT
 import com.automattic.photoeditor.views.added.AddedViewList
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
-import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.wordpress.stories.BuildConfig
 import com.wordpress.stories.R
 import com.wordpress.stories.compose.ComposeLoopFrameActivity.ExternalMediaPickerRequestCodesAndExtraKeys
@@ -862,10 +861,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                     })
             )
 
-        container_gallery_upload.setOnClickListener {
-            showMediaPicker()
-        }
-
         camera_flip_group.setOnClickListener {
             cameraSelection = backgroundSurfaceManager.flipCamera()
             saveCameraSelectionPref()
@@ -1224,10 +1219,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                 runOnUiThread {
                     Glide.with(this@ComposeLoopFrameActivity)
                         .load(file)
-                        .transform(CenterCrop(), RoundedCorners(16))
-                        .into(gallery_upload_img)
-                    Glide.with(this@ComposeLoopFrameActivity)
-                        .load(file)
                         .transform(CenterCrop())
                         .into(photoEditorView.source)
                     storyViewModel.apply {
@@ -1468,8 +1459,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         label_flash.visibility = View.INVISIBLE
 
         camera_flip_group.visibility = View.INVISIBLE
-
-        container_gallery_upload.visibility = View.INVISIBLE
     }
 
     private fun showVideoUIControls() {
@@ -1477,8 +1466,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         label_flash.visibility = View.VISIBLE
 
         camera_flip_group.visibility = View.VISIBLE
-
-        container_gallery_upload.visibility = View.VISIBLE
     }
 
     private fun showEditModeUIControls() {

--- a/stories/src/main/res/layout/content_composer.xml
+++ b/stories/src/main/res/layout/content_composer.xml
@@ -59,54 +59,6 @@
         android:contentDescription="@string/capture_button_alt" />
 
 
-    <LinearLayout
-        android:id="@+id/container_gallery_upload"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:orientation="vertical"
-        android:animateLayoutChanges="true"
-        app:layout_constraintBottom_toBottomOf="@+id/camera_capture_button"
-        app:layout_constraintEnd_toStartOf="@+id/camera_capture_button"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/camera_capture_button">
-
-        <RelativeLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal">
-            <!-- this will hold the thumbnail img for the picture taken  -->
-            <ImageView
-                android:id="@+id/gallery_upload_img"
-                android:layout_width="@dimen/normal_button_medium_round_corner"
-                android:layout_height="@dimen/normal_button_medium_round_corner"
-                android:background="@drawable/ic_gallery_upload"
-                android:contentDescription="@string/capture_button_alt"
-                android:scaleType="centerCrop"
-                android:layout_centerInParent="true"/>
-
-            <!-- this is just the border  -->
-            <ImageView
-                android:id="@+id/gallery_upload"
-                android:layout_width="@dimen/normal_button_medium"
-                android:layout_height="@dimen/normal_button_medium"
-                android:background="@drawable/ic_gallery_upload"
-                android:contentDescription="@string/capture_button_alt"
-                android:scaleType="fitCenter"
-                android:layout_centerInParent="true"/>
-        </RelativeLayout>
-
-        <TextView
-            android:id="@+id/label_upload"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:text="@string/label_control_upload"
-            android:textColor="@color/white"
-            android:textSize="@dimen/normal_button_font_size"
-            android:layout_gravity="center_horizontal"/>
-    </LinearLayout>
-
     <!-- top gradient  -->
     <View
         android:id="@+id/gradient_top"


### PR DESCRIPTION
Fixes #442 

Decided to remove the gallery/upload icon it entirely to keep code clean, we can bring it back if needed later.

<img width="394" alt="Screen Shot 2020-07-19 at 21 11 10" src="https://user-images.githubusercontent.com/6597771/87888644-64520c00-ca04-11ea-84e8-2b20acf70e2c.png">
