### PR TITLE
Add Flipper support for Loop app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,10 @@ android {
     useLibrary 'android.test.runner'
 }
 
+ext {
+    flipperVersion = '0.50.0'
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
@@ -69,9 +73,9 @@ dependencies {
     implementation project(path: ':stories')
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
-    debugImplementation 'com.facebook.flipper:flipper:0.50.0'
+    debugImplementation "com.facebook.flipper:flipper:$flipperVersion"
     debugImplementation 'com.facebook.soloader:soloader:0.9.0'
-    debugImplementation 'com.facebook.flipper:flipper-network-plugin:0.50.0'
+    debugImplementation "com.facebook.flipper:flipper-network-plugin:$flipperVersion"
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,10 @@ dependencies {
     implementation project(path: ':stories')
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
+    debugImplementation 'com.facebook.flipper:flipper:0.50.0'
+    debugImplementation 'com.facebook.soloader:soloader:0.9.0'
+    debugImplementation 'com.facebook.flipper:flipper-network-plugin:0.50.0'
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.automattic.loop"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:name=".LoopDebug"
+        tools:replace="android:name" />
+
+</manifest>

--- a/app/src/debug/java/com/automattic/loop/LoopDebug.kt
+++ b/app/src/debug/java/com/automattic/loop/LoopDebug.kt
@@ -1,7 +1,20 @@
 package com.automattic.loop
 
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.android.utils.FlipperUtils
+import com.facebook.flipper.plugins.inspector.DescriptorMapping
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
+import com.facebook.soloader.SoLoader
+
 class LoopDebug : Loop() {
     override fun onCreate() {
         super.onCreate()
+
+        if (FlipperUtils.shouldEnableFlipper(this)) {
+            SoLoader.init(this, false)
+            AndroidFlipperClient.getInstance(this).apply {
+                addPlugin(InspectorFlipperPlugin(applicationContext, DescriptorMapping.withDefaults()))
+            }.start()
+        }
     }
 }

--- a/app/src/debug/java/com/automattic/loop/LoopDebug.kt
+++ b/app/src/debug/java/com/automattic/loop/LoopDebug.kt
@@ -1,0 +1,7 @@
+package com.automattic.loop
+
+class LoopDebug : Loop() {
+    override fun onCreate() {
+        super.onCreate()
+    }
+}

--- a/app/src/main/java/com/automattic/loop/Loop.kt
+++ b/app/src/main/java/com/automattic/loop/Loop.kt
@@ -15,7 +15,7 @@ import com.automattic.loop.util.CrashLoggingUtils
 import com.wordpress.stories.compose.NotificationTrackerProvider
 import com.wordpress.stories.compose.frame.StoryNotificationType
 
-class Loop : Application(), NotificationTrackerProvider {
+open class Loop : Application(), NotificationTrackerProvider {
     private var statusBarHeight: Int = 0
 
     override fun onCreate() {


### PR DESCRIPTION
**(Stacked on top of #470 to prevent a conflict since I renamed the app in that PR.)**

Adds support for Flipper, a runtime debugging tool, to the example app in debug.

(You've probably used Stetho in FluxC or WPAndroid - Flipper is a replacement for Stetho, and comes with a Mac binary as a debugging tool. There's [an open PR in FluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1602) introducing Flipper there.)

I found it useful for being able to inspect layouts in realtime:

<img width="1512" alt="Screen Shot 2020-07-29 at 2 29 57 PM" src="https://user-images.githubusercontent.com/9613966/88760451-03ff5f00-d1a8-11ea-93c0-3b5a854351ac.png">

There are other features like network interception and storage inspection but those aren't useful for this project, so I just enabled the layout inspector.

To test:

1. Install the desktop app: https://www.facebook.com/fbflipper/public/mac and run it.
2. Run the Loop app.
3. Make sure the Flipper app connects to the device/emulator.
4. Enable the layout inspector in the desktop app.
5. Make sure you can inspect the layout.

More about Flipper here: https://fbflipper.com/