### PR TITLE
Dark mode support

### DIFF
--- a/app/src/main/java/com/automattic/loop/photopicker/utils/CameraIntentUtils.java
+++ b/app/src/main/java/com/automattic/loop/photopicker/utils/CameraIntentUtils.java
@@ -90,7 +90,7 @@ public class CameraIntentUtils {
     }
 
     private static void showSDCardRequiredDialog(Context context) {
-        MaterialAlertDialogBuilder dialogBuilder = new MaterialAlertDialogBuilder(context, R.style.AlertDialogTheme);
+        MaterialAlertDialogBuilder dialogBuilder = new MaterialAlertDialogBuilder(context);
         dialogBuilder.setTitle(context.getResources().getText(R.string.sdcard_title));
         dialogBuilder.setMessage(context.getResources().getText(R.string.sdcard_message));
         dialogBuilder.setPositiveButton(context.getString(android.R.string.ok), new DialogInterface.OnClickListener() {

--- a/app/src/main/java/com/automattic/loop/photopicker/utils/CameraIntentUtils.java
+++ b/app/src/main/java/com/automattic/loop/photopicker/utils/CameraIntentUtils.java
@@ -11,11 +11,11 @@ import android.provider.MediaStore;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.FileProvider;
 
 import com.automattic.loop.photopicker.RequestCodes;
 import com.automattic.loop.R;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.io.File;
 import java.io.IOException;
@@ -90,7 +90,7 @@ public class CameraIntentUtils {
     }
 
     private static void showSDCardRequiredDialog(Context context) {
-        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context, R.style.AlertDialogTheme);
+        MaterialAlertDialogBuilder dialogBuilder = new MaterialAlertDialogBuilder(context, R.style.AlertDialogTheme);
         dialogBuilder.setTitle(context.getResources().getText(R.string.sdcard_title));
         dialogBuilder.setMessage(context.getResources().getText(R.string.sdcard_message));
         dialogBuilder.setPositiveButton(context.getString(android.R.string.ok), new DialogInterface.OnClickListener() {

--- a/app/src/main/res/values-night-v28/styles.xml
+++ b/app/src/main/res/values-night-v28/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">?attr/colorPrimary</item>
+        <item name="android:immersive">true</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">?attr/colorPrimary</item>
+        <item name="android:immersive">true</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values-v28/styles.xml
+++ b/app/src/main/res/values-v28/styles.xml
@@ -17,7 +17,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme.Immersive" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>

--- a/app/src/main/res/values-v28/styles.xml
+++ b/app/src/main/res/values-v28/styles.xml
@@ -20,7 +20,7 @@
     <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">?attr/colorPrimary</item>
         <item name="android:immersive">true</item>
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,7 +4,7 @@
     <color name="colorPrimaryDark">@color/colorPrimaryDark_wp</color>
     <color name="colorAccent">@color/colorAccent_wp</color>
 
-    <color name="colorPrimary_wp">#006088</color>
+    <color name="colorPrimary_wp">#2271b1</color>
     <color name="colorPrimaryDark_wp">#006088</color>
     <color name="colorAccent_wp">@color/white</color>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -22,7 +22,7 @@
     <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">?attr/colorPrimary</item>
     </style>
 
     <style name="EditText">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,7 +19,7 @@
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"/>
 
     <!-- core creation experience style -->
-    <style name="AppTheme.Immersive" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -25,10 +25,6 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
-    <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="colorAccent">@color/colorPrimary</item>
-    </style>
-
     <style name="EditText">
         <item name="android:singleLine">true</item>
         <item name="colorControlNormal">#FFFFFF</item>

--- a/photoeditor/build.gradle
+++ b/photoeditor/build.gradle
@@ -51,6 +51,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
+    implementation 'com.google.android.material:material:1.1.0'
+
     implementation 'com.github.bumptech.glide:glide:4.10.0'
     kapt 'com.github.bumptech.glide:compiler:4.10.0'
 

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/ErrorDialog.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/ErrorDialog.kt
@@ -16,9 +16,9 @@
 
 package com.automattic.photoeditor.camera
 
-import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 
 interface ErrorDialogOk {
@@ -31,7 +31,7 @@ interface ErrorDialogOk {
 class ErrorDialog : DialogFragment() {
     private var okListener: ErrorDialogOk? = null
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        var builder = AlertDialog.Builder(activity)
+        var builder = MaterialAlertDialogBuilder(activity)
                 .setMessage(arguments?.getString(ARG_MESSAGE))
 
         okListener?.let {

--- a/stories/src/main/java/com/wordpress/stories/compose/FrameSaveErrorDialog.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/FrameSaveErrorDialog.kt
@@ -1,10 +1,10 @@
 package com.wordpress.stories.compose
 
-import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
-import com.wordpress.stories.R
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.wordpress.stories.R.style
 
 interface FrameSaveErrorDialogOk {
     fun OnOkClicked(dialog: DialogFragment)
@@ -13,7 +13,7 @@ interface FrameSaveErrorDialogOk {
 class FrameSaveErrorDialog : DialogFragment() {
     private var okListener: FrameSaveErrorDialogOk? = null
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val builder = AlertDialog.Builder(activity, R.style.AlertDialogTheme)
+        val builder = MaterialAlertDialogBuilder(activity, style.AlertDialogTheme)
             .setTitle(arguments?.getString(ARG_TITLE))
             .setMessage(arguments?.getString(ARG_MESSAGE))
 

--- a/stories/src/main/java/com/wordpress/stories/compose/FrameSaveErrorDialog.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/FrameSaveErrorDialog.kt
@@ -13,7 +13,7 @@ interface FrameSaveErrorDialogOk {
 class FrameSaveErrorDialog : DialogFragment() {
     private var okListener: FrameSaveErrorDialogOk? = null
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val builder = MaterialAlertDialogBuilder(activity, style.AlertDialogTheme)
+        val builder = MaterialAlertDialogBuilder(activity)
             .setTitle(arguments?.getString(ARG_TITLE))
             .setMessage(arguments?.getString(ARG_MESSAGE))
 

--- a/stories/src/main/java/com/wordpress/stories/compose/FrameSaveErrorDialog.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/FrameSaveErrorDialog.kt
@@ -4,7 +4,6 @@ import android.app.Dialog
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.wordpress.stories.R.style
 
 interface FrameSaveErrorDialogOk {
     fun OnOkClicked(dialog: DialogFragment)

--- a/stories/src/main/res/drawable/custom_menu_background.xml
+++ b/stories/src/main/res/drawable/custom_menu_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/white" />
+    <solid android:color="?attr/colorSurface" />
     <corners android:radius="@dimen/custom_menu_background_radius" />
 </shape>

--- a/stories/src/main/res/drawable/next_button_background_enabled.xml
+++ b/stories/src/main/res/drawable/next_button_background_enabled.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/white" />
+    <solid android:color="?attr/colorSurface" />
     <corners android:radius="@dimen/save_button_radius" />
 </shape>

--- a/stories/src/main/res/layout/content_next_button.xml
+++ b/stories/src/main/res/layout/content_next_button.xml
@@ -15,6 +15,6 @@
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:textAllCaps="true"
-        android:textColor="@color/text_color_blue"
+        android:textColor="?attr/colorOnSurface"
         />
 </RelativeLayout>

--- a/stories/src/main/res/layout/content_next_button.xml
+++ b/stories/src/main/res/layout/content_next_button.xml
@@ -15,6 +15,6 @@
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:textAllCaps="true"
-        android:textColor="?attr/colorOnSurface"
+        android:textColor="?attr/colorPrimary"
         />
 </RelativeLayout>

--- a/stories/src/main/res/layout/view_compose_popup_menu.xml
+++ b/stories/src/main/res/layout/view_compose_popup_menu.xml
@@ -17,11 +17,11 @@
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/delete_button"
+            style="@style/Stories.Delete.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:minWidth="@dimen/custom_menu_button_width"
             android:text="@string/menu_delete_page"
-            android:backgroundTint="@color/white"
             android:background="?android:attr/selectableItemBackground"
             android:textAppearance="?textAppearanceSmallPopupMenu"
             android:textAllCaps="false"

--- a/stories/src/main/res/values-night/styles.xml
+++ b/stories/src/main/res/values-night/styles.xml
@@ -1,0 +1,30 @@
+<resources>
+
+    <!-- core creation experience style -->
+    <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+
+        <item name="android:colorBackground">@color/background_dark</item>
+        <item name="colorSurface">@color/background_dark</item>
+        <item name="colorError">@color/red_30</item>
+        <item name="colorOnPrimary">@android:color/black</item>
+        <item name="colorOnSecondary">@android:color/white</item>
+        <item name="colorOnBackground">@android:color/white</item>
+        <item name="colorOnSurface">@android:color/white</item>
+        <item name="colorOnError">@android:color/black</item>
+        <item name="colorControlActivated">?attr/colorPrimary</item>
+<!--        <item name="colorAccent">?attr/colorPrimary</item>-->
+    </style>
+
+    <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="colorAccent">@color/colorPrimary</item>
+    </style>
+
+    <style name="Stories.Delete.Button" parent="Widget.MaterialComponents.Button">
+        <item name="backgroundTint">?attr/colorOnBackground</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
+    </style>
+
+</resources>

--- a/stories/src/main/res/values-night/styles.xml
+++ b/stories/src/main/res/values-night/styles.xml
@@ -15,7 +15,6 @@
         <item name="colorOnSurface">@android:color/white</item>
         <item name="colorOnError">@android:color/black</item>
         <item name="colorControlActivated">?attr/colorPrimary</item>
-<!--        <item name="colorAccent">?attr/colorPrimary</item>-->
     </style>
 
 </resources>

--- a/stories/src/main/res/values-night/styles.xml
+++ b/stories/src/main/res/values-night/styles.xml
@@ -18,13 +18,4 @@
 <!--        <item name="colorAccent">?attr/colorPrimary</item>-->
     </style>
 
-    <style name="AlertDialogTheme" parent="Theme.MaterialComponents.DayNight.Dialog.Alert">
-        <item name="colorAccent">@color/colorPrimary</item>
-    </style>
-
-    <style name="Stories.Delete.Button" parent="Widget.MaterialComponents.Button">
-        <item name="backgroundTint">?attr/colorOnBackground</item>
-        <item name="android:textColor">?attr/colorOnSurface</item>
-    </style>
-
 </resources>

--- a/stories/src/main/res/values-night/styles.xml
+++ b/stories/src/main/res/values-night/styles.xml
@@ -18,7 +18,7 @@
 <!--        <item name="colorAccent">?attr/colorPrimary</item>-->
     </style>
 
-    <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
+    <style name="AlertDialogTheme" parent="Theme.MaterialComponents.DayNight.Dialog.Alert">
         <item name="colorAccent">@color/colorPrimary</item>
     </style>
 

--- a/stories/src/main/res/values-night/styles.xml
+++ b/stories/src/main/res/values-night/styles.xml
@@ -4,7 +4,7 @@
     <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">?attr/colorPrimary</item>
 
         <item name="android:colorBackground">@color/background_dark</item>
         <item name="colorSurface">@color/background_dark</item>

--- a/stories/src/main/res/values-v28/styles.xml
+++ b/stories/src/main/res/values-v28/styles.xml
@@ -17,7 +17,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme.Immersive" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>

--- a/stories/src/main/res/values-v28/styles.xml
+++ b/stories/src/main/res/values-v28/styles.xml
@@ -20,7 +20,7 @@
     <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">?attr/colorPrimary</item>
         <item name="android:immersive">true</item>
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>

--- a/stories/src/main/res/values/colors.xml
+++ b/stories/src/main/res/values/colors.xml
@@ -42,5 +42,9 @@
     <!-- WordPress colors-->
     <color name="wordpress_blue_50">#006088</color>
     <color name="primary_50">@color/wordpress_blue_50</color>
+    <color name="red_50">#d63638</color>
+    <color name="red_30">#f86368</color>
+    <color name="background_dark">#121212</color>
+    <color name="background_dark_elevated">#2e2e2e</color>
 
 </resources>

--- a/stories/src/main/res/values/colors.xml
+++ b/stories/src/main/res/values/colors.xml
@@ -4,7 +4,7 @@
     <color name="colorPrimaryDark">@color/colorPrimaryDark_wp</color>
     <color name="colorAccent">@color/colorAccent_wp</color>
 
-    <color name="colorPrimary_wp">#006088</color>
+    <color name="colorPrimary_wp">#2271b1</color>
     <color name="colorPrimaryDark_wp">#006088</color>
     <color name="colorAccent_wp">@color/white</color>
 

--- a/stories/src/main/res/values/styles.xml
+++ b/stories/src/main/res/values/styles.xml
@@ -17,10 +17,6 @@
 <!--        <item name="colorAccent">?attr/colorPrimary</item>-->
     </style>
 
-    <style name="AlertDialogTheme" parent="Theme.MaterialComponents.Light.Dialog.Alert">
-        <item name="colorAccent">@color/colorPrimary</item>
-    </style>
-
     <style name="EditText">
         <item name="android:singleLine">true</item>
         <item name="colorControlNormal">#FFFFFF</item>

--- a/stories/src/main/res/values/styles.xml
+++ b/stories/src/main/res/values/styles.xml
@@ -4,7 +4,7 @@
     <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">?attr/colorPrimary</item>
 
         <item name="android:colorBackground">@android:color/white</item>
         <item name="colorSurface">@android:color/white</item>

--- a/stories/src/main/res/values/styles.xml
+++ b/stories/src/main/res/values/styles.xml
@@ -14,7 +14,6 @@
         <item name="colorOnBackground">@android:color/black</item>
         <item name="colorOnSurface">@android:color/black</item>
         <item name="colorOnError">@android:color/white</item>
-<!--        <item name="colorAccent">?attr/colorPrimary</item>-->
     </style>
 
     <style name="EditText">

--- a/stories/src/main/res/values/styles.xml
+++ b/stories/src/main/res/values/styles.xml
@@ -1,10 +1,20 @@
 <resources>
 
     <!-- core creation experience style -->
-    <style name="AppTheme.Immersive" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme.Immersive" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+
+        <item name="android:colorBackground">@android:color/white</item>
+        <item name="colorSurface">@android:color/white</item>
+        <item name="colorError">@color/red_50</item>
+        <item name="colorOnPrimary">@android:color/white</item>
+        <item name="colorOnSecondary">@android:color/white</item>
+        <item name="colorOnBackground">@android:color/black</item>
+        <item name="colorOnSurface">@android:color/black</item>
+        <item name="colorOnError">@android:color/white</item>
+<!--        <item name="colorAccent">?attr/colorPrimary</item>-->
     </style>
 
     <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
@@ -25,6 +35,11 @@
 
     <style name="TransparentBottomSheet" parent="Widget.Design.BottomSheet.Modal">
         <item name="android:background">@android:color/transparent</item>
+    </style>
+
+    <style name="Stories.Delete.Button" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="backgroundTint">?attr/colorOnBackground</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
     </style>
 
 </resources>

--- a/stories/src/main/res/values/styles.xml
+++ b/stories/src/main/res/values/styles.xml
@@ -17,7 +17,7 @@
 <!--        <item name="colorAccent">?attr/colorPrimary</item>-->
     </style>
 
-    <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
+    <style name="AlertDialogTheme" parent="Theme.MaterialComponents.Light.Dialog.Alert">
         <item name="colorAccent">@color/colorPrimary</item>
     </style>
 


### PR DESCRIPTION
Fix #443 

Builds on top of #507 

#### Description
Done in this PR:

- added specific folder `values-night` overriding style for Dark Mode (read setup [here](https://material.io/develop/android/theming/dark))
- moved from `AlertDialog.Builder` to `MaterialAlertDialogBuilder`, also checked https://material.io/develop/android/components/dialogs and https://github.com/wordpress-mobile/WordPress-Android/pull/11164
- added some colors following from the WordPress Android app (may not be strictly needed given not used here, but copied since following along so the host app can override the values if needed)
- applying dark/light mode styles to `NextButton`

For further thought:
- Re: this last point, also looked into how buttons would be themed here https://github.com/material-components/material-components-android/blob/master/docs/components/Button.md, wondering whether the Next button should be a "contained button" and move away from the custom view component solution.but leaving it for a further iteration as it's not being asked for now.
- Also wondering: should we define a dark mode version / coloring for the rest of the controls? (X to close, three dots, frame selector item borders, selected indication, plus control, etc.).

#### To test
On an API 29 device / emulator with dark mode support:
- Check that things look good in both modes
- check with WPAndroid and verify it works alright
- ~[x] Known issue: when tapping on the three dots with the demo app on API 29 in dark mode only, you'll see the status bar appears. It doesn't happen on WPAndroid so, didn't look further (although it would be nice to fix of course).~ fixed in a069a880

**Light mode:**

<img width="409" alt="Screen Shot 2020-08-24 at 20 48 06" src="https://user-images.githubusercontent.com/6597771/91107254-35563800-e64b-11ea-97e8-9d2d1e3489be.png">

<img width="409" alt="Screen Shot 2020-08-24 at 20 48 08" src="https://user-images.githubusercontent.com/6597771/91107248-312a1a80-e64b-11ea-8d14-3b5831ea58a5.png">


**Dark mode:**
<img width="409" alt="Screen Shot 2020-08-24 at 20 47 36" src="https://user-images.githubusercontent.com/6597771/91107275-4141fa00-e64b-11ea-980a-9444bc8b2ebf.png">

<img width="409" alt="Screen Shot 2020-08-24 at 20 47 49" src="https://user-images.githubusercontent.com/6597771/91107268-3be4af80-e64b-11ea-9ef0-8928dcf20902.png">

