### PR TITLE
Force non-null type in ComposeLoopFrameActivity.kt

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -502,7 +502,9 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             permissionsRequestForCameraInProgress = savedInstanceState.getBoolean(STATE_KEY_PERMISSION_REQ_IN_PROGRESS)
 
             storyViewModel.loadStory(
-                StorySerializerUtils.deserializeStory(savedInstanceState.getString(STATE_KEY_STORY_SAVE_STATE))
+                StorySerializerUtils.deserializeStory(
+                        requireNotNull(savedInstanceState.getString(STATE_KEY_STORY_SAVE_STATE))
+                )
             )
 
             val selectedFrameIndex = savedInstanceState.getInt(STATE_KEY_STORY_SAVE_STATE_SELECTED_FRAME)


### PR DESCRIPTION
This PR wraps bundle.getString() call with `requireNotNull`.  `StorySerializerUtils.deserializeStory` accepts only non-nullable String. This change is required so we can migrate WPAndroid to SDK 29.