### PR TITLE
Only clean temp files for slides that have successfully been saved

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -146,7 +146,7 @@ class FrameSaveService : Service() {
             // remove the processor from the list once it's done processing this Story's frames
             storySaveProcessors.remove(processor)
 
-            cleanUpTempStoryFrameFiles(storyFrames)
+            cleanUpTempStoryFrameFiles(storyFrames.filter { it.saveResultReason == SaveSuccess })
 
             // also if more than one processor is running, let's not stop the Service just now.
             if (storySaveProcessors.isEmpty()) {


### PR DESCRIPTION
This was first observed by @aforcier  here https://github.com/Automattic/stories-android/pull/481#issuecomment-670818099
When capturing a file with the camera and such a Story slide results in an error being saved, it would then be unable to get retrieved with an `open failed: ENOENT (No such file or directory)` exception.

```
2020-08-11 13:27:21.712 6104-6104/com.automattic.loop I/Glide: Root cause (2 of 3)
    java.io.FileNotFoundException: /data/user/0/com.automattic.loop/app_tmp/tmp_wp_story1597162592700.jpg: open failed: ENOENT (No such file or directory)
        at libcore.io.IoBridge.open(IoBridge.java:496)
        at java.io.FileInputStream.<init>(FileInputStream.java:159)
        at com.bumptech.glide.load.model.FileLoader$StreamFactory$1.open(FileLoader.java:142)
        at com.bumptech.glide.load.model.FileLoader$StreamFactory$1.open(FileLoader.java:139)
        at com.bumptech.glide.load.model.FileLoader$FileFetcher.loadData(FileLoader.java:71)
        at com.bumptech.glide.load.engine.SourceGenerator.startNext(SourceGenerator.java:63)
        at com.bumptech.glide.load.engine.DecodeJob.runGenerators(DecodeJob.java:310)
        at com.bumptech.glide.load.engine.DecodeJob.onDataFetcherFailed(DecodeJob.java:408)
        at com.bumptech.glide.load.engine.SourceGenerator.onLoadFailed(SourceGenerator.java:130)
        at com.bumptech.glide.load.model.ByteBufferFileLoader$ByteBufferFetcher.loadData(ByteBufferFileLoader.java:66)
        at com.bumptech.glide.load.engine.SourceGenerator.startNext(SourceGenerator.java:63)
        at com.bumptech.glide.load.engine.DecodeJob.runGenerators(DecodeJob.java:310)
        at com.bumptech.glide.load.engine.DecodeJob.runWrapped(DecodeJob.java:279)
        at com.bumptech.glide.load.engine.DecodeJob.run(DecodeJob.java:234)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
        at com.bumptech.glide.load.engine.executor.GlideExecutor$DefaultThreadFactory$1.run(GlideExecutor.java:431)
     Caused by: android.system.ErrnoException: open failed: ENOENT (No such file or directory)

```

To reproduce:

1. apply this gist https://gist.github.com/mzorz/852c06f673d3e27ecabab3532619c4a8
2. open the demo app
3. tap + to start a story
4. capture a photo in the capture mode
5. add a view
6. tap NEXT
7. observe an error occurs 
8. tap on the error notification so the error screen appears
9. observe the background is black.

This PR fixes this by only doing the temporal files cleanup on slides that were saved successfully (otherwise tapping on the error notification would bring you to a slide for which the background resource is not available anymore).

To test:
- follow the steps above, except observe in step 9 the slide background is not black anymore (it now shows the actual background).
