### PR TITLE
Only proceed with onDone() if Activity is not in DESTROYED state

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -38,7 +38,6 @@ import androidx.core.content.FileProvider
 import androidx.core.view.GestureDetectorCompat
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle.State.DESTROYED
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider


### PR DESCRIPTION
Fixes #453 

When don't keep activities is ON, the `onDismiss` override gets called only through `Activity.onDestroy() -> Fragment.onDestroy()` as can be seen in the stacktrace. Hence, checking the current lifecycle state to only proceed if it's anything but `DESTROYED`.

**Known issue**: if you enter some text and come back to portkey, the Dialog's state will be preserved, but when you tap DONE the text you entered will go nowhere because:
1. we're not keeping track of which serialized `AddedView` was being edited at the time the Activity was destroyed (hence, we can't link the entered text data to a specific AddedView). 
2. the new Activity is not setting the new listener on the re-created fragment either.

We'd need to do both these things in order to get things to work 100% under these circumstances, but I think it's a minor edge case we can live with (as long as it's not crashing).

To test:
1. enable 'Don't keep activities'
2. Start a new story, and tap the A button to add text
3. Switch to another app and return
4. Notice no more crashes

