### PR TITLE
Introduce the GenericAnnouncementDialogProvider interface

### DIFF
--- a/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
@@ -18,6 +18,8 @@ import com.automattic.loop.photopicker.RequestCodes
 import com.automattic.loop.util.CopyExternalUrisLocallyUseCase
 import com.google.android.material.snackbar.Snackbar
 import com.wordpress.stories.compose.ComposeLoopFrameActivity
+import com.wordpress.stories.compose.FrameSaveErrorDialog
+import com.wordpress.stories.compose.GenericAnnouncementDialogProvider
 import com.wordpress.stories.compose.MediaPickerProvider
 import com.wordpress.stories.compose.MetadataProvider
 import com.wordpress.stories.compose.NotificationIntentLoader
@@ -46,6 +48,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     MetadataProvider,
     StoryDiscardListener,
     PrepublishingEventProvider,
+    GenericAnnouncementDialogProvider,
     CoroutineScope {
     private var job: Job = Job()
 
@@ -61,6 +64,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         setStoryDiscardListener(this) // optionally listen to discard events
         setPrepublishingEventProvider(this)
         setNotificationTrackerProvider(application as Loop) // optionally set Notification Tracker.
+        setGenericAnnouncementDialogProvider(this)
         // The notifiationTracker needs to be something that outlives the Activity, given the Service could be running
         // after the user has exited ComposeLoopFrameActivity
     }
@@ -153,6 +157,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     companion object {
+        protected const val FRAGMENT_DIALOG = "dialog"
         const val KEY_EXAMPLE_METADATA = "key_example_metadata"
         const val KEY_STORY_INDEX = "key_story_index"
         const val BASE_FRAME_MEDIA_ERROR_NOTIFICATION_ID: Int = 72300
@@ -165,5 +170,12 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
 
     override fun onStorySaveButtonPressed() {
         processStorySaving()
+    }
+
+    override fun showGenericAnnouncementDialog() {
+        FrameSaveErrorDialog.newInstance(
+                title = getString(R.string.dialog_general_announcement_title),
+                message = getString(R.string.dialog_general_announcement_title)
+        ).show(supportFragmentManager, FRAGMENT_DIALOG)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,9 @@
     <string name="photo_picker_wpmedia_desc">pick from WordPress media</string>
     <string name="content_description_person_reading_device_notification">Person reading device with notifications</string>
 
+    <string name="dialog_general_announcement_title">General announcement</string>
+    <string name="dialog_general_announcement_message">This is an announcement you can make from the host app</string>
+
     <!-- Photo picker - Loop   -->
     <string name="photo_picker_add_photos_to_story">Choose the photos and videos you\'d like to add to your story</string>
     <!-- SD Card errors -->

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -172,6 +172,10 @@ interface PermanentPermissionDenialDialogProvider {
     fun showPermissionPermanentlyDeniedDialog(permission: String)
 }
 
+interface GenericAnnouncementDialogProvider {
+    fun showGenericAnnouncementDialog()
+}
+
 interface StoryDiscardListener {
     fun onStoryDiscarded()
 }
@@ -222,6 +226,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private var firstIntentLoaded: Boolean = false
     protected var permissionsRequestForCameraInProgress: Boolean = false
     private var permissionDenialDialogProvider: PermanentPermissionDenialDialogProvider? = null
+    private var genericAnnouncementDialogProvider: GenericAnnouncementDialogProvider? = null
+    private var showGenericAnnouncementDialogWhenReady = false
     private var useTempCaptureFile = true
 
     private val connection = object : ServiceConnection {
@@ -526,6 +532,11 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         if (selectedFrameIndex < storyViewModel.getCurrentStorySize()) {
             updateBackgroundSurfaceUIWithStoryFrame(selectedFrameIndex)
         }
+        // upon loading an existing Story, show the generic announcement dialog if present
+        if (showGenericAnnouncementDialogWhenReady) {
+            showGenericAnnouncementDialogWhenReady = false
+            genericAnnouncementDialogProvider?.showGenericAnnouncementDialog()
+        }
     }
 
     private fun setupStoryViewModelObservers() {
@@ -652,6 +663,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         } else if (storyIndexToSelect != StoryRepository.DEFAULT_NONE_SELECTED &&
                 StoryRepository.getStoryAtIndex(storyIndexToSelect).frames.isNotEmpty()) {
             storyViewModel.loadStory(storyIndexToSelect)
+            showGenericAnnouncementDialogWhenReady = true
             return
         }
 
@@ -1983,6 +1995,10 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         this.useTempCaptureFile = useTempFiles
         this.storyViewModel.useTempCaptureFile = useTempFiles
         this.backgroundSurfaceManager.useTempCaptureFile = useTempFiles
+    }
+
+    fun setGenericAnnouncementDialogProvider(provider: GenericAnnouncementDialogProvider) {
+        genericAnnouncementDialogProvider = provider
     }
 
     class ExternalMediaPickerRequestCodesAndExtraKeys {

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
@@ -13,11 +13,9 @@ typealias StoryIndex = Int
 object StoryRepository {
     const val DEFAULT_NONE_SELECTED = -1
     const val DEFAULT_FRAME_NONE_SELECTED = -1
-    @JvmField
     var currentStoryIndex = DEFAULT_NONE_SELECTED
     private val stories = ArrayList<Story>()
 
-    @JvmStatic
     fun loadStory(storyIndex: StoryIndex): Story? {
         when {
             storyIndex == DEFAULT_NONE_SELECTED -> {
@@ -40,7 +38,6 @@ object StoryRepository {
         }
     }
 
-    @JvmStatic
     fun loadStory(story: Story): StoryIndex {
         stories.add(story)
         currentStoryIndex = stories.size - 1
@@ -51,11 +48,11 @@ object StoryRepository {
         return storyIndex > DEFAULT_NONE_SELECTED && stories.size > storyIndex
     }
 
-    @JvmStatic fun getStoryAtIndex(index: StoryIndex): Story {
+    fun getStoryAtIndex(index: StoryIndex): Story {
         return stories[index]
     }
 
-    @JvmStatic fun getImmutableStories(): List<Story> {
+    fun getImmutableStories(): List<Story> {
         return stories.toList()
     }
 
@@ -80,7 +77,6 @@ object StoryRepository {
         return currentStoryIndex
     }
 
-    @JvmStatic
     fun addStoryFrameItemToCurrentStory(item: StoryFrameItem) {
         if (!isStoryIndexValid(currentStoryIndex)) return
         stories[currentStoryIndex].frames.add(item)


### PR DESCRIPTION
This PR builds on top of #529 

This PR calls a listener when a Story has been loaded by intent using KEY_STORY_INDEX and the views are about to be presented, so this way the host app / listener can present a Dialog.

It is used in the WPAndroid app to show the "Limited editing experience" dialog depending on whether the passed Story could be completely loaded or was only re-created from the flattened images being passed as per background sources for one or more slides.

<img width="394" alt="Screen Shot 2020-09-16 at 15 20 45" src="https://user-images.githubusercontent.com/6597771/93377967-24f04200-f832-11ea-9d87-4d472703176a.png">


To test:
1. use https://github.com/wordpress-mobile/WordPress-Android/pull/12939
2. create a story and publish it
3. delete / reinstall the app (or run the app on another device) and log in
4. go to posts list and open the story post
5. tap on the story block tool icon
6. observe the story is loaded and the dialog appears as shown in the capture above.


