### PR TITLE
Making camera and autofocus features declaration not required

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,8 +11,11 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
 
-    <uses-feature android:name="android.hardware.camera" />
-    <uses-feature android:name="android.hardware.camera.autofocus" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus"
+        android:required="false" />
 
     <uses-permission android:name="android.permission.VIBRATE"/>
 

--- a/photoeditor/src/main/AndroidManifest.xml
+++ b/photoeditor/src/main/AndroidManifest.xml
@@ -8,7 +8,10 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
 
-    <uses-feature android:name="android.hardware.camera" />
-    <uses-feature android:name="android.hardware.camera.autofocus" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus"
+        android:required="false" />
 
 </manifest>


### PR DESCRIPTION
Title has it - as the [documentation states](https://developer.android.com/guide/topics/manifest/uses-feature-element), the `uses-feature` declaration defaults to `true`  if a feature is declared and not set to `false` explicitly, resulting in potentially filtering out devices when listed on Google Play.

> android:required
Boolean value that indicates whether the application requires the feature specified in android:name.
When you declare android:required="true" for a feature, you are specifying that the application cannot function, or is not designed to function, when the specified feature is not present on the device.
When you declare android:required="false" for a feature, it means that the application prefers to use the feature if present on the device, but that it is designed to function without the specified feature, if necessary.
The default value for android:required if not declared is "true".

Stories are not dependent on the camera or autofocus functionality (as media can be fed into the stories functionality by using a MediaPickerProvider), hence we're setting these to `false` explicitly.

### To test:

N/A as the documentation states: 

> Declared <uses-feature> elements are informational only, meaning that the Android system itself does not check for matching feature support on the device before installing an application. However, other services (such as Google Play) or applications may check your application's <uses-feature> declarations as part of handling or interacting with your application. For this reason, it's very important that you declare all of the features (from the list below) that your application uses.

We'll have to merge this and try uploading the host app to the Store and run it through the process to see how filters there apply.



