### PR TITLE
Stories projects interoperability: strip Android specifics

### DIFF
--- a/stories-interop-example.json
+++ b/stories-interop-example.json
@@ -1,4 +1,15 @@
 {
+  "metadata": {
+    "revision": "1.0",
+    "device": {
+      "screen": {
+        "width": 1080,
+        "height": 1280
+      },
+      "platform": "android|ios",
+      "model": "iphone10"
+    }
+  },
   "frames": [
     {
       "source": {

--- a/stories-interop-example.json
+++ b/stories-interop-example.json
@@ -18,9 +18,9 @@
             "scale": 1,
             "addedViewTextInfo": {
               "text": "this is some text",
-              "fontSizePx": 140,
-              "textColor": -1,
-              "textAlignment": 2
+              "fontSize": 14,
+              "textColor": "#00000000",
+              "textAlignment": "left|center|right"
             }
           },
           "uri": null
@@ -46,9 +46,9 @@
             "scale": 1,
             "addedViewTextInfo": {
               "text": "this is some text, on a video background",
-              "fontSizePx": 140,
-              "textColor": -1,
-              "textAlignment": 4
+              "fontSize": 14,
+              "textColor": "#ffffffff",
+              "textAlignment": "left|center|right"
             }
           },
           "uri": null
@@ -62,9 +62,9 @@
             "scale": 1,
             "addedViewTextInfo": {
               "text": "😁",
-              "fontSizePx": 284,
-              "textColor": -16777216,
-              "textAlignment": 4
+              "fontSize": 28,
+              "textColor": "#ffffffff",
+              "textAlignment": "left|center|right"
             }
           },
           "uri": null
@@ -89,9 +89,9 @@
             "scale": 1,
             "addedViewTextInfo": {
               "text": "one text view",
-              "fontSizePx": 140,
-              "textColor": -1,
-              "textAlignment": 2
+              "fontSize": 14,
+              "textColor": "#ffffffff",
+              "textAlignment": "center"
             }
           },
           "uri": null
@@ -105,9 +105,9 @@
             "scale": 1,
             "addedViewTextInfo": {
               "text": "another text view",
-              "fontSizePx": 140,
-              "textColor": -1,
-              "textAlignment": 2
+              "fontSize": 14,
+              "textColor": "#ffffffff",
+              "textAlignment": "center"
             }
           },
           "uri": null
@@ -121,9 +121,9 @@
             "scale": 1,
             "addedViewTextInfo": {
               "text": "third text view",
-              "fontSizePx": 140,
-              "textColor": -1,
-              "textAlignment": 2
+              "fontSize": 14,
+              "textColor": "#ffffffff",
+              "textAlignment": "center"
             }
           },
           "uri": null
@@ -137,9 +137,9 @@
             "scale": 1,
             "addedViewTextInfo": {
               "text": "😬",
-              "fontSizePx": 284,
-              "textColor": -16777216,
-              "textAlignment": 4
+              "fontSize": 28,
+              "textColor": "#ff55ff",
+              "textAlignment": "right"
             }
           },
           "uri": null

--- a/stories-interop-example.json
+++ b/stories-interop-example.json
@@ -25,10 +25,7 @@
           },
           "uri": null
         }
-      ],
-      "saveResultReason": {
-        "type": "com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason.SaveSuccess"
-      }
+      ]
     },
     {
       "source": {
@@ -72,10 +69,7 @@
           },
           "uri": null
         }
-      ],
-      "saveResultReason": {
-        "type": "com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason.SaveSuccess"
-      }
+      ]
     },
     {
       "source": {
@@ -150,10 +144,7 @@
           },
           "uri": null
         }
-      ],
-      "saveResultReason": {
-        "type": "com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason.SaveSuccess"
-      }
+      ]
     }
   ],
   "title": null


### PR DESCRIPTION
See #477 first

### Discussion

Here I'm proposing some of the changes to the current serialization format, to get to a format that works for both Android and iOS.

- 28b78d27831981cc1e2df2cc539d871f6455f59a removed SaveResultReason which was a very local state representation
- 7188bcdd2c2532a09e6956464bc5960599f438d6 normalized `fontSize`, `textColor`, `textAlignment`
- 186679d54481c579e56fb48418cf2b5f5621fedb added `metadata` object which tells more about the context in which this Story has been created:

```
  "metadata": {
    "revision": "1.0",
    "device": {
      "screen": {
        "width": 1080,
        "height": 1280
      },
      "platform": "android|ios",
      "model": "iphone10"
    }
  },
```


- the `revision` is the interop JSON definition revision number to correctly attempt deserialization.
- the `device` object for now contains a screen width/height measures as informed by the device, given all other positioning measures will be relative to this canvas size.
- `platform` and `model` are self-explanative. We can add `brand` or `vendor` too which makes sense for Android.

Adding more comments on the code itself down here in the PR 👍 
