### PR TITLE
Normalize exported images to 9:16 - cropping resulting bitmap

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -752,14 +752,18 @@ class PhotoEditor private constructor(builder: Builder) :
         fun onProgress(progress: Double)
     }
 
-    fun saveImageFromPhotoEditorViewAsLoopFrameFile(sequenceId: Int, photoEditorView: PhotoEditorView): File {
+    fun saveImageFromPhotoEditorViewAsLoopFrameFile(
+        sequenceId: Int,
+        photoEditorView: PhotoEditorView,
+        cropSize: Size? = null
+    ): File {
         val localFile = FileUtils.getLoopFrameFile(context, false, sequenceId.toString())
         localFile.createNewFile()
         val saveSettings = SaveSettings.Builder()
             .setClearViewsEnabled(true)
             .setTransparencyEnabled(false)
             .build()
-        FileUtils.saveViewToFile(localFile.absolutePath, saveSettings, photoEditorView)
+        FileUtils.saveViewToFile(localFile.absolutePath, saveSettings, photoEditorView, cropSize)
         return localFile
     }
 

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/BitmapUtil.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/BitmapUtil.kt
@@ -120,4 +120,15 @@ internal object BitmapUtil {
         v.draw(c)
         return bitmap
     }
+
+    fun createCroppedBitmapFromView(v: View, cropX: Int, cropY: Int, cropWidth: Int, cropHeight: Int): Bitmap {
+        val originalBitmap = createBitmapFromView(v)
+        return Bitmap.createBitmap(
+                originalBitmap,
+                cropX,
+                cropY,
+                cropWidth,
+                cropHeight
+        )
+    }
 }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/FileUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/FileUtils.kt
@@ -2,6 +2,7 @@ package com.automattic.photoeditor.util
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.util.Size
 import android.view.View
 import com.automattic.photoeditor.R
 import com.automattic.photoeditor.SaveSettings
@@ -50,14 +51,21 @@ class FileUtils {
         fun saveViewToFile(
             imagePath: String,
             saveSettings: SaveSettings,
-            view: View
+            view: View,
+            cropSize: Size? = null // we center-crop on the X axis, but we crop the bottom on the Y axis
         ) {
             val file = File(imagePath)
             val out = FileOutputStream(file, false)
             val wholeBitmap = if (saveSettings.isTransparencyEnabled)
                 BitmapUtil.removeTransparency(BitmapUtil.createBitmapFromView(view))
-            else
-                BitmapUtil.createBitmapFromView(view)
+            else if (cropSize == null)
+                    BitmapUtil.createBitmapFromView(view)
+                else {
+                    // we center-crop on the X axis, but we crop the bottom on the Y axis, so Y starts at 0 (top).
+                    val x = (view.width - cropSize.width) / 2
+                    BitmapUtil.createCroppedBitmapFromView(view, x, 0, cropSize.width, cropSize.height)
+                }
+
             wholeBitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
             out.flush()
             out.close()

--- a/stories/src/main/java/com/wordpress/stories/util/ViewUtils.kt
+++ b/stories/src/main/java/com/wordpress/stories/util/ViewUtils.kt
@@ -1,8 +1,11 @@
 package com.wordpress.stories.util
 
+import android.util.Size
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.children
+
+const val TARGET_RATIO_9_16 = 0.5625f // 9:16
 
 fun removeViewFromParent(view: View) {
     view.parent?.let {
@@ -22,4 +25,35 @@ fun cloneViewSpecs(originalView: View, targetView: View) {
 
     targetView.measure(measuredWidth, measuredHeight)
     targetView.layout(0, 0, targetView.getMeasuredWidth(), targetView.getMeasuredHeight())
+}
+
+fun isSizeRatio916(originalWidth: Int, originalHeight: Int): Boolean {
+    return (originalWidth.toFloat() / originalHeight.toFloat()) == TARGET_RATIO_9_16
+}
+
+fun normalizeSizeExportTo916(originalWidth: Int, originalHeight: Int): Size {
+    /*
+        1. if the screen is 16:9, we're OK
+        2. if not, resolve what the height should be for the screen's given width.
+        3. if the result of (2) is less than actual height, set the new target
+            height for the cloned view to the number calculated as of (2) (cropping)
+        4. if the result of (2) is greater than actual height --> crop on width to make it fit 9:16
+     */
+    if (isSizeRatio916(originalWidth, originalHeight)) {
+        // 1. if the screen is already 16:9, we're OK, return the original width and height
+        return Size(originalWidth, originalHeight)
+    } else {
+        // 2. if not, resolve what the height should be for the screen's given width.
+        val normalizedHeightShouldBe = originalWidth / TARGET_RATIO_9_16
+        if (normalizedHeightShouldBe <= originalHeight) {
+            // 3. if the result of (2) is less than actual height, set the new target height for the cloned
+            // view to the number calculated as of (2) (cropping on height)
+            return Size(originalWidth, normalizedHeightShouldBe.toInt())
+        } else {
+            // 4. if the result of (2) is greater than actual height --> crop the width to match the ratio needed
+            // for the given original height (cropping on width)
+            val normalizedWidthShouldBe = originalHeight * TARGET_RATIO_9_16
+            return Size(normalizedWidthShouldBe.toInt(), originalHeight)
+        }
+    }
 }


### PR DESCRIPTION
Fix #451 

Title has it, in this PR we added method `normalizeHeightExportTo916()` and crop the _resulting_ bitmap to a normalized 9:16 aspect ratio if _requested_ **and** _needed_. Given we're cropping the resulting bitmap, this means added views may be clipped as well, this risk has been properly assessed and evaluated against different approaches we could take (as for example growing the available taken space, or showing the artificially limited working area on the composer) `pbD5rk-id-p2`.

This is how it works:
1. if the screen is 16:9, we're OK and return as usual
2. if not, we resolve what the height should be for the screen's given width.
3. if the result of (2) is less than actual height, set the new target height for the cloned view to the number calculated as of (2) (cropping)
4. if the result of (2) is greater than actual height --> crop the width to match the ratio needed for the given height

**Important note**: While step/case (4) here was supposed to be less frequent to happen according to the different screen sizes we've been evaluating (*), in practice, I've found out even more common 9:16 screen sizes such as 1080x1920 still report a height value a bit smaller due to the portion of the screen the bottom Android controls take up for back arrow, home and recents navigation buttons. Hence, in order to normalize to 9:16, we need to crop on width when we find such cases.

For example, using a Pixel 3 with a screen of 1440x2792:

**Before**:
produces an image of 1440x2792 (matching the screen's resolution)
https://testmzorz3.files.wordpress.com/2020/07/wp-1595874869618.jpg


**After**:
produces an image that is now 1440x2560 (matching the target ratio)
https://testmzorz3.files.wordpress.com/2020/07/wp-1595874869642.jpg

A few more border cases:
- Pixel 3XL APi 29 is 1440x2960 - this shows the result bottom-cropped to 1440x2560 (9:16)
<img width="320" alt="Screen Shot 2020-08-05 at 12 24 07" src="https://user-images.githubusercontent.com/6597771/89431844-d02bb880-d716-11ea-9296-5fe85b825e0a.png">

- Nexus 4 768x1280: this shows the result cropped to 666x1184, clipping some added views (this is expected)
<img width="1031" alt="Screen Shot 2020-08-05 at 12 27 14" src="https://user-images.githubusercontent.com/6597771/89432067-0c5f1900-d717-11ea-8a7f-70e34626c896.png">


- This one here 750x1334 reports an actual size of 750x1238, and as such gets cropped on width as well, resulting in 696x1238
<img width="968" alt="Screen Shot 2020-08-05 at 12 29 27" src="https://user-images.githubusercontent.com/6597771/89432321-5a741c80-d717-11ea-9eba-0404f543f4c2.png">


- 1080x1920 reports an available height of 1794. Normalized ends up being 1009x1794:
(emulator screenshot on the right, actual produced result on the left)
<img width="375" alt="Screen Shot 2020-08-05 at 12 20 49" src="https://user-images.githubusercontent.com/6597771/89431404-4380fa80-d716-11ea-9d8d-adebabd9228f.png">




#### To test
1. take a phone that is not 16:9
2. install the demo app and produce a slide with an image background
3. verify the output image is 16:9

#### Added notes
- (*) From https://deviceatlas.com/blog/most-used-smartphone-screen-resolutions
<img width="522" alt="Screen Shot 2020-08-05 at 11 40 29" src="https://user-images.githubusercontent.com/6597771/89426392-8213b680-d710-11ea-984b-45c18d1296fd.png">

- when I mention "reported size" we're actually taking the size available to the `ghostPhotoEditorView` in full screen mode, and I was able to inspect and reproduce this is the exact same size as returned by  `[getDisplayMetrics](https://developer.android.com/reference/android/util/DisplayMetrics)` 's  `.heightPixels` and `.widthPixels`;

- Videos export will be tackled on a follow up PR

