### PR TITLE
Make permission checking flag protected

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -211,7 +211,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private var notificationTrackerProvider: NotificationTrackerProvider? = null
     private var prepublishingEventProvider: PrepublishingEventProvider? = null
     private var firstIntentLoaded: Boolean = false
-    private var permissionsRequestForCameraInProgress: Boolean = false
+    protected var permissionsRequestForCameraInProgress: Boolean = false
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, service: IBinder) {


### PR DESCRIPTION
Fixes #501 
Related WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/12735

This PR just allows classes inheriting from ComposeLoopFrameActivity to access  `permissionsRequestForCameraInProgress` so they can hold off from calling `onLoadFromIntent()` or  act accordingly depending on whether the base class is handling permission requests.