### PR TITLE
Use Uri.fromFile() insteaf of Uri.file?.absolutePath

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
@@ -253,7 +253,7 @@ class FrameSaveManager(
     ): Boolean {
         var callMade = false
         val uri: Uri? = (frame.source as? UriBackgroundSource)?.contentUri
-            ?: Uri.parse((frame.source as FileBackgroundSource).file?.absolutePath)
+                ?: Uri.fromFile(requireNotNull((frame.source as FileBackgroundSource).file))
         // we only need the width and height of a model canvas, not creating a canvas clone in the case of videos
         // as these are all processed in the background
         uri?.let {


### PR DESCRIPTION
Should fix #431 

While investigating this, observed the problem might have come from the content resolver not being able to figure out the right location for the file.

Given this has been reported to have crashed with a file being captured with the app itself, and we know for sure the location of the file and that it's a valid file, I figured there was a bit of information being missed when transforming the File's to `Uri` 
 by only taking its `absolutePath`.

This was indeed the case given we were doing
`Uri.parse(file.getAbsolutePath())` which is based on a simple String, while we could use `Uri.fromFile()` here as we have full control over this file. 

This is how things looked before, for a given file:

```
uri2 = {Uri$StringUri@12538} "/data/user/0/com.automattic.loop/app_tmp/tmp_wp_story1597419063035.mp4"
 authority = null
 cachedFsi = -2
 cachedSsi = -2
 fragment = null
 path = null
 query = null
 scheme = "NOT CACHED"
 ssp = null
 uriString = "/data/user/0/com.automattic.loop/app_tmp/tmp_wp_story1597419063035.mp4"
 host = "NOT CACHED"
 port = -2
 userInfo = null
 shadow$_klass_ = {Class@4668} "class android.net.Uri$StringUri"
 shadow$_monitor_ = 0
```

And this is the information we have now (observe the `scheme` in particular is correctly populated, so the content Resolver should have more information to figure out the actual content location for this Uri)

```
uri = {Uri$HierarchicalUri@12515} "file:///data/user/0/com.automattic.loop/app_tmp/tmp_wp_story1597419063035.mp4"
 authority = {Uri$Part$EmptyPart@12520} 
 fragment = {Uri$Part$EmptyPart@12521} 
 path = {Uri$PathPart@12522} 
 query = {Uri$Part$EmptyPart@12521} 
 scheme = "file"
 ssp = null
 uriString = "file:///data/user/0/com.automattic.loop/app_tmp/tmp_wp_story1597419063035.mp4"
 host = "NOT CACHED"
 port = -2
 userInfo = null
 shadow$_klass_ = {Class@2946} "class android.net.Uri$HierarchicalUri"
 shadow$_monitor_ = 0
```

Hence, we're now not losing this information and the content resolver should figure out things in a straight-forward manner.

To test:
N/A, haven't been able to reproduce myself on the devices / emulators I have, will ask someone with a Samsung S10 later.

