### PR TITLE
Assign gesture listener on views created from deserialization

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -254,18 +254,7 @@ class PhotoEditor private constructor(builder: Builder) :
             }
 
             val multiTouchListenerInstance = getNewMultitouchListener() // newMultiTouchListener
-            multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {
-                override fun onClick() {
-                    val textInput = textInputTv.text.toString()
-                    val currentTextColor = textInputTv.currentTextColor
-                    mOnPhotoEditorListener?.onEditTextChangeListener(this@apply, textInput, currentTextColor, false)
-                }
-
-                override fun onLongClick() {
-                    // no op
-                }
-            })
-
+            setGestureControlOnMultiTouchListener(this, ViewType.TEXT, multiTouchListenerInstance)
             setOnTouchListener(multiTouchListenerInstance)
             addViewToParent(this, ViewType.TEXT)
 
@@ -365,14 +354,7 @@ class PhotoEditor private constructor(builder: Builder) :
             }
 
             val multiTouchListenerInstance = getNewMultitouchListener(this) // newMultiTouchListener
-            multiTouchListenerInstance.setOnGestureControl(object : MultiTouchListener.OnGestureControl {
-                override fun onClick() {
-                }
-
-                override fun onLongClick() {
-                    // no op
-                }
-            })
+            setGestureControlOnMultiTouchListener(this, ViewType.EMOJI, multiTouchListenerInstance)
             touchableArea.setOnTouchListener(multiTouchListenerInstance)
             // setOnTouchListener(multiTouchListenerInstance)
             addViewToParent(this, ViewType.EMOJI)


### PR DESCRIPTION
Fix #460 

This PR refactors the places where `MultiTouchListener.OnGestureControl` was being set, into one new method called `setGestureControlOnMultiTouchListener()`  so it can be used both on normal (new) views being added and views being re-built from a serialized object representation.

To test (use `Don't keep activities`= ON) 
1. capture an image
2. tap A to add text
3. add text, then tap DONE
4. send the app to the background
5. bring it back to the foreground
6. tap on the text you added in step 3
7. observe you can edit it (the TextEditorDialog shows up with the content pre-populated, you can modify it and tap DONE and it will be reflected on the view).
8. also check you can still move the view around.


