### PR TITLE
9:16 normalization: make image export full screen when possible

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -39,7 +39,8 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
+      <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
     </JetCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
@@ -229,10 +230,17 @@
       </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_WRAP" value="5" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="EXTENDS_LIST_WRAP" value="5" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
       <option name="METHOD_ANNOTATION_WRAP" value="1" />
       <option name="FIELD_ANNOTATION_WRAP" value="1" />
       <option name="ENUM_CONSTANTS_WRAP" value="5" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -39,8 +39,7 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
-      <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
-      <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
@@ -230,17 +229,10 @@
       </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-      <option name="CALL_PARAMETERS_WRAP" value="5" />
-      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_WRAP" value="5" />
-      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="EXTENDS_LIST_WRAP" value="5" />
-      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
       <option name="METHOD_ANNOTATION_WRAP" value="1" />
       <option name="FIELD_ANNOTATION_WRAP" value="1" />
       <option name="ENUM_CONSTANTS_WRAP" value="5" />

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -191,6 +191,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private var screenSizeY: Int = 0
     private var topControlsBaseTopMargin: Int = 0
     private var nextButtonBaseTopMargin: Int = 0
+    private var bottomNavigationBarMargin: Int = 0
     private var isEditingText: Boolean = false
 
     private lateinit var storyViewModel: StoryViewModel
@@ -277,7 +278,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         val width = photoEditorView.measuredWidth
         val height = photoEditorView.measuredHeight
 
-        val bottomAreaHeight = resources.getDimensionPixelSize(R.dimen.bottom_strip_height)
+        val bottomAreaHeight = resources.getDimensionPixelSize(R.dimen.bottom_strip_height) + bottomNavigationBarMargin
         val topAreaHeight = resources.getDimensionPixelSize(R.dimen.next_button_total_height)
 
         return Rect(
@@ -300,7 +301,10 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             addInsetTopMargin(next_button.layoutParams, nextButtonBaseTopMargin, insets.systemWindowInsetTop)
             addInsetTopMargin(close_button.layoutParams, topControlsBaseTopMargin, insets.systemWindowInsetTop)
             addInsetTopMargin(control_flash_group.layoutParams, topControlsBaseTopMargin, insets.systemWindowInsetTop)
-            (bottom_strip_view as StoryFrameSelectorFragment).setBottomOffset(insets.systemWindowInsetBottom)
+            bottomNavigationBarMargin = insets.systemWindowInsetBottom
+            workingAreaRect = calculateWorkingArea()
+            photoEditor.updateWorkAreaRect(workingAreaRect)
+            (bottom_strip_view as StoryFrameSelectorFragment).setBottomOffset(bottomNavigationBarMargin)
             view_popup_menu.setTopOffset(
                 next_button.measuredHeight + (nextButtonBaseTopMargin * 2) + insets.systemWindowInsetTop)
             insets

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -304,6 +304,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             bottomNavigationBarMargin = insets.systemWindowInsetBottom
             workingAreaRect = calculateWorkingArea()
             photoEditor.updateWorkAreaRect(workingAreaRect)
+            delete_view.addBottomOffset(bottomNavigationBarMargin)
             (bottom_strip_view as StoryFrameSelectorFragment).setBottomOffset(bottomNavigationBarMargin)
             view_popup_menu.setTopOffset(
                 next_button.measuredHeight + (nextButtonBaseTopMargin * 2) + insets.systemWindowInsetTop)

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -101,6 +101,7 @@ import com.wordpress.stories.util.getStoryIndexFromIntentOrBundle
 import com.wordpress.stories.util.isVideo
 import kotlinx.android.synthetic.main.activity_composer.*
 import kotlinx.android.synthetic.main.content_composer.*
+import kotlinx.android.synthetic.main.fragment_story_frame_selector.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -299,6 +300,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             addInsetTopMargin(next_button.layoutParams, nextButtonBaseTopMargin, insets.systemWindowInsetTop)
             addInsetTopMargin(close_button.layoutParams, topControlsBaseTopMargin, insets.systemWindowInsetTop)
             addInsetTopMargin(control_flash_group.layoutParams, topControlsBaseTopMargin, insets.systemWindowInsetTop)
+            (bottom_strip_view as StoryFrameSelectorFragment).setBottomOffset(insets.systemWindowInsetBottom)
             view_popup_menu.setTopOffset(
                 next_button.measuredHeight + (nextButtonBaseTopMargin * 2) + insets.systemWindowInsetTop)
             insets

--- a/stories/src/main/java/com/wordpress/stories/compose/DeleteButton.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/DeleteButton.kt
@@ -54,6 +54,11 @@ class DeleteButton @JvmOverloads constructor(
 
     fun addBottomOffset(offset: Int) {
         val params = layoutParams as RelativeLayout.LayoutParams
-        params.bottomMargin = resources.getDimensionPixelSize(R.dimen.delete_button_margin_bottom) + offset
+        val hasChanged = params.bottomMargin !=
+                (resources.getDimensionPixelSize(R.dimen.delete_button_margin_bottom) + offset)
+        if (hasChanged) {
+            params.bottomMargin = resources.getDimensionPixelSize(R.dimen.delete_button_margin_bottom) + offset
+            requestLayout()
+        }
     }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/DeleteButton.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/DeleteButton.kt
@@ -6,6 +6,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageButton
+import android.widget.RelativeLayout
 import androidx.core.content.ContextCompat.getDrawable
 import com.wordpress.stories.R
 
@@ -49,5 +50,10 @@ class DeleteButton @JvmOverloads constructor(
         if (!readyForDeleteState) {
             deleteButtonClickListener?.onClick(view)
         }
+    }
+
+    fun addBottomOffset(offset: Int) {
+        val params = layoutParams as RelativeLayout.LayoutParams
+        params.bottomMargin = resources.getDimensionPixelSize(R.dimen.delete_button_margin_bottom) + offset
     }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/ImmersiveUtils.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ImmersiveUtils.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import android.view.Window
+import android.view.WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION
 
 const val IMMERSIVE_FLAG_TIMEOUT = 500L
 /** Combination of all flags required to put activity into immersive mode */
@@ -23,6 +24,10 @@ fun hideStatusBar(window: Window) {
     window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_FULLSCREEN
             or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
             or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+    window.setFlags(
+        FLAG_TRANSLUCENT_NAVIGATION,
+        FLAG_TRANSLUCENT_NAVIGATION
+    )
 }
 
 // Shows the system bars by removing all the flags

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -187,5 +188,10 @@ class StoryFrameSelectorFragment : Fragment() {
 
     fun showAddFrameControl() {
         view?.plus_icon?.visibility = View.VISIBLE
+    }
+
+    fun setBottomOffset(offset: Int) {
+        val params = view?.layoutParams as ConstraintLayout.LayoutParams
+        params.bottomMargin = offset
     }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
@@ -192,6 +192,10 @@ class StoryFrameSelectorFragment : Fragment() {
 
     fun setBottomOffset(offset: Int) {
         val params = view?.layoutParams as ConstraintLayout.LayoutParams
-        params.bottomMargin = offset
+        val hasChanged = params.bottomMargin != offset
+        if (hasChanged) {
+            params.bottomMargin = offset
+            view?.requestLayout()
+        }
     }
 }

--- a/stories/src/main/res/layout/content_composer.xml
+++ b/stories/src/main/res/layout/content_composer.xml
@@ -239,7 +239,7 @@
         android:layout_marginBottom="@dimen/save_button_margin_bottom"
         android:visibility="gone"
         android:layout_centerHorizontal="true"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_strip_view"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         />

--- a/stories/src/main/res/values/dimens.xml
+++ b/stories/src/main/res/values/dimens.xml
@@ -22,7 +22,7 @@
     <dimen name="save_button_total_width">104dp</dimen>
     <dimen name="save_button_total_height">40dp</dimen>
     <dimen name="save_button_radius">4dp</dimen>
-    <dimen name="save_button_margin_bottom">96dp</dimen>
+    <dimen name="save_button_margin_bottom">16dp</dimen>
     <dimen name="save_button_padding">8dp</dimen>
     <dimen name="save_button_spinner_size">24dp</dimen>
 


### PR DESCRIPTION
Following up from [this comment](https://github.com/Automattic/stories-android/pull/479#issuecomment-670215512) from @aforcier I spent a few trying to figure out if we would be able to actually get uncropped widths whenever possiblle by satisfying both these conditions:
- make the background photoview occupy the entire phone screen
- keep the navigation bar visible (so to satisfy [feedback collected here](https://github.com/Automattic/stories-android/issues/61), which is why it was being kept visible at all times), but semitransparent.

I thought if we could do this, we could take advantage of having most of the screen available.
This PR seems to work in this regard. Did the following:
```
window.setFlags(
        FLAG_TRANSLUCENT_NAVIGATION,
        FLAG_TRANSLUCENT_NAVIGATION
    )
```
[FLAG_TRANSLUCENT_NAVIGATION](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_TRANSLUCENT_NAVIGATION) is deprecated since API 30, but setting the recommended flags there will make the navigation bar hidden (which is what I was trying to avoid as per the collected feedback). Hope this won't be a problem for the time being, and I think at a later phase we can then introduce the flags to hide the navigation bar after people are already used to this screen.

With these changes, the Composer uses most of the screen, and we're able to produce 9:16 output that most of the time matches the phone screen size (or at least avoids cropping on width, as per our earlier assumptions that I wrote a caveat for in #479)

Some results:
- Pixel 3 XL - 1440x2960 (original screen size). Ends up being normalized on height to 1440x2560.
retry button needs to be adjusted as well
- 750x1334: is kept the same
- 1080x1920 is kept the same
- nexus 4 API 26: 768x1280: 720x1280

To test:
1. create story slides with the demo app
2. observe the background view occupies the full screen, and the navigation bar is shown translucent on top of the background image
3. observe the story slides selector (bottom strip) is always above the navigation bar
4. observe the add text, add emoji, delete button, etc appear above the story frame selector
5. save the slides, verify the above mentioned resolutions work as expected
6. Repeat this process with different screen sizes
7. also try the error screen by applying this gist https://gist.github.com/mzorz/852c06f673d3e27ecabab3532619c4a8
8. observe the error RETRY button  appear above the story frame selector
9. observe the story frame selector appears above the navigation bar.




