### PR TITLE
Set layerType LAYER_TYPE_SOFTWARE on added Views while saving

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
@@ -3,6 +3,7 @@ package com.wordpress.stories.compose.frame
 import android.content.Context
 import android.graphics.Color
 import android.net.Uri
+import android.view.View
 import android.view.ViewGroup.LayoutParams
 import android.widget.RelativeLayout
 import com.automattic.photoeditor.PhotoEditor
@@ -279,6 +280,10 @@ class FrameSaveManager(private val photoEditor: PhotoEditor) : CoroutineScope {
             for (oneView in frame.addedViews) {
                 oneView.view?.let {
                     removeViewFromParent(it)
+                    // this is needed, otherwise some vector graphics such as emoji in text will not render
+                    // correctly when a hardware display is not in place (such is the case of FrameSaveManager,
+                    // as we're laying out the views on an off-screen view).
+                    it.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
                     ghostPhotoEditorView.addView(it, getViewLayoutParams())
                 }
             }


### PR DESCRIPTION
Fix #446 

As the issue describes, adding text with emoji in it would make the saved slide miss such a view.
We need to set to use `setLayerType(View.LAYER_TYPE_SOFTWARE, null)` on the added View, otherwise some vector graphics such as emoji in text will not render correctly when a hardware display is not in place (such is the case of `FrameSaveManager`, as we're laying out the views on an off-screen view).


To test
(on a Pixel 2 this issue was observed 100% of the times)
1. create a story with 1 slide
2. add 1 emoji, move it and resize / rotate
3. add one text, but instead of entering text, look for an emoji and add it
4. resize it to the biggest possible
5. tap NEXT/PUBLISH
6. look in the phone's gallery and observe the produced (saved) slide contains both added views.

only 1 reviewer needed, pinging Alex as we talked about this issue recently.
