### PR TITLE
Fix for camera mode

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
@@ -124,6 +124,9 @@ class BackgroundSurfaceManager(
     @OnLifecycleEvent(ON_START)
     fun onStart(source: LifecycleOwner) {
         // TODO: get state and restart fragments / camera preview?
+        if (isTextureViewAvailable()) {
+            managerReadyListener?.onBackgroundSurfaceManagerReady()
+        }
     }
 
     @Suppress("unused")

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -745,16 +745,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     private fun showCurrentSelectedFrame() {
         // get currently selected frame and check whether this is a video or an image
-        when (storyViewModel.getSelectedFrame()?.frameItemType) {
-            is VIDEO -> runOnUiThread {
-                // now start playing the video that was selected in the frame selector
-                showPlayVideo()
-            }
-            is IMAGE -> runOnUiThread {
-                // switch to static background
-                showStaticBackground()
-            }
-        }
+        updateBackgroundSurfaceUIWithStoryFrame(storyViewModel.getSelectedFrameIndex())
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {


### PR DESCRIPTION
Fixes #485 

### What was happening
In ComposeLoopFrameActivity, in `onStart()` we call `updateBackgroundSurfaceUIWithStoryFrame()`.
It then calls  `onStoryFrameSelected` which in turn takes the previously selected frame and draws it on the screen, rendering the `TextureView` invisible, and as such it never becomes available which is what the `BackgroundSurfaceManagerReadyListener` is waiting for.

This bug was actually introduced in this commit https://github.com/Automattic/stories-android/commit/436946a0912242b4151912b412006d4258a907ac belonging to the work done in this PR https://github.com/Automattic/stories-android/pull/435

###  How's it fixed
Right after coming from the media picker, the ComposeLoopFrameActivity is not STARTED but CREATED, and as such tries to enqueue a pending request for the textureView to be ready, But, the TextureView happens to already be ready, because it was prepped in the first place, so the SurfaceReadyListener never gets triggered (well actually yes, it was triggered long before). For this, I added a call to `BackgroundSurfaceManager.onSurfaceReady()` after the `onStart()` call in `BackgroundSurfaceManager` (see e584c11). I think it makes sense given the condition for isTextureAvailable() is that the AutofitTextureView is available _and_  the lifecycleowner is at least STARTED.
This is enough to keep the pending request flags to get checked back when coming from the picker.

Note the subtlety that the onStart() method will always be called once and as such if there is a Story loaded and a selectedFrame, that frame is first prepped and then after onStart() on the Activity is finished the lifecycleobservers will get called. This means, the backgroundSurfaceManager is called now, and the proper live camera preview appears at this point.

Also after fixing this, another bug surfaced, which is: when going to the media picker then tapping the camera icon there and showing the live camera preview mode for ComposeLoopFrameActivity, if we tapped the X there to just dismiss the live camera preview and come back to the Stories composer mode, the selected Story slide would have lost or not show the added views, because we'd only refresh the background in `showCurrentSelectedFrame`. We fixed that by making `showCurrentSelectedFrame()` call the more general purpose `updateBackgroundSurfaceUIWithStoryFrame()` in 2d7283c, which takes care of not only refreshing the background but also painting the AddedViews on it for the selected frame, all reusing the existing code paths.

### How to test

To test: CASE A
1. open the app and take new picture
2. add some text
3. tap on + icon to add another slide
4. on the media picker, tap the camera icon
5. observe the camera live preview is now presented
6. take a picture: will add a new slide to the story.


To test: CASE B (added views - cancel instead of adding a new picture)
1. capture an image
2. add a text
3. tap on + 
4. tap on camera icon on the media picker
5. now the camera capture mode is presented, here tap on the X on the top left
6. you're back at the story, make sure the added views are still there and you can touch them, edit them, drag them around.


To test CASE C: WPAndroid (because our demo app's media picker doesn't have all the permissions request wired in to make this happen, as the demo app assumes the permissions to have been granted in the Intro screen).

Follow Use case B described in https://github.com/Automattic/stories-android/pull/412




