### PR TITLE
Only try adding emojiPickerFragment when it's not added and not visible

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -38,6 +38,7 @@ import androidx.core.content.FileProvider
 import androidx.core.view.GestureDetectorCompat
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.automattic.photoeditor.OnPhotoEditorListener
@@ -915,7 +916,11 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         }
 
         stickers_add_button.setOnClickListener {
-            emojiPickerFragment.show(supportFragmentManager, emojiPickerFragment.tag)
+            // avoid multiple clicks when the one click is already being processed, fixes
+            // https://github.com/Automattic/portkey-android/issues/455
+            if (!emojiPickerFragment.isAdded && !emojiPickerFragment.isVisible) {
+                emojiPickerFragment.show(supportFragmentManager, emojiPickerFragment.tag)
+            }
         }
 
         next_button.setOnClickListener {


### PR DESCRIPTION
Fixes #455 

To test:

1. open the demo app
2. capture an image
3. tap on the stickers icon like crazy until it appears (it's easier to reproduce on lower end handsets, for example the Samsung J2 takes a noticeable length of time to show the bottom sheet emoji picker)
4. observe no crash

See video of the Samsung J2 here https://cloudup.com/cfittOshxwa

