### PR TITLE
Fix story load by index

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -209,7 +209,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private var saveServiceBound: Boolean = false
     private var preHookRun: Boolean = false
     private var storyIndexToSelect = -1
-    private var storyFrameIndexToRetry: FrameIndex = StoryRepository.DEFAULT_NONE_SELECTED
+    private var storyFrameIndexToRetry: FrameIndex = StoryRepository.DEFAULT_FRAME_NONE_SELECTED
     private var snackbarProvider: SnackbarProvider? = null
     private var mediaPickerProvider: MediaPickerProvider? = null
     private var notificationIntentLoader: NotificationIntentLoader? = null

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -511,6 +511,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             if (selectedFrameIndex < storyViewModel.getCurrentStorySize()) {
                 storyViewModel.setSelectedFrame(selectedFrameIndex)
             }
+        } else {
+            onLoadFromIntent(intent)
         }
     }
 
@@ -643,6 +645,10 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         if (storyViewModel.getCurrentStoryIndex() == StoryRepository.DEFAULT_NONE_SELECTED) {
             storyViewModel.loadStory(storyIndexToSelect)
             storyIndexToSelect = storyViewModel.getCurrentStoryIndex()
+        } else if (StoryRepository.getStoryAtIndex(storyIndexToSelect).frames.isNotEmpty()) {
+            storyViewModel.loadStory(storyIndexToSelect)
+            refreshStoryFrameSelection()
+            return
         }
 
         if (intent.hasExtra(requestCodes.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED) ||
@@ -674,11 +680,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             )
             addFramesToStoryFromMediaUriList(uriList)
             setDefaultSelectionAndUpdateBackgroundSurfaceUI(uriList)
-        } else if (storyIndexToSelect != StoryRepository.DEFAULT_NONE_SELECTED) {
-            if (StoryRepository.getStoryAtIndex(storyIndexToSelect).frames.isNotEmpty()) {
-                storyViewModel.loadStory(storyIndexToSelect)
-                refreshStoryFrameSelection()
-            }
         }
     }
 

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -511,7 +511,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             if (selectedFrameIndex < storyViewModel.getCurrentStorySize()) {
                 storyViewModel.setSelectedFrame(selectedFrameIndex)
             }
-        } else {
+        } else if (storyIndexToSelect != StoryRepository.DEFAULT_NONE_SELECTED) {
             onLoadFromIntent(intent)
         }
     }
@@ -645,7 +645,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         if (storyViewModel.getCurrentStoryIndex() == StoryRepository.DEFAULT_NONE_SELECTED) {
             storyViewModel.loadStory(storyIndexToSelect)
             storyIndexToSelect = storyViewModel.getCurrentStoryIndex()
-        } else if (StoryRepository.getStoryAtIndex(storyIndexToSelect).frames.isNotEmpty()) {
+        } else if (storyIndexToSelect != StoryRepository.DEFAULT_NONE_SELECTED &&
+                StoryRepository.getStoryAtIndex(storyIndexToSelect).frames.isNotEmpty()) {
             storyViewModel.loadStory(storyIndexToSelect)
             refreshStoryFrameSelection()
             return

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -648,7 +648,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         } else if (storyIndexToSelect != StoryRepository.DEFAULT_NONE_SELECTED &&
                 StoryRepository.getStoryAtIndex(storyIndexToSelect).frames.isNotEmpty()) {
             storyViewModel.loadStory(storyIndexToSelect)
-            refreshStoryFrameSelection()
             return
         }
 


### PR DESCRIPTION
This PR builds on top of #520 

This PR adds a missing call to`onLoadFromInent()` in `onCreate()` which will take care of loading a pre-existing Story when it didn't come from getting a call to `onNewIntent()` (the other path would be error notifications, which worked well in that case, but no in `onCreate` since this is the first time we're going to fire up a ComposeLoopFrameActivity with an actual non empty Story to get loaded).

Also, we moved the story loading handling by index up so that case gets handled right away if the story index is being passed in the intent.

To test:
N/A, do this in conjunction with https://github.com/wordpress-mobile/WordPress-Android/pull/12939
1. open a story block that has been created elsewhere
2. tap on the story block's tool icon
3. observe the story gets loaded on the composer

Also:
- verify the other flows still work: create a new story and tap the camera icon first, create a new story and select media from device to start it with, create a new story and select media from WPMedia, etc.
