### PR TITLE
Only show video player error dialog if the error corresponds to the current slide

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
@@ -42,7 +42,9 @@ import java.io.IOException
 
 interface PlayerPreparedListener {
     fun onPlayerPrepared()
-    fun onPlayerError()
+    // onPlayerError takes what and extra from MediaPlayer's OnErrorListener.onError() method signature
+    // https://developer.android.com/reference/android/media/MediaPlayer.OnErrorListener
+    fun onPlayerError(uri: Uri, what: Int? = 0, extra: Int? = 0, exception: Exception? = null)
 }
 
 class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlayerSoundOnOffHandler {
@@ -176,6 +178,10 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
                         playerPreparedListener?.onPlayerPrepared()
                         it.start()
                     }
+                    setOnErrorListener { mp, what, extra ->
+                        playerPreparedListener?.onPlayerError(Uri.fromFile(file), what, extra)
+                        true
+                    }
                     prepareAsync()
                     setVolume(if (isMuted) 0f else 1f, if (isMuted) 0f else 1f)
                 }
@@ -209,7 +215,7 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
                         it.setLooping(true)
                     }
                     setOnErrorListener { mp, what, extra ->
-                        playerPreparedListener?.onPlayerError()
+                        playerPreparedListener?.onPlayerError(uri, what, extra)
                         true
                     }
                     setOnCompletionListener {
@@ -222,18 +228,24 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
                 }
             }
         } catch (e: IllegalArgumentException) {
-            playerPreparedListener?.onPlayerError()
+            playerPreparedListener?.onPlayerError(uri = getCurrentUri(), exception = e)
             e.printStackTrace()
         } catch (e: SecurityException) {
-            playerPreparedListener?.onPlayerError()
+            playerPreparedListener?.onPlayerError(uri = getCurrentUri(), exception = e)
             e.printStackTrace()
         } catch (e: IllegalStateException) {
-            playerPreparedListener?.onPlayerError()
+            playerPreparedListener?.onPlayerError(uri = getCurrentUri(), exception = e)
             e.printStackTrace()
         } catch (e: IOException) {
-            playerPreparedListener?.onPlayerError()
+            playerPreparedListener?.onPlayerError(uri = getCurrentUri(), exception = e)
             e.printStackTrace()
         }
+    }
+
+    private fun getCurrentUri(): Uri {
+        return currentFile?.let {
+            return Uri.fromFile(currentFile)
+        } ?: requireNotNull(currentExternalUri)
     }
 
     override fun mute() {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.view.TextureView
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.Event.ON_CREATE
@@ -17,11 +16,8 @@ import androidx.lifecycle.Lifecycle.Event.ON_PAUSE
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.OnLifecycleEvent
-import com.automattic.photoeditor.R
 import com.automattic.photoeditor.camera.Camera2BasicHandling
 import com.automattic.photoeditor.camera.CameraXBasicHandling
-import com.automattic.photoeditor.camera.ErrorDialog
-import com.automattic.photoeditor.camera.ErrorDialogOk
 import com.automattic.photoeditor.camera.PlayerPreparedListener
 import com.automattic.photoeditor.camera.VideoPlayingBasicHandling
 import com.automattic.photoeditor.camera.interfaces.CameraSelection
@@ -45,6 +41,12 @@ interface BackgroundSurfaceManagerReadyListener {
     fun onBackgroundSurfaceManagerReady()
 }
 
+interface VideoPlayerErrorListener {
+    // onPlayerError takes what and extra from MediaPlayer's OnErrorListener.onError() method signature
+    // https://developer.android.com/reference/android/media/MediaPlayer.OnErrorListener
+    fun onPlayerError(uri: Uri, what: Int? = 0, extra: Int? = 0, exception: Exception? = null)
+}
+
 class BackgroundSurfaceManager(
     private val savedInstanceState: Bundle?,
     private val lifeCycle: Lifecycle,
@@ -53,6 +55,7 @@ class BackgroundSurfaceManager(
     private val flashSupportChangeListener: FlashSupportChangeListener,
     private val useCameraX: Boolean,
     private val managerReadyListener: BackgroundSurfaceManagerReadyListener? = null,
+    private val videoPlayerErrorListener: VideoPlayerErrorListener? = null,
     private val authenticationHeadersInterface: AuthenticationHeadersInterface? = null
 ) : LifecycleObserver {
     private lateinit var cameraBasicHandler: VideoRecorderFragment
@@ -410,18 +413,9 @@ class BackgroundSurfaceManager(
                         photoEditorView.hideLoading()
                     }
 
-                    override fun onPlayerError() {
+                    override fun onPlayerError(uri: Uri, what: Int?, extra: Int?, exception: Exception?) {
                         photoEditorView.hideLoading()
-                        ErrorDialog.newInstance(requireNotNull(videoPlayerHandling.context)
-                                .getString(R.string.toast_error_playing_video),
-                                    object : ErrorDialogOk {
-                                        override fun OnOkClicked(dialog: DialogFragment) {
-                                            dialog.dismiss()
-                                        }
-                                    }
-                                ).show(supportFragmentManager,
-                                        FRAGMENT_DIALOG
-                                )
+                        videoPlayerErrorListener?.onPlayerError(uri, what, extra, exception)
                     }
                 }
 

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -45,6 +45,8 @@ import com.automattic.photoeditor.text.FontResolver
 import com.automattic.photoeditor.OnPhotoEditorListener
 import com.automattic.photoeditor.PhotoEditor
 import com.automattic.photoeditor.SaveSettings
+import com.automattic.photoeditor.camera.ErrorDialog
+import com.automattic.photoeditor.camera.ErrorDialogOk
 import com.automattic.photoeditor.text.TextStyler
 import com.automattic.photoeditor.camera.interfaces.CameraSelection
 import com.automattic.photoeditor.camera.interfaces.FlashIndicatorState
@@ -54,6 +56,7 @@ import com.automattic.photoeditor.camera.interfaces.VideoRecorderFragment.FlashS
 import com.automattic.photoeditor.state.AuthenticationHeadersInterface
 import com.automattic.photoeditor.state.BackgroundSurfaceManager
 import com.automattic.photoeditor.state.BackgroundSurfaceManagerReadyListener
+import com.automattic.photoeditor.state.VideoPlayerErrorListener
 import com.automattic.photoeditor.util.FileUtils
 import com.automattic.photoeditor.util.FileUtils.Companion.getLoopFrameFile
 import com.automattic.photoeditor.text.IdentifiableTypeface
@@ -440,6 +443,40 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                     } else if (launchVideoPlayerRequestPending) {
                         launchVideoPlayerRequestPending = false
                         showPlayVideoWithSurfaceSafeguard(launchVideoPlayerRequestPendingSource)
+                    }
+                }
+            },
+            object : VideoPlayerErrorListener {
+                override fun onPlayerError(uri: Uri, what: Int?, extra: Int?, exception: Exception?) {
+                    // only show dialog if the player error is for a background source that is currently
+                    // being shown. This will prevent showing an error dialog for a Story slide that the user
+                    // has already changed / switched away from.
+                    var doShowDialog = false
+                    storyViewModel.getCurrentStoryFrameAt(storyViewModel.getSelectedFrameIndex())?.let {
+                        if (it.source is UriBackgroundSource) {
+                            it.source.contentUri?.let { sourceUri ->
+                                if (sourceUri.equals(uri)) {
+                                    doShowDialog = true
+                                }
+                            }
+                        } else {
+                            (it.source as FileBackgroundSource).file?.let { sourceFile ->
+                                if (Uri.fromFile(sourceFile).equals(uri)) {
+                                    doShowDialog = true
+                                }
+                            }
+                        }
+                    }
+
+                    if (doShowDialog) {
+                        ErrorDialog.newInstance(requireNotNull(this@ComposeLoopFrameActivity)
+                                .getString(com.automattic.photoeditor.R.string.toast_error_playing_video),
+                                object : ErrorDialogOk {
+                                    override fun OnOkClicked(dialog: DialogFragment) {
+                                        dialog.dismiss()
+                                    }
+                                }
+                        ).show(supportFragmentManager, FRAGMENT_DIALOG)
                     }
                 }
             },


### PR DESCRIPTION
Fix #437 

**tl;dr** it doesn't make sense to show an error dialog for a video that is not on the screen anymore.

Been checking the error handling and I think it's in good shape so for the specific case described in the issue I think it's OK to present a Dialog. So instead of trying to silence or change any of that, what I did in this PR is:
- elevate the error handling for video playing from `BackgroundSurfaceManager` up to the Activity through a new `VidePlayerErrorListener` interface
- at the ComposeLoopFrameActivity level, we know about `Story slides` , so we can check whether an error coming from the video player corresponds to the current slide being presented on the screen by comparing the video player `Uri` and that of the current slide's `BackgroundSource`. Then if these match, we're good to show the dialog.


To test:
- You can try with a corrupt video or alternatively, having a few slides and a couple of video slides and then switching slides frantically would eventually make the dialog appear, but only if the slide matches.
- You could try this before and after: before, you'll get several dialogs. After, you'll get _less_ dialogs.
- Alternatively, you can add logs and observe how sometimes the error listener is called but the current slide differs and as such, the dialog showing code is not called.

