### PR TITLE
Handle partial permission granting for video / introduce dialog interface for permanent permission denial

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
@@ -15,8 +15,13 @@ class PermissionUtils {
         val PERMISSION_REQUEST_CODE = 5200
         val REQUIRED_PERMISSIONS = arrayOf(
             Manifest.permission.CAMERA,
-            Manifest.permission.RECORD_AUDIO,
             Manifest.permission.WRITE_EXTERNAL_STORAGE
+        )
+
+        val REQUIRED_PERMISSIONS_WITH_AUDIO = arrayOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.RECORD_AUDIO,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
         )
 
         fun checkPermission(context: Context, permission: String) =
@@ -69,9 +74,17 @@ class PermissionUtils {
         }
 
         fun allRequiredPermissionsGranted(context: Context): Boolean {
-            for (permission in REQUIRED_PERMISSIONS) {
+            return checkPermissionsForArray(context, REQUIRED_PERMISSIONS)
+        }
+
+        fun allVideoPermissionsGranted(context: Context): Boolean {
+            return checkPermissionsForArray(context, REQUIRED_PERMISSIONS_WITH_AUDIO)
+        }
+
+        private fun checkPermissionsForArray(context: Context, permissions: Array<String>): Boolean {
+            for (permission in permissions) {
                 if (ContextCompat.checkSelfPermission(
-                        context, permission) != PackageManager.PERMISSION_GRANTED) {
+                                context, permission) != PackageManager.PERMISSION_GRANTED) {
                     return false
                 }
             }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
@@ -18,6 +18,7 @@ class PermissionUtils {
             Manifest.permission.WRITE_EXTERNAL_STORAGE
         )
 
+        // Video requires access to recording audio (microphone).
         val REQUIRED_PERMISSIONS_WITH_AUDIO = arrayOf(
                 Manifest.permission.CAMERA,
                 Manifest.permission.RECORD_AUDIO,
@@ -45,6 +46,12 @@ class PermissionUtils {
             )
         }
 
+        fun requestAllRequiredPermissionsIncludingAudioForVideo(activity: Activity) {
+            ActivityCompat.requestPermissions(activity, REQUIRED_PERMISSIONS_WITH_AUDIO,
+                    PERMISSION_REQUEST_CODE
+            )
+        }
+        
         fun checkAndRequestPermission(activity: Activity, permission: String): Boolean {
             val isGranted = ContextCompat.checkSelfPermission(activity, permission) == PackageManager.PERMISSION_GRANTED
             if (!isGranted) {
@@ -89,6 +96,21 @@ class PermissionUtils {
                 }
             }
             return true
+        }
+
+        fun anyVideoNeededPermissionPermanentlyDenied(activity: Activity): Boolean {
+            return checkPermanentDenyForPermission(activity, REQUIRED_PERMISSIONS_WITH_AUDIO)
+        }
+
+        private fun checkPermanentDenyForPermission(activity: Activity, permissions: Array<String>): Boolean {
+            for (permission in permissions) {
+                if (ContextCompat.checkSelfPermission(
+                                activity, permission) == PackageManager.PERMISSION_DENIED &&
+                        !ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
+                    return true
+                }
+            }
+            return false
         }
     }
 }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
@@ -51,7 +51,7 @@ class PermissionUtils {
                     PERMISSION_REQUEST_CODE
             )
         }
-        
+
         fun checkAndRequestPermission(activity: Activity, permission: String): Boolean {
             val isGranted = ContextCompat.checkSelfPermission(activity, permission) == PackageManager.PERMISSION_GRANTED
             if (!isGranted) {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
@@ -80,6 +80,15 @@ class PermissionUtils {
             }
         }
 
+        fun allRequestedPermissionsGranted(grantResults: IntArray): Boolean {
+            for (result in grantResults) {
+                if (result != PackageManager.PERMISSION_GRANTED) {
+                    return false
+                }
+            }
+            return true
+        }
+
         fun allRequiredPermissionsGranted(context: Context): Boolean {
             return checkPermissionsForArray(context, REQUIRED_PERMISSIONS)
         }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
@@ -161,7 +161,7 @@ class PermissionUtils {
             )
             val editor: SharedPreferences.Editor = genPrefs.edit()
             editor.putBoolean(permission, true)
-            editor.commit()
+            editor.apply()
         }
 
         private fun isShouldShowPermissionPermanentlyDeniedDialog(

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
@@ -98,19 +98,19 @@ class PermissionUtils {
             return true
         }
 
-        fun anyVideoNeededPermissionPermanentlyDenied(activity: Activity): Boolean {
-            return checkPermanentDenyForPermission(activity, REQUIRED_PERMISSIONS_WITH_AUDIO)
+        fun anyVideoNeededPermissionPermanentlyDenied(activity: Activity): String? {
+            return checkPermanentDenyForPermissions(activity, REQUIRED_PERMISSIONS_WITH_AUDIO)
         }
 
-        private fun checkPermanentDenyForPermission(activity: Activity, permissions: Array<String>): Boolean {
+        private fun checkPermanentDenyForPermissions(activity: Activity, permissions: Array<String>): String? {
             for (permission in permissions) {
                 if (ContextCompat.checkSelfPermission(
                                 activity, permission) == PackageManager.PERMISSION_DENIED &&
                         !ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
-                    return true
+                    return permission
                 }
             }
-            return false
+            return null
         }
     }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -722,7 +722,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (PermissionUtils.allRequiredPermissionsGranted(this)) {
+        if (PermissionUtils.allRequestedPermissionsGranted(grantResults)) {
             onLoadFromIntent(intent)
             permissionsRequestForCameraInProgress = false
         } else if (permissions.isEmpty() || storyViewModel.getCurrentStorySize() == 0) {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -838,7 +838,22 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                         }
                         override fun onHoldingGestureStart() {
                             timesUpHandler.removeCallbacksAndMessages(null)
-                            startRecordingVideoAfterVibrationIndication()
+                            if (PermissionUtils.allVideoPermissionsGranted(this@ComposeLoopFrameActivity)) {
+                                // if we at least have
+                                startRecordingVideoAfterVibrationIndication()
+                            } else {
+                                // request permissions including audio for video
+                                if (PermissionUtils.anyVideoNeededPermissionPermanentlyDenied(
+                                                this@ComposeLoopFrameActivity
+                                        )
+                                ) {
+                                    showToast(getString(R.string.toast_capture_operation_permission_needed))
+                                } else {
+                                    PermissionUtils.requestAllRequiredPermissionsIncludingAudioForVideo(
+                                            this@ComposeLoopFrameActivity
+                                    )
+                                }
+                            }
                         }
 
                         override fun onHoldingGestureEnd() {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -722,6 +722,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        PermissionUtils.processRequestedPermissionsResultAndSave(this, permissions, grantResults)
         if (PermissionUtils.allRequestedPermissionsGranted(grantResults)) {
             onLoadFromIntent(intent)
             permissionsRequestForCameraInProgress = false

--- a/stories/src/main/res/values/strings.xml
+++ b/stories/src/main/res/values/strings.xml
@@ -81,6 +81,7 @@
     <string name="toast_capture_operation_in_progress">Operation in progress, try again</string>
     <string name="toast_error_saving_image">Error saving image</string>
     <string name="toast_error_saving_video">Video could not be saved</string>
+    <string name="toast_capture_operation_permission_needed">You need to grant the app audio recording permission in order to record video</string>
 
     <!-- Typeface labels -->
     <string name="typeface_label_nunito">Casual</string>


### PR DESCRIPTION
Fixes #418 

WordPress Android related PR: https://github.com/wordpress-mobile/WordPress-Android/pull/12845

For recording video, 2 permissions are required: `[CAMERA](https://developer.android.com/reference/android/Manifest.permission#CAMERA)` and `[RECORD_AUDIO](https://developer.android.com/reference/android/Manifest.permission#RECORD_AUDIO)`. This PR makes a few changes as follows:
- allows users to still take image captures with the Stories capture mode even if they have not given permissions to record video
- delay requesting the needed permissions for capturing video when the user actually taps and holds the camera control in capture mode for the first time (so there's no doubt they want video recording and hence, make the permission grant request at the right moment).
- also if the user permanently denied the `RECORD_AUDIO` permission, we now call the `PermanentPermissionDenialDialogProvider` interface to show some dialog (or FWIW, do whatever the host app feels is necessary) explaining why the permission is needed. If the provider is not set, we'll show a generic toast.



### To test
do this with WPAndroid - the demo host app here requests permissions altogether on the main screen so, this flow can't be manually tested here:

#### FLOW A: open media picker from existing in progress Story
0. Deny all permissions (go to settings -> apps -> permissions -> deny each one)
1. Tap on the FAB -> new story
2. when the media picker shows up, tap the pink `allow` button and then allow on the permission dialog. Now select a media item to start the Story
3. now tap on the + on the right - bottom of the screen to add a new Story slide
4. when the media picker shows up, tap on the camera button FAB
5. allow WordPress to take pictures and record video (observe it now does not ask for recording audio at this point as well)
6. observe the camera live preview appears
7. tap on the trigger, and observe the still image gets added to your Story.


#### FLOW B: now try to record a video
Continuing from where you left in FLOW A above:
1. tap on the + on the right - bottom of the screen to add a new Story slide
2. on the media picker, tap on the camera FAB icon
3. the camera live preview appears
4. tap and hold the camera capture control
5. observe the permission request dialog appears
6. tap DENY
7. observe you're back to the story slide picker
8. you can repeat this process many times, it should always stay on the Story with the previous slides you had.

#### FLOW C: deny & don't ask again
Continuing from Flow B above:
1. tap on the + on the right - bottom of the screen to add a new Story slide
2. on the media picker, tap on the camera FAB icon
3. the camera live preview appears
4. tap and hold the camera capture control
5. observe the permission request dialog appears
6. tap DENY & Don't ask again
7. observe you're back to the story slide picker
8. now if you try the flow again and try to tap and hold on the capture control, you'll see the following dialog appears
<img width="394" alt="Screen Shot 2020-08-31 at 18 37 05" src="https://user-images.githubusercontent.com/6597771/91771239-098e0180-ebb9-11ea-9d63-e2fc959ef129.png">


Here's a gif showing all of the previous actions in one go:

![flowa](https://user-images.githubusercontent.com/6597771/91771278-1874b400-ebb9-11ea-81f3-9ba5f797f2bb.gif)






