### PR TITLE
Create Ghost PhotoEditorView in Main looper

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
@@ -298,12 +298,15 @@ class FrameSaveManager(private val photoEditor: PhotoEditor) : CoroutineScope {
         return params
     }
 
-    private fun createGhostPhotoEditor(context: Context, originalPhotoEditorView: PhotoEditorView): PhotoEditorView {
-        val ghostPhotoView = PhotoEditorView(context)
-        cloneViewSpecs(originalPhotoEditorView, ghostPhotoView)
-        ghostPhotoView.setBackgroundColor(Color.BLACK)
-        return ghostPhotoView
-    }
+    private suspend fun createGhostPhotoEditor(
+        context: Context,
+        originalPhotoEditorView: PhotoEditorView
+    ) = withContext(Dispatchers.Main) {
+            val ghostPhotoView = PhotoEditorView(context)
+            cloneViewSpecs(originalPhotoEditorView, ghostPhotoView)
+            ghostPhotoView.setBackgroundColor(Color.BLACK)
+            return@withContext ghostPhotoView
+        }
 
     interface FrameSaveProgressListener {
         // only one Story gets saved at a time, frameIndex is the frame's position within the Story array


### PR DESCRIPTION
Fix #473 

This PR encapsulates the code for method `createGhostPhotoEditor()` in Main UI dispatcher given Views creation are not allowed outside the Main Looper.

To test:
Use an emulator on API levels < 26 as it happens there 100% of the time
1. launch the demo app
2. capture an image
3. add text or emoji
4. tap NEXT
5. observe no errors are tracked (in particular, no longer the error reported in #473)
6. go to the Gallery app on the device to find your composed image has been saved.

Also perform smoke tests on API levels > 26 to make sure everything still works.

