### PR TITLE
Add id field to StoryFrameItem

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameItem.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameItem.kt
@@ -5,7 +5,9 @@ import com.automattic.photoeditor.views.added.AddedView
 import com.automattic.photoeditor.views.added.AddedViewList
 import com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason
 import com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason.SaveSuccess
+import com.wordpress.stories.compose.story.StoryFrameItem.BackgroundSource.UriBackgroundSource
 import com.wordpress.stories.compose.story.StoryFrameItemType.IMAGE
+import com.wordpress.stories.compose.story.StoryFrameItemType.VIDEO
 import kotlinx.serialization.Decoder
 import kotlinx.serialization.Encoder
 import kotlinx.serialization.KSerializer
@@ -22,7 +24,8 @@ data class StoryFrameItem(
     var addedViews: AddedViewList = AddedViewList(),
     var saveResultReason: SaveResultReason = SaveSuccess,
     @Serializable(with = FileSerializer::class)
-    var composedFrameFile: File? = null
+    var composedFrameFile: File? = null,
+    var id: String? = null
 ) {
     @Serializable
     sealed class BackgroundSource {
@@ -71,6 +74,20 @@ data class StoryFrameItem(
 
         override fun serialize(output: Encoder, addedViews: AddedViewList) {
             output.encodeSerializableValue(ArrayListSerializer(AddedView.serializer()), addedViews)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun getNewStoryFrameItemFromUri(uri: Uri, isVideo: Boolean): StoryFrameItem {
+            return StoryFrameItem(
+                    UriBackgroundSource(uri),
+                    if (isVideo) {
+                        VIDEO(false)
+                    } else {
+                        IMAGE
+                    }
+            )
         }
     }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
@@ -13,10 +13,11 @@ typealias StoryIndex = Int
 object StoryRepository {
     const val DEFAULT_NONE_SELECTED = -1
     const val DEFAULT_FRAME_NONE_SELECTED = -1
+    @JvmField
     var currentStoryIndex = DEFAULT_NONE_SELECTED
-        private set
     private val stories = ArrayList<Story>()
 
+    @JvmStatic
     fun loadStory(storyIndex: StoryIndex): Story? {
         when {
             storyIndex == DEFAULT_NONE_SELECTED -> {
@@ -39,6 +40,7 @@ object StoryRepository {
         }
     }
 
+    @JvmStatic
     fun loadStory(story: Story): StoryIndex {
         stories.add(story)
         currentStoryIndex = stories.size - 1
@@ -57,6 +59,20 @@ object StoryRepository {
         return stories.toList()
     }
 
+    @JvmStatic
+    fun findStoryContainingStoryFrameItemsByIds(ids: ArrayList<String>): StoryIndex {
+        // now look for a Story in the StoryRepository that has all these frames and, if not found, let's
+        // just build the Story object ourselves to keep these files arrangement
+        for ((index, story) in stories.withIndex()) {
+            // find the MediaModel for a given Uri from composedFrameFile
+            if (story.frames.filter { ids.contains(it.id) }.size == ids.size) {
+                // here we found the story whose frames collection contains all of the passed ids
+                return index
+            }
+        }
+        return DEFAULT_NONE_SELECTED
+    }
+
     private fun createNewStory(): StoryIndex {
         val story = Story(ArrayList())
         stories.add(story)
@@ -64,6 +80,7 @@ object StoryRepository {
         return currentStoryIndex
     }
 
+    @JvmStatic
     fun addStoryFrameItemToCurrentStory(item: StoryFrameItem) {
         if (!isStoryIndexValid(currentStoryIndex)) return
         stories[currentStoryIndex].frames.add(item)


### PR DESCRIPTION
This PR builds on top of #519 - together these are needed for the Story block handling on WPAndroid. 

This PR adds the `id` field (which in the context of the Stories library can be nullable and of general purpose) and exposes / adds helper methods to find and create StoryFrameItem instances easily.

To test:
N/A