### PR TITLE
Update delete slide popup menu  appearance

### DIFF
--- a/stories/src/main/res/layout/view_compose_popup_menu.xml
+++ b/stories/src/main/res/layout/view_compose_popup_menu.xml
@@ -23,7 +23,7 @@
             android:text="@string/menu_delete_page"
             android:backgroundTint="@color/white"
             android:background="?android:attr/selectableItemBackground"
-            android:drawableStart="@drawable/ic_delete_black_24dp"
+            android:textAppearance="?textAppearanceSmallPopupMenu"
             android:textAllCaps="false"
             android:textAlignment="textStart"
             android:paddingRight="@dimen/custom_menu_padding"

--- a/stories/src/main/res/values/dimens.xml
+++ b/stories/src/main/res/values/dimens.xml
@@ -54,7 +54,7 @@
 
     <!--  custom menu view-->
     <dimen name="custom_menu_margin">16dp</dimen>
-    <dimen name="custom_menu_padding">8dp</dimen>
+    <dimen name="custom_menu_padding">16dp</dimen>
     <dimen name="custom_menu_background_radius">1dp</dimen>
     <dimen name="custom_menu_elevation">6dp</dimen>
     <dimen name="custom_menu_button_width">140dp</dimen>

--- a/stories/src/main/res/values/dimens.xml
+++ b/stories/src/main/res/values/dimens.xml
@@ -55,7 +55,7 @@
     <!--  custom menu view-->
     <dimen name="custom_menu_margin">16dp</dimen>
     <dimen name="custom_menu_padding">8dp</dimen>
-    <dimen name="custom_menu_background_radius">4dp</dimen>
+    <dimen name="custom_menu_background_radius">1dp</dimen>
     <dimen name="custom_menu_elevation">6dp</dimen>
     <dimen name="custom_menu_button_width">140dp</dimen>
 


### PR DESCRIPTION
Fix #399 

**Note:** Please review and merge https://github.com/Automattic/stories-android/pull/509 first

This changes the `textAppearance` and removes the left drawable (trash icon)  for the custom "delete slide" popup menu.
I didn't add any shadows as per the referenced WPAndroid style given we are already showing a dark background to make the popupmenu stand out (and also block interaction on the rest of the screen while the menu is showing).
- [x] removes trash icon
- [x] preserves popup text style 
- [x] using a radius 1dp for corner borders to approach the style used in WPAndroid (bear in mind this here is not an actual Popup component but a custom view, was done like this because a regular popup is shown on another Window and that made the status bar appear - see #330 commit 54772da)
~- [ ] checked it works alright with dark mode~  Dark mode related work in https://github.com/Automattic/stories-android/pull/509

<img width="409" alt="Screen Shot 2020-08-21 at 14 47 41" src="https://user-images.githubusercontent.com/6597771/90919922-b4364100-e3bd-11ea-90ea-66bf53046e99.png">

