### PR TITLE
Remove kotlin.code.style from example properties

### DIFF
--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,3 +1,5 @@
+# Properties file for Loop stories demo app: https://github.com/Automattic/stories-android/
+
 # Project-wide Gradle settings.
 
 # IDE (e.g. Android Studio) users:
@@ -18,8 +20,6 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-# Kotlin code style for this project: "official" or "obsolete":
-kotlin.code.style=official
 
 # Stories properties
 


### PR DESCRIPTION
We're using our own synced rules, and having this in the real gradle.properties keeps changing the rules and generating changes to tracked .idea files.

I removed it from my own gradle.properties a while ago but thought we should sync it centrally.

Relies on #470 since that one has changes to `gradle.properties-example` as well.