### PR TITLE
Add tracking interface + track text changed event

### DIFF
--- a/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
@@ -15,6 +16,7 @@ import com.automattic.loop.photopicker.MediaBrowserType
 import com.automattic.loop.photopicker.PhotoPickerActivity
 import com.automattic.loop.photopicker.PhotoPickerFragment
 import com.automattic.loop.photopicker.RequestCodes
+import com.automattic.loop.util.ANALYTICS_TAG
 import com.automattic.loop.util.CopyExternalUrisLocallyUseCase
 import com.google.android.material.snackbar.Snackbar
 import com.wordpress.stories.compose.ComposeLoopFrameActivity
@@ -23,6 +25,7 @@ import com.wordpress.stories.compose.MetadataProvider
 import com.wordpress.stories.compose.NotificationIntentLoader
 import com.wordpress.stories.compose.PrepublishingEventProvider
 import com.wordpress.stories.compose.SnackbarProvider
+import com.wordpress.stories.compose.StoriesAnalyticsListener
 import com.wordpress.stories.compose.StoryDiscardListener
 import com.wordpress.stories.compose.story.StoryIndex
 import kotlinx.coroutines.CoroutineScope
@@ -45,6 +48,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     NotificationIntentLoader,
     MetadataProvider,
     StoryDiscardListener,
+    StoriesAnalyticsListener,
     PrepublishingEventProvider,
     CoroutineScope {
     private var job: Job = Job()
@@ -59,6 +63,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         setNotificationExtrasLoader(this)
         setMetadataProvider(this)
         setStoryDiscardListener(this) // optionally listen to discard events
+        setStoriesAnalyticsListener(this)
         setPrepublishingEventProvider(this)
         setNotificationTrackerProvider(application as Loop) // optionally set Notification Tracker.
         // The notifiationTracker needs to be something that outlives the Activity, given the Service could be running
@@ -152,12 +157,6 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         return bundle
     }
 
-    companion object {
-        const val KEY_EXAMPLE_METADATA = "key_example_metadata"
-        const val KEY_STORY_INDEX = "key_story_index"
-        const val BASE_FRAME_MEDIA_ERROR_NOTIFICATION_ID: Int = 72300
-    }
-
     override fun onStoryDiscarded() {
         // example: do any cleanup you may need here
         Toast.makeText(this, "Story has been discarded!", Toast.LENGTH_SHORT).show()
@@ -165,5 +164,15 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
 
     override fun onStorySaveButtonPressed() {
         processStorySaving()
+    }
+
+    override fun trackStoryTextChanged(properties: Map<String, *>) {
+        Log.i(ANALYTICS_TAG, "story_text_changed: $properties")
+    }
+
+    companion object {
+        const val KEY_EXAMPLE_METADATA = "key_example_metadata"
+        const val KEY_STORY_INDEX = "key_story_index"
+        const val BASE_FRAME_MEDIA_ERROR_NOTIFICATION_ID: Int = 72300
     }
 }

--- a/app/src/main/java/com/automattic/loop/util/Consts.kt
+++ b/app/src/main/java/com/automattic/loop/util/Consts.kt
@@ -1,3 +1,4 @@
 package com.automattic.loop.util
 
 const val INVALID_RESOURCE_ID = 0
+const val ANALYTICS_TAG = "ANALYTICS"

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -375,6 +375,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                         editModeRestoreAllUIControls()
                     }
                 })
+                textEditorDialogFragment.setAnalyticsEventListener(analyticsListener)
             }
 
             override fun onAddViewListener(viewType: ViewType, numberOfAddedViews: Int) {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -216,6 +216,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private var authHeadersProvider: AuthenticationHeadersProvider? = null
     private var metadataProvider: MetadataProvider? = null
     private var storyDiscardListener: StoryDiscardListener? = null
+    private var analyticsListener: StoriesAnalyticsListener? = null
     private var notificationTrackerProvider: NotificationTrackerProvider? = null
     private var prepublishingEventProvider: PrepublishingEventProvider? = null
     private var firstIntentLoaded: Boolean = false
@@ -1950,6 +1951,10 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     fun setStoryDiscardListener(listener: StoryDiscardListener) {
         storyDiscardListener = listener
+    }
+
+    fun setStoriesAnalyticsListener(listener: StoriesAnalyticsListener) {
+        analyticsListener = listener
     }
 
     fun setNotificationTrackerProvider(provider: NotificationTrackerProvider) {

--- a/stories/src/main/java/com/wordpress/stories/compose/StoriesAnalyticsListener.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/StoriesAnalyticsListener.kt
@@ -1,0 +1,5 @@
+package com.wordpress.stories.compose
+
+interface StoriesAnalyticsListener {
+    fun trackStoryTextChanged(properties: Map<String, *>)
+}

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorAnalyticsHandler.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorAnalyticsHandler.kt
@@ -1,0 +1,22 @@
+package com.wordpress.stories.compose.text
+
+class TextEditorAnalyticsHandler(private val callback: (properties: Map<String, *>) -> Unit) {
+    private var textStyle = ANALYTICS_PROPERTY_TEXT_STYLE_VALUE_UNCHANGED
+
+    fun trackTextStyleToggled(newStyle: String) {
+        textStyle = newStyle
+    }
+
+    fun report() = callback.invoke(assembleProperties())
+
+    private fun assembleProperties(): Map<String, *> {
+        return mapOf(
+                ANALYTICS_PROPERTY_KEY_TEXT_STYLE to textStyle
+        )
+    }
+
+    companion object {
+        const val ANALYTICS_PROPERTY_KEY_TEXT_STYLE = "text_style"
+        const val ANALYTICS_PROPERTY_TEXT_STYLE_VALUE_UNCHANGED = "unchanged"
+    }
+}

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -33,6 +33,7 @@ class TextEditorDialogFragment : DialogFragment() {
     private lateinit var textStyleGroupManager: TextStyleGroupManager
 
     private var analyticsListener: StoriesAnalyticsListener? = null
+    private var textEditorAnalyticsHandler: TextEditorAnalyticsHandler? = null
 
     interface TextEditor {
         fun onDone(inputText: String, textStyler: TextStyler)
@@ -122,12 +123,14 @@ class TextEditorDialogFragment : DialogFragment() {
             dismiss()
             val inputText = add_text_edit_text.text.toString()
             textEditor?.onDone(inputText, TextStyler.from(add_text_edit_text, typefaceId))
+            textEditorAnalyticsHandler?.report()
         }
     }
 
     override fun onDismiss(dialog: DialogInterface) {
         val inputText = add_text_edit_text?.text.toString()
         textEditor?.onDone(inputText, TextStyler.from(add_text_edit_text, typefaceId))
+        textEditorAnalyticsHandler?.report()
         super.onDismiss(dialog)
     }
 
@@ -138,6 +141,7 @@ class TextEditorDialogFragment : DialogFragment() {
 
     fun setAnalyticsEventListener(listener: StoriesAnalyticsListener?) {
         analyticsListener = listener
+        textEditorAnalyticsHandler = TextEditorAnalyticsHandler { analyticsListener?.trackStoryTextChanged(it) }
     }
 
     private fun updateTextAlignment(textAlignment: TextAlignment) {

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -88,6 +88,7 @@ class TextEditorDialogFragment : DialogFragment() {
                 typefaceId = textStyleGroupManager.getNextTypeface(typefaceId)
                 textStyleGroupManager.styleTextView(typefaceId, add_text_edit_text)
                 textStyleGroupManager.styleAndLabelTextView(typefaceId, text_style_toggle_button)
+                trackTextStyleToggled()
             }
         }
 
@@ -164,6 +165,10 @@ class TextEditorDialogFragment : DialogFragment() {
             TextAlignment.CENTER -> R.drawable.ic_gridicons_align_center_32
             TextAlignment.RIGHT -> R.drawable.ic_gridicons_align_right_32
         })
+    }
+
+    private fun trackTextStyleToggled() {
+        textEditorAnalyticsHandler?.trackTextStyleToggled(textStyleGroupManager.getAnalyticsLabelFor(typefaceId))
     }
 
     companion object {

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.automattic.photoeditor.text.IdentifiableTypeface.TypefaceId
 import com.automattic.photoeditor.text.TextStyler
 import com.wordpress.stories.R
+import com.wordpress.stories.compose.StoriesAnalyticsListener
 import kotlinx.android.synthetic.main.add_text_dialog.*
 import kotlinx.android.synthetic.main.add_text_dialog.view.*
 
@@ -30,6 +31,8 @@ class TextEditorDialogFragment : DialogFragment() {
     private var textEditor: TextEditor? = null
 
     private lateinit var textStyleGroupManager: TextStyleGroupManager
+
+    private var analyticsListener: StoriesAnalyticsListener? = null
 
     interface TextEditor {
         fun onDone(inputText: String, textStyler: TextStyler)
@@ -131,6 +134,10 @@ class TextEditorDialogFragment : DialogFragment() {
     // Callback to listener if user is done with text editing
     fun setOnTextEditorListener(textEditor: TextEditor) {
         this.textEditor = textEditor
+    }
+
+    fun setAnalyticsEventListener(listener: StoriesAnalyticsListener?) {
+        analyticsListener = listener
     }
 
     private fun updateTextAlignment(textAlignment: TextAlignment) {

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -122,9 +122,6 @@ class TextEditorDialogFragment : DialogFragment() {
         add_text_done_tv?.setOnClickListener { _ ->
             dialog?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN)
             dismiss()
-            val inputText = add_text_edit_text.text.toString()
-            textEditor?.onDone(inputText, TextStyler.from(add_text_edit_text, typefaceId))
-            textEditorAnalyticsHandler?.report()
         }
     }
 

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextStyleGroupManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextStyleGroupManager.kt
@@ -16,6 +16,7 @@ import androidx.core.content.res.ResourcesCompat
 import com.automattic.photoeditor.text.IdentifiableTypeface
 import com.automattic.photoeditor.text.IdentifiableTypeface.TypefaceId
 import com.wordpress.stories.R
+import java.util.Locale
 import java.util.TreeMap
 
 /**
@@ -133,6 +134,10 @@ class TextStyleGroupManager(val context: Context) {
      */
     fun getNextTypeface(@TypefaceId typefaceId: Int): Int {
         return supportedTypefaces.higherKey(typefaceId) ?: supportedTypefaces.firstKey()
+    }
+
+    fun getAnalyticsLabelFor(@TypefaceId typefaceId: Int): String {
+        return supportedTypefaces[typefaceId]?.label?.toLowerCase(Locale.ROOT).orEmpty()
     }
 
     private fun TextView.setShadowLayer(shadowLayer: ShadowLayer?) {


### PR DESCRIPTION
Partially addresses #476.

Adds a basic `StoriesAnalyticsListener` to be implemented in the host app, which tunnels over generic events.

For now there's only one event, `storyTextChanged`.

I also added a `TextEditorAnalyticsHandler` to centrally manage the properties for `storyTextChanged` in the editor. This is because we don't want to fire an event on action, but instead report on the state of the text at the time the user is done with the text editor. For now we're only interested in knowing the relative popularity of the different text styles.

~Leaving it draft for now until I get to implement the WPAndroid PR, but interested in any early thoughts/feedback on the implementation @mzorz, I know you had some specific thoughts here.~

WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/13006

### To test
Run the loop app, and look for ANALYTICS events in the console.
Open the text editor, add text, then go back and edit it. Each time the editor is closed, you should see an event like this:

`com.automattic.loop I/ANALYTICS: story_text_changed: {text_style=classic}`

Check that if you don't interact with the text style button, the event looks like this:

`com.automattic.loop I/ANALYTICS: story_text_changed: {text_style=unchanged}`