### PR TITLE
Elevate strings from PhotoEditor to Stories library

### DIFF
--- a/stories/src/main/res/values/strings.xml
+++ b/stories/src/main/res/values/strings.xml
@@ -83,6 +83,11 @@
     <string name="toast_error_saving_image">Error saving image</string>
     <string name="toast_error_saving_video">Video could not be saved</string>
 
+    <!-- PhotoEditor strings - overrides for user-facing strings so these can be translated at the app level and applied
+     by resource merging -->
+    <string name="camera_error">This device doesn\'t support Camera2 API.</string>
+    <string name="toast_error_playing_video">An error occurred while playing your video</string>
+
     <!-- WordPress Android strings - matching in case of future integration -->
     <!-- Android O notification channels, these show in the Android app settings -->
     <string name="notification_channel_general_title">General</string>


### PR DESCRIPTION
This PR copies the only 2 strings that are used for user-facing messages [from the PhotoEditor library ](https://github.com/Automattic/stories-android/blob/9c477b3e36bab8ec47abdd77182ff12045434962/photoeditor/src/main/res/values/strings.xml#L412-L413)used internally in the Stories library, so these can be extracted for translation on the host app level, or overwritten at the host app level.

See more on https://developer.android.com/studio/write/add-resources.html#resource_merging

