### PR TITLE
Remove unused pref key which was conflicting with host app

### DIFF
--- a/stories/src/main/res/values/strings.xml
+++ b/stories/src/main/res/values/strings.xml
@@ -42,7 +42,6 @@
     <!--preference keys-->
     <string name="pref_camera_selection" translatable="false">pref_camera_selection</string>
     <string name="pref_flash_mode_selection" translatable="false">pref_flash_mode_selection</string>
-    <string name="pref_key_send_crash" translatable="false">pref_key_send_crash</string>
 
     <!-- Save Frame process strings-->
     <!--suppress UnusedResources -->


### PR DESCRIPTION
@loremattei found an issue with the WPAndroid release cut today, a conflict with a pref key we copied from the host app which is used in a different file:

> I'm doing the WPAndroid code freeze and I've a small issue with stories
12:21
stories' strings.xml  contains this entry: https://github.com/Automattic/stories-android/blob/8ef22f0ed0bf57f1078b5104f7925c688f733ee4/stories/src/main/res/values/strings.xml#L45 
> and the same key is used by WPAndroid here: https://github.com/wordpress-mobile/WordPress-Android/blob/9054ed555065f42456194dc9463650b6c7d5d975/WordPress/src/main/res/values/key_strings.xml#L17 
> what happens is that it gets copied to WPAndroid's strings.xml  file and then the linter complains because it founds it in both strings.xml  and key_strings.xml

In short, the pref key doesn't belong to `strings.xml`, and also we're not really using it in the stories lib (nor the stories demo app, given we use a `DeletablePrefKey.CRASH_LOGGING_ENABLED` here), so, removing.

