### PR TITLE
Added missing calls to onStoryDiscarded()

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -907,11 +907,13 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                                     dialog.dismiss()
                                     // discard the whole story
                                     safelyDiscardCurrentStoryAndCleanUpIntent()
+                                    storyDiscardListener?.onStoryDiscarded()
                                 }
                             }).show(supportFragmentManager, FRAGMENT_DIALOG)
                     } else {
                         // discard the whole story
                         safelyDiscardCurrentStoryAndCleanUpIntent()
+                        storyDiscardListener?.onStoryDiscarded()
                     }
                 }
             }


### PR DESCRIPTION
Fix #421 

The actual responsibility to clear up any empty posts is already implemented on the host app side, we were just missing  a few `onStoryDiscarded()` callback calls.

To test:
CASE A: without added views
1. start a story
2. tap back or the X button
3. observe no new empty drafts are added

CASE B: with added views
1. start a story
2. add some text or emoji
3. tap back or the X button -> when the dialog appears, proceed to discard
4. observe no new empty drafts are added


