### PR TITLE
Fix MVVM's onClear -> StoryRepository.clearAll

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
@@ -154,9 +154,4 @@ object StoryRepository {
             (model.source as FileBackgroundSource).file.toString()
         }
     }
-
-    fun clearAll() {
-        currentStoryIndex = DEFAULT_NONE_SELECTED
-        stories.clear()
-    }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
@@ -222,11 +222,6 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
         updateUiState(createUiStateFromModelState(repository.getImmutableCurrentStoryFrames()))
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        repository.clearAll()
-    }
-
     private fun updateUiState(uiState: StoryFrameListUiState) {
         _uiState.value = uiState
     }


### PR DESCRIPTION
A bug was introduced in #435, that cleared the  StoryRepository when coming back from `onCreate` with a non-null `savedInstanceState` bundle.

The StoryRepository needs to hold the information for us for longer given we use it to store / update things while the `FrameSaveService` is running, and for populating parts of the `SaveResult` event.

The cons of reverting are minor and transient: when the Activity was killed and brought back to the foreground, we'll be getting a duplicate Story in the StoryRepository, but it's not really important since the indexes would correctly point to the newly, recreated from savedInstanceState one.

To test:
1. Create a story with a video so it takes longer to produce. Ideally introduce an error also, so we test the error flow.
2. tap NEXT
3. observe the app doesn't crash
