### PR TITLE
Introduce done button name change

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -503,6 +503,10 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
         setupStoryViewModelObservers()
 
+        if (intent.getBooleanExtra(KEY_STORY_EDIT_MODE, false)) {
+            next_button.setText(getString(R.string.label_control_edit_done))
+        }
+
         if (savedInstanceState != null) {
             currentOriginalCapturedFile =
                 savedInstanceState.getSerializable(STATE_KEY_CURRENT_ORIGINAL_CAPTURED_FILE) as File?

--- a/stories/src/main/java/com/wordpress/stories/compose/NextButton.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/NextButton.kt
@@ -36,4 +36,8 @@ class NextButton @JvmOverloads constructor(
         super.setEnabled(enabled)
         invalidate()
     }
+
+    fun setText(newText: String) {
+        findViewById<TextView>(R.id.next_button_text).text = newText
+    }
 }

--- a/stories/src/main/res/values/strings.xml
+++ b/stories/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="label_share_to">Share to</string>
     <string name="label_done">Done</string>
     <string name="label_control_publish">Next</string>
+    <string name="label_control_edit_done">Done</string>
 
     <!-- content description labels   -->
     <string name="label_close_button">Close</string>


### PR DESCRIPTION
This PR builds on top of #530 

The NEXT button now can change its label to DONE when entering EDIT_MODE.

To test:
1. use https://github.com/wordpress-mobile/WordPress-Android/pull/12939
2. create a story and publish it (observe when this is a new story, the button label is NEXT).
3. go to posts list, tap on the new post
4. tap on the story block's tool icon
5. the story loads in the StoryComposer, observe the NEXT button now reads "DONE".

