### PR TITLE
Show different discard dialog messaging when editing

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -99,6 +99,7 @@ import com.wordpress.stories.compose.story.StoryViewModel.StoryFrameListItemUiSt
 import com.wordpress.stories.compose.story.StoryViewModelFactory
 import com.wordpress.stories.compose.text.TextEditorDialogFragment
 import com.wordpress.stories.compose.text.TextStyleGroupManager
+import com.wordpress.stories.util.KEY_STORY_EDIT_MODE
 import com.wordpress.stories.util.KEY_STORY_SAVE_RESULT
 import com.wordpress.stories.util.STATE_KEY_CURRENT_STORY_INDEX
 import com.wordpress.stories.util.getDisplayPixelSize
@@ -930,10 +931,18 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                     // add discard dialog
                     if (storyViewModel.anyOfCurrentStoryFramesHasViews()) {
                         // show dialog
+                        var discardTitle = getString(R.string.dialog_discard_story_title)
+                        var discardMessage = getString(R.string.dialog_discard_story_message)
+                        var discardOkButton = getString(R.string.dialog_discard_story_ok_button)
+                        if (intent.getBooleanExtra(KEY_STORY_EDIT_MODE, false)) {
+                            discardTitle = getString(R.string.dialog_discard_story_title_edit)
+                            discardMessage = getString(R.string.dialog_discard_story_message_edit)
+                            discardOkButton = getString(R.string.dialog_discard_story_ok_button_edit)
+                        }
                         FrameSaveErrorDialog.newInstance(
-                            title = getString(R.string.dialog_discard_story_title),
-                            message = getString(R.string.dialog_discard_story_message),
-                            okButtonLabel = getString(R.string.dialog_discard_story_ok_button),
+                            title = discardTitle,
+                            message = discardMessage,
+                            okButtonLabel = discardOkButton,
                             listener = object : FrameSaveErrorDialogOk {
                                 override fun OnOkClicked(dialog: DialogFragment) {
                                     dialog.dismiss()

--- a/stories/src/main/java/com/wordpress/stories/util/BundleUtils.kt
+++ b/stories/src/main/java/com/wordpress/stories/util/BundleUtils.kt
@@ -28,6 +28,7 @@ fun getStoryIndexFromIntentOrBundle(savedInstanceState: Bundle?, intent: Intent?
     return index
 }
 
+const val KEY_STORY_EDIT_MODE = "key_story_edit_mode"
 const val KEY_STORY_INDEX = "key_story_index"
 const val KEY_STORY_SAVE_RESULT = "key_story_save_result"
 const val STATE_KEY_CURRENT_STORY_INDEX = "key_current_story_index"

--- a/stories/src/main/res/values/strings.xml
+++ b/stories/src/main/res/values/strings.xml
@@ -39,6 +39,10 @@
     <string name="dialog_discard_story_message">Your story post will not be saved as a draft.</string>
     <string name="dialog_discard_story_ok_button">Discard</string>
 
+    <string name="dialog_discard_story_title_edit">Discard changes?</string>
+    <string name="dialog_discard_story_message_edit">Any changes made will be lost.</string>
+    <string name="dialog_discard_story_ok_button_edit">Discard</string>
+
     <!--preference keys-->
     <string name="pref_camera_selection" translatable="false">pref_camera_selection</string>
     <string name="pref_flash_mode_selection" translatable="false">pref_flash_mode_selection</string>


### PR DESCRIPTION
This PR builds on top of https://github.com/Automattic/stories-android/pull/528

Here we added `KEY_STORY_EDIT_MODE` intent boolean extra to decide showing specific discard dialog confirmation text for a new Story or an existing one being edited.

#### Exiting the Story composer on a new story
<img width="394" alt="Screen Shot 2020-09-16 at 14 16 48" src="https://user-images.githubusercontent.com/6597771/93370920-ec4b6b00-f827-11ea-95ff-5134900397e5.png">

#### Exiting the Story composer on a pre-existing story  being edited
<img width="394" alt="Screen Shot 2020-09-16 at 14 16 16" src="https://user-images.githubusercontent.com/6597771/93370897-e190d600-f827-11ea-90ef-a99b5c45c4b3.png">

**_Please consider the messaging and confirm this is ok / feel free to suggest a better phrasing._**

To test:
CASE A: new story
1. start a new story with a  slide
2. add a view (text, emoji)
3. tap on the cross  and observe the first dialog shows.

CASE B: existing story
1. using WPAndroid Story Block PR https://github.com/wordpress-mobile/WordPress-Android/pull/12939
2. create a story and publish it
3. go to posts list and open the newly created post
4. tap on the story block tool icon
5. observe the story loads in the composer
6. tap on the X or tap back
7. observe the second dialog shows.

