### PR TITLE
Keep composed frame file & expose stories list

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameItem.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameItem.kt
@@ -9,7 +9,6 @@ import com.wordpress.stories.compose.story.StoryFrameItemType.IMAGE
 import kotlinx.serialization.Decoder
 import kotlinx.serialization.Encoder
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Transient
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer
 import kotlinx.serialization.internal.ArrayListSerializer
@@ -22,7 +21,7 @@ data class StoryFrameItem(
     @Serializable(with = AddedViewListSerializer::class)
     var addedViews: AddedViewList = AddedViewList(),
     var saveResultReason: SaveResultReason = SaveSuccess,
-    @Transient
+    @Serializable(with = FileSerializer::class)
     var composedFrameFile: File? = null
 ) {
     @Serializable

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
@@ -53,6 +53,10 @@ object StoryRepository {
         return stories[index]
     }
 
+    @JvmStatic fun getImmutableStories(): List<Story> {
+        return stories.toList()
+    }
+
     private fun createNewStory(): StoryIndex {
         val story = Story(ArrayList())
         stories.add(story)


### PR DESCRIPTION
This PR adds 2 very small changes that make it easier for a host app to interact and retrieve content from serialization and the live internal StoryRepository:
- e22e671 removes the `@Transient`  annotation from `composedFrameFile` and ensures it gets serialized with `FileSerializer`, this way it's always present and can the flattened filename can be retrieved later
- c9ffa96 allows library consumers to get the full current list of Stories available in the live StoryRepository, which makes it easier for iteration when you're interested in finding all frames for any Story that match a certain criteria.
