### PR TITLE
Using RECORD_AUDIO permission declaration only for SDK23+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission-sdk-23 android:name="android.permission.RECORD_AUDIO"/>
 
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />

--- a/photoeditor/src/main/AndroidManifest.xml
+++ b/photoeditor/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission-sdk-23 android:name="android.permission.RECORD_AUDIO"/>
 
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />


### PR DESCRIPTION
Following a suggestion by @aforcier, with this PR we make sure not to request any new permissions for users on API levels lower than 23 (in particular 5.0 = api level 21 and 5.1 = api level 22 which are supported as per our `minSdk` in the Stories library).

This is the documentation for [`uses-permission`](https://developer.android.com/guide/topics/manifest/uses-permission-element)

And here's the documentation for [`uses-permission-sdk-23`](https://developer.android.com/guide/topics/manifest/uses-permission-sdk-23-element), citing the important part here:

> Specifies that an app wants a particular permission, but only if the app is installed on a device running Android 6.0 (API level 23) or higher. If the device is running API level 22 or lower, the app does not have the specified permission.
This element is useful when you update an app to include a new feature that requires an additional permission. If a user updates an app on a device that is running API level 22 or lower, the system prompts the user at install time to grant all new permissions that are declared in that update. If a new feature is minor enough, you may prefer to disable the feature altogether on those devices, so the user does not have to grant additional permissions to update the app. By using the <uses-permission-sdk-23> element instead of <uses-permission>, you can request the permission only if the app is running on platforms that support the runtime permissions model, in which the user grants permissions to the app while it is running

_NOTE:_ Given the stories functionality is behind a feature flag, we can make use of this special declaration to avoid getting the new permission filtered, and come up with a more rigorous approach before launch.
Tested  the demo app on a couple of API 21 emulators and it will let you install, and the camera live preview will just show a blank screen, but the app didn't crash - caveat there's no code to actively handle this gracefully as of this PR, this will need to be handled elsewhere as just said above.



