### PR TITLE
Hold on to bitmap reference until it's no longer needed

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -325,7 +325,9 @@ class FrameSaveService : Service() {
         }
 
         override fun onFrameSaveFailed(frameIndex: FrameIndex, reason: String?) {
-            Log.d(LOG_TAG, "FAILED save frame idx: " + applyFrameIndexOverride(frameIndex))
+            val reasonString = if (reason != null) reason else ""
+            Log.d(LOG_TAG, "FAILED save frame idx: " + applyFrameIndexOverride(frameIndex)+
+                    " - error: " + reasonString)
             // remove one from the count
             frameSaveNotifier.incrementUploadedMediaCountFromProgressNotification(
                 storyIndex,

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -325,9 +325,8 @@ class FrameSaveService : Service() {
         }
 
         override fun onFrameSaveFailed(frameIndex: FrameIndex, reason: String?) {
-            val reasonString = if (reason != null) reason else ""
             Log.d(LOG_TAG, "FAILED save frame idx: " + applyFrameIndexOverride(frameIndex) +
-                    " - error: " + reasonString)
+                    " - error: " + reason.orEmpty())
             // remove one from the count
             frameSaveNotifier.incrementUploadedMediaCountFromProgressNotification(
                 storyIndex,

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -326,7 +326,7 @@ class FrameSaveService : Service() {
 
         override fun onFrameSaveFailed(frameIndex: FrameIndex, reason: String?) {
             val reasonString = if (reason != null) reason else ""
-            Log.d(LOG_TAG, "FAILED save frame idx: " + applyFrameIndexOverride(frameIndex)+
+            Log.d(LOG_TAG, "FAILED save frame idx: " + applyFrameIndexOverride(frameIndex) +
                     " - error: " + reasonString)
             // remove one from the count
             frameSaveNotifier.incrementUploadedMediaCountFromProgressNotification(


### PR DESCRIPTION
Fixes #429 🎉 

This one was tricky given it not always would fail, but found out to be fairly easily reproduceable on a Pixel 3 XL API 29 emulator.

The reasons why some image background slides would fail and then, on retry would be saved correctly most of the times (or correct itself after a few passes without much of anything but pressing the `RETRY` button) was due to our saving process utilizing the bitmap and then discarding it right away (marking it for recycling by calling [Glide.clear() ](https://bumptech.github.io/glide/doc/targets.html#clear) on the `futureTarget`), without waiting for the actual image file to get saved. So, if the GC came in between and _then_ we tried to use it in order to save the file, we'd get an Exception that was captured by the try/catch block and recoursed to `saveProgressListener?.onFrameSaveFailed(frameIndex, ex.message)` in this [block of code](https://github.com/Automattic/stories-android/blob/develop/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt#L140-L154).

Logging the error reason in 1cf9832 gave me the hint:

> 2020-08-11 15:07:36.728 20372-20432/com.automattic.loop D/EGL_emulation: eglMakeCurrent: 0xddb1a600: ver 3 0 (tinfo 0xddb0fa30)
2020-08-11 15:07:36.744 20372-20396/com.automattic.loop W/System: A resource failed to call release. 
2020-08-11 15:07:36.746 20372-20396/com.automattic.loop W/System: A resource failed to call release. 
2020-08-11 15:07:36.752 20372-21379/com.automattic.loop D/STORIES: ABOUT TO FAIL save frame idx: 1 - error: java.lang.RuntimeException: Canvas: trying to use a recycled bitmap android.graphics.Bitmap@afa2852
2020-08-11 15:07:36.752 20372-21379/com.automattic.loop D/STORIES: FAILED save frame idx: 1 - error: Canvas: trying to use a recycled bitmap android.graphics.Bitmap@afa2852

(hence, keeping the addition to the log message in code as it'll help us in the future as well).

So, what this PR does is effectively keep the `futureTarget` reference as long as it takes, up until after the file has been saved, and only calling `clear()` on it before leaving.

To test:
1. open the demo app
2. add many image slides, with added views (I was able to make it  fail with 2 images and 1 video sometimes)
3. tap NEXT
4. observe everything got saved correctly without any frames failing.

