### PR TITLE
Added views & delete view: pixel color based overlap detection

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
@@ -3,7 +3,6 @@ package com.automattic.photoeditor.gesture
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.Color
-import android.graphics.Point
 import android.graphics.Rect
 import android.view.GestureDetector
 import android.view.MotionEvent
@@ -183,12 +182,12 @@ internal class MultiTouchListener(
 
     fun isViewOverlappingDeleteView(deleteView: View, viewB: View): Boolean {
         // using the View's matrix so the bitmap also has its content rotated and scaled.
-        val bmpForDraggedView =  BitmapUtil.createRotatedBitmapFromViewWithMatrix(viewB)
+        val bmpForDraggedView = BitmapUtil.createRotatedBitmapFromViewWithMatrix(viewB)
 
         val globalVisibleRectB = Rect()
         viewB.getGlobalVisibleRect(globalVisibleRectB)
 
-        val globalVisibleRectDelete= Rect()
+        val globalVisibleRectDelete = Rect()
         deleteView.getGlobalVisibleRect(globalVisibleRectDelete)
 
         return isPixelOverlapping(
@@ -200,8 +199,12 @@ internal class MultiTouchListener(
     // when we find both pixels on the same coordinate for each bitmap being not transparent, that means
     // there is an overlap between both images
     fun isPixelOverlapping(
-        bitmap1: Bitmap, x1: Int, y1: Int,
-        bitmap2: Bitmap, x2: Int, y2: Int
+        bitmap1: Bitmap,
+        x1: Int,
+        y1: Int,
+        bitmap2: Bitmap,
+        x2: Int,
+        y2: Int
     ): Boolean {
         val bounds1 = Rect(
                 x1,

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
@@ -260,14 +260,6 @@ internal class MultiTouchListener(
         this.onMultiTouchListener = onMultiTouchListener
     }
 
-    class RectanglePoints {
-        var points = ArrayList<Point>()
-        constructor(rect: Rect) {
-            points.add(Point(rect.left, rect.top))
-            points.add(Point(rect.right, rect.bottom))
-        }
-    }
-
     private inner class ScaleGestureListener : SimpleOnScaleGestureListener() {
         private var mPivotX: Float = 0.toFloat()
         private var mPivotY: Float = 0.toFloat()

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/BitmapUtil.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/BitmapUtil.kt
@@ -3,6 +3,7 @@ package com.automattic.photoeditor.util
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Matrix
 import android.opengl.GLException
 import android.opengl.GLSurfaceView
 import android.view.View
@@ -130,5 +131,18 @@ internal object BitmapUtil {
                 cropWidth,
                 cropHeight
         )
+    }
+
+    fun createRotatedBitmapFromViewWithMatrix(v: View): Bitmap {
+        val bitmap = Bitmap.createBitmap(
+                v.width,
+                v.height,
+                Bitmap.Config.ARGB_8888
+        )
+        val c = Canvas(bitmap)
+        v.draw(c)
+        val result =
+                Bitmap.createBitmap(bitmap, 0, 0, v.width,v.height, v.matrix, false)
+        return result
     }
 }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/BitmapUtil.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/BitmapUtil.kt
@@ -3,7 +3,6 @@ package com.automattic.photoeditor.util
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
-import android.graphics.Matrix
 import android.opengl.GLException
 import android.opengl.GLSurfaceView
 import android.view.View
@@ -142,7 +141,7 @@ internal object BitmapUtil {
         val c = Canvas(bitmap)
         v.draw(c)
         val result =
-                Bitmap.createBitmap(bitmap, 0, 0, v.width,v.height, v.matrix, false)
+                Bitmap.createBitmap(bitmap, 0, 0, v.width, v.height, v.matrix, false)
         return result
     }
 }


### PR DESCRIPTION
Fixes #339 

This PR implements pixel color check to see if 2 views are overlapping. Basically if both pixels located at the same place have a color other than [Color.TRANSPARENT](https://developer.android.com/reference/android/graphics/Color#TRANSPARENT), then we can be sure these two views are overlapping.

While it's not still perfect given we're calculating the dragged view bitmap with the view's matrix (but not re-creating bigger bitmaps if scaled up too much), there are some false positives with really large stickers (for example long angled text), but the experience is way better now than before and I think it's in an acceptable condition. With false positives I mean, angled text will be detected sometimes when approaching the delete view (trash icon) bounds but not visually overlapping; this is still better than not being able to delete large stickers at all as per what the issue describes. I noticed this only happens when a long text is angled to the right, but seems to work very well when angled to the left (maybe this is just a feeling).
**EDIT**: there can also be some times when detection doesn't happen right away and you have to move your finger closer to the trash icon. Not all the times and only with long boxes (long text). Again, not perfect, but way better than what we had.

[Here's a video](https://cloudup.com/cvND00yY5bN) showing this on a Samsung J2. 

To test:
1. open the demo app
2. add a view
3. drag it to the trash icon, observe it only changes to "about to delete" appearance when there's actual overlap.
4. resize, rotate, etc. and drag again, confirm you notice the improvement.




