### PR TITLE
Added flags to allow library consumers to use temporary or permanent files for capture

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/Camera2BasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/Camera2BasicHandling.kt
@@ -720,7 +720,11 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
             /**
              * create video output file
              */
-            currentFile = FileUtils.getTempCaptureFile(activity, true)
+            if (useTempCaptureFile) {
+                currentFile = FileUtils.getTempCaptureFile(activity, true)
+            } else {
+                currentFile = FileUtils.getLoopFrameFile(activity, true)
+            }
             currentFile?.createNewFile()
 
             /**
@@ -840,7 +844,11 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
     override fun takePicture(onImageCapturedListener: ImageCaptureListener) {
         // Create output file to hold the image
         activity?.let {
-            currentFile = FileUtils.getTempCaptureFile(it, false)
+            if (useTempCaptureFile) {
+                currentFile = FileUtils.getTempCaptureFile(it, false)
+            } else {
+                currentFile = FileUtils.getLoopFrameFile(it, false)
+            }
         }
         currentFile?.createNewFile()
 
@@ -954,10 +962,12 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
 
         @JvmStatic fun getInstance(
             textureView: AutoFitTextureView,
-            flashSupportChangeListener: FlashSupportChangeListener
+            flashSupportChangeListener: FlashSupportChangeListener,
+            useTempCaptureFile: Boolean
         ): Camera2BasicHandling {
             instance.textureView = textureView
             instance.flashSupportChangeListener = flashSupportChangeListener
+            instance.useTempCaptureFile = useTempCaptureFile
             return instance
         }
     }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt
@@ -164,7 +164,11 @@ class CameraXBasicHandling : VideoRecorderFragment() {
     @SuppressLint("RestrictedApi")
     override fun startRecordingVideo(finishedListener: VideoRecorderFinished?) {
         activity?.let {
-            currentFile = FileUtils.getTempCaptureFile(it, true)
+            if (useTempCaptureFile) {
+                currentFile = FileUtils.getTempCaptureFile(it, true)
+            } else {
+                currentFile = FileUtils.getLoopFrameFile(it, true)
+            }
         }
 
         currentFile?.let {
@@ -226,7 +230,11 @@ class CameraXBasicHandling : VideoRecorderFragment() {
     override fun takePicture(onImageCapturedListener: ImageCaptureListener) {
         // Create output file to hold the image
         context?.let { context ->
-            currentFile = FileUtils.getTempCaptureFile(context, false).apply { createNewFile() }
+            if (useTempCaptureFile) {
+                currentFile = FileUtils.getTempCaptureFile(context, false).apply { createNewFile() }
+            } else {
+                currentFile = FileUtils.getLoopFrameFile(context, false).apply { createNewFile() }
+            }
 
             currentFile?.let {
                 // Setup image capture metadata
@@ -326,10 +334,12 @@ class CameraXBasicHandling : VideoRecorderFragment() {
 
         @JvmStatic fun getInstance(
             textureView: AutoFitTextureView,
-            flashSupportChangeListener: FlashSupportChangeListener
+            flashSupportChangeListener: FlashSupportChangeListener,
+            useTempCaptureFile: Boolean
         ): CameraXBasicHandling {
             instance.textureView = textureView
             instance.flashSupportChangeListener = flashSupportChangeListener
+            instance.useTempCaptureFile = useTempCaptureFile
             return instance
         }
     }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/interfaces/VideoRecorderFragment.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/interfaces/VideoRecorderFragment.kt
@@ -27,6 +27,7 @@ abstract class VideoRecorderFragment : Fragment(),
             prop, old, new -> flashSupportChangeListener.onFlashSupportChanged(new)
         }
     )
+    var useTempCaptureFile = true
 
     interface FlashSupportChangeListener {
         fun onFlashSupportChanged(isSupported: Boolean)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
@@ -53,7 +53,8 @@ class BackgroundSurfaceManager(
     private val flashSupportChangeListener: FlashSupportChangeListener,
     private val useCameraX: Boolean,
     private val managerReadyListener: BackgroundSurfaceManagerReadyListener? = null,
-    private val authenticationHeadersInterface: AuthenticationHeadersInterface? = null
+    private val authenticationHeadersInterface: AuthenticationHeadersInterface? = null,
+    var useTempCaptureFile: Boolean = true
 ) : LifecycleObserver {
     private lateinit var cameraBasicHandler: VideoRecorderFragment
     private lateinit var videoPlayerHandling: VideoPlayingBasicHandling
@@ -360,7 +361,7 @@ class BackgroundSurfaceManager(
                 val cameraFragment = supportFragmentManager.findFragmentByTag(KEY_CAMERA_HANDLING_FRAGMENT_TAG)
                 if (cameraFragment == null) {
                     cameraBasicHandler = CameraXBasicHandling.getInstance(photoEditorView.textureView,
-                        flashSupportChangeListener)
+                        flashSupportChangeListener, useTempCaptureFile)
                     supportFragmentManager
                         .beginTransaction().add(cameraBasicHandler, KEY_CAMERA_HANDLING_FRAGMENT_TAG).commit()
                 } else {
@@ -369,6 +370,7 @@ class BackgroundSurfaceManager(
                     // the photoEditorView layout has been recreated so, re-assign its TextureView
                     cameraBasicHandler.textureView = photoEditorView.textureView
                     cameraBasicHandler.flashSupportChangeListener = flashSupportChangeListener
+                    cameraBasicHandler.useTempCaptureFile = useTempCaptureFile
                 }
             }
             CAMERA2 -> {
@@ -376,7 +378,7 @@ class BackgroundSurfaceManager(
                 val cameraFragment = supportFragmentManager.findFragmentByTag(KEY_CAMERA_HANDLING_FRAGMENT_TAG)
                 if (cameraFragment == null) {
                     cameraBasicHandler = Camera2BasicHandling.getInstance(photoEditorView.textureView,
-                        flashSupportChangeListener)
+                        flashSupportChangeListener, useTempCaptureFile)
                     supportFragmentManager
                         .beginTransaction().add(cameraBasicHandler, KEY_CAMERA_HANDLING_FRAGMENT_TAG).commit()
                 } else {
@@ -385,6 +387,7 @@ class BackgroundSurfaceManager(
                     // the photoEditorView layout has been recreated so, re-assign its TextureView
                     cameraBasicHandler.textureView = photoEditorView.textureView
                     cameraBasicHandler.flashSupportChangeListener = flashSupportChangeListener
+                    cameraBasicHandler.useTempCaptureFile = useTempCaptureFile
                 }
                 // add camera handling texture listener
                 photoEditorView.listeners.add((cameraBasicHandler as Camera2BasicHandling).surfaceTextureListener)

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -221,12 +221,14 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private var firstIntentLoaded: Boolean = false
     protected var permissionsRequestForCameraInProgress: Boolean = false
     private var permissionDenialDialogProvider: PermanentPermissionDenialDialogProvider? = null
+    private var useTempCaptureFile = true
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, service: IBinder) {
             Log.d("ComposeLoopFrame", "onServiceConnected()")
             val binder = service as FrameSaveService.FrameSaveServiceBinder
             frameSaveService = binder.getService()
+            frameSaveService.useTempCaptureFile = useTempCaptureFile
 
             // keep these as they're changing when we call `storyViewModel.finishCurrentStory()`
             val storyIndex = storyViewModel.getCurrentStoryIndex()
@@ -448,7 +450,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                     }
                 }
             },
-            authHeaderInterfaceBridge
+                authHeaderInterfaceBridge,
+                useTempCaptureFile
         )
 
         lifecycle.addObserver(backgroundSurfaceManager)
@@ -1963,6 +1966,14 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     fun setPermissionDialogProvider(provider: PermanentPermissionDenialDialogProvider) {
         permissionDenialDialogProvider = provider
+    }
+
+    // true: default, files are created in the internal app directory and these will be cleaned on exit
+    // false: we won't do cleanup and the files will be saved on the app's output directory
+    fun setUseTempCaptureFile(useTempFiles: Boolean) {
+        this.useTempCaptureFile = useTempFiles
+        this.storyViewModel.useTempCaptureFile = useTempFiles
+        this.backgroundSurfaceManager.useTempCaptureFile = useTempFiles
     }
 
     class ExternalMediaPickerRequestCodesAndExtraKeys {

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -43,6 +43,7 @@ class FrameSaveService : Service() {
     private var optionalMetadata: Bundle? = null // keeps optional metadata about the Story
     private var notificationErrorBaseId: Int = 700 // default
     private var notificationTrackerProvider: NotificationTrackerProvider? = null
+    var useTempCaptureFile: Boolean = true
 
     override fun onCreate() {
         super.onCreate()
@@ -146,7 +147,9 @@ class FrameSaveService : Service() {
             // remove the processor from the list once it's done processing this Story's frames
             storySaveProcessors.remove(processor)
 
-            cleanUpTempStoryFrameFiles(storyFrames.filter { it.saveResultReason == SaveSuccess })
+            if (useTempCaptureFile) {
+                cleanUpTempStoryFrameFiles(storyFrames.filter { it.saveResultReason == SaveSuccess })
+            }
 
             // also if more than one processor is running, let's not stop the Service just now.
             if (storySaveProcessors.isEmpty()) {

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
@@ -14,6 +14,7 @@ import com.wordpress.stories.util.SingleLiveEvent
 
 class StoryViewModel(private val repository: StoryRepository, val storyIndex: StoryIndex) : ViewModel() {
     private var currentSelectedFrameIndex: Int = DEFAULT_SELECTION
+    var useTempCaptureFile = true
 
     private val _uiState: MutableLiveData<StoryFrameListUiState> = MutableLiveData()
     val uiState: LiveData<StoryFrameListUiState> = _uiState
@@ -69,7 +70,9 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
     }
 
     fun discardCurrentStory() {
-        FrameSaveService.cleanUpTempStoryFrameFiles(getImmutableCurrentStoryFrames())
+        if (useTempCaptureFile) {
+            FrameSaveService.cleanUpTempStoryFrameFiles(getImmutableCurrentStoryFrames())
+        }
         repository.discardCurrentStory()
         currentSelectedFrameIndex = DEFAULT_SELECTION // default selected frame when loading a new Story
         _onSelectedFrameIndex.value = Pair(DEFAULT_SELECTION, currentSelectedFrameIndex)
@@ -178,7 +181,9 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
 
     fun removeFrameAt(pos: Int) {
         // delete any temporal files
-        FrameSaveService.cleanUpTempStoryFrameFiles(getImmutableCurrentStoryFrames().subList(pos, pos + 1))
+        if (useTempCaptureFile) {
+            FrameSaveService.cleanUpTempStoryFrameFiles(getImmutableCurrentStoryFrames().subList(pos, pos + 1))
+        }
 
         // remove from the repo
         repository.removeFrameAt(pos)


### PR DESCRIPTION
Builds on top of #527 

This came from the need in WPAndroid to be able to reload a given unflattened Story saved elsewhere with background media that was captured using the camera capture mode of ComposeLoopFrameActivity.

Up until now, we would just use an internal temporary file to hold the media and then get rid of such file upon discarding the Story or finishing the Activity, but now we need to be able to retrieve the original media to reconstruct the Story slide properly at a later point in time.

Hence, it made sense to provide this option to the consumer of the library, which is indicated through the newly added method `setUseTempCaptureFile()` in `ComposeLoopFrameActivity`.

The flag is propagated and checked everywhere else in the library to:
- use an ordinary file (accessible from outside the app) instead of an internal directory file for capturing
- make checks everywhere where needed so to avoid cleaning up the files

If you call `setUseTempCaptureFile(false)`, no captured media will be deleted.

To test:
1. use the WPAndroid related PR for the Story block (https://github.com/wordpress-mobile/WordPress-Android/pull/12939)
2. verify you can create a story with an image captured in the stories capture mode
3. publish it
4. open the post in the editor
5. tap on the story block's tool icon
6. verify the story slide gets rendered properly (background image is not a black box, and added views show on top).

