### PR TITLE
Using setTargetResolution instead of custom aspect ratio for VideoCapture usecase

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.util.DisplayMetrics
 import android.util.Log
 import android.util.Rational
+import android.util.Size
 import android.view.ViewGroup
 import androidx.camera.core.CameraX
 import androidx.camera.core.ImageCapture
@@ -185,9 +186,11 @@ class CameraXBasicHandling : VideoRecorderFragment() {
                 videoCapture?.clear()
             }
 
+            val metrics = DisplayMetrics().also { textureView.display.getRealMetrics(it) }
+
             val videoCaptureConfig = VideoCaptureConfig.Builder().apply {
                 setLensFacing(lensFacing)
-                setTargetAspectRatioCustom(screenAspectRatio)
+                setTargetResolution(Size(metrics.widthPixels, metrics.heightPixels))
                 setTargetRotation(textureView.display.rotation)
             }.build()
             videoCapture = VideoCapture(videoCaptureConfig)


### PR DESCRIPTION
Fix #200

This seems to fix the problem with unbinding / re-binding the TextureView from the live preview use case and to the VideoCapture use case.

I have been able to reproduce the problem on the Samsung J2 and _sometimes_ on the Redmi Note 5, and with this change I could see it works 100% of the time as per my tests.
The emulators don't seem to work very well but tested on these real devices and it works alright; worth noting the Samsung J2 was having the same issue 100% of the time and now it's fixed.
- Samsung J2 OK
- Pixel 2 ANDROID 8.1 OK
- Redmi Note 5 OK
- Samsung S5e tablet: OK
- Nexus 5X: OK

To test:
1. open the demo app
2. tap on + 
3. capture a video
4. observe the live preview & the video capture keep the same resolution / aspect ratio and are not deformed
5. once the video is done recording, also observe the video player plays the video as it was recorded (no stretching)

