### PR TITLE
Added EditMode flag passing to SaveResult

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -236,6 +236,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             val binder = service as FrameSaveService.FrameSaveServiceBinder
             frameSaveService = binder.getService()
             frameSaveService.useTempCaptureFile = useTempCaptureFile
+            frameSaveService.isEditMode = intent.getBooleanExtra(KEY_STORY_EDIT_MODE, false)
 
             // keep these as they're changing when we call `storyViewModel.finishCurrentStory()`
             val storyIndex = storyViewModel.getCurrentStoryIndex()

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -44,6 +44,7 @@ class FrameSaveService : Service() {
     private var notificationErrorBaseId: Int = 700 // default
     private var notificationTrackerProvider: NotificationTrackerProvider? = null
     var useTempCaptureFile: Boolean = true
+    var isEditMode: Boolean = false
 
     override fun onCreate() {
         super.onCreate()
@@ -137,7 +138,7 @@ class FrameSaveService : Service() {
             // also hold a reference to it in the storySaveProcessors list in case the Service is destroyed, so
             // we can cancel each coroutine.
             val isRetry = frameIndex > StoryRepository.DEFAULT_NONE_SELECTED
-            val processor = createProcessor(storyIndex, frameIndex, photoEditor, isRetry)
+            val processor = createProcessor(storyIndex, frameIndex, photoEditor, isRetry, isEditMode)
             storySaveProcessors.add(processor)
             runProcessor(
                 processor,
@@ -172,7 +173,8 @@ class FrameSaveService : Service() {
         storyIndex: StoryIndex,
         frameIndex: FrameIndex,
         photoEditor: PhotoEditor,
-        isRetry: Boolean
+        isRetry: Boolean,
+        isEditMode: Boolean
     ): StorySaveProcessor {
         return StorySaveProcessor(
             this,
@@ -181,6 +183,7 @@ class FrameSaveService : Service() {
             frameSaveNotifier,
             FrameSaveManager(photoEditor),
             isRetry,
+            isEditMode,
             FrameSaveTimeTracker(),
             metadata = optionalMetadata
         )
@@ -279,10 +282,11 @@ class FrameSaveService : Service() {
         private val frameSaveNotifier: FrameSaveNotifier,
         private val frameSaveManager: FrameSaveManager,
         private val isRetry: Boolean,
+        private val isEditMode: Boolean,
         val timeTracker: FrameSaveTimeTracker,
         private val metadata: Bundle? = null
     ) : FrameSaveProgressListener {
-        val storySaveResult = StorySaveResult(isRetry = isRetry, metadata = metadata)
+        val storySaveResult = StorySaveResult(isRetry = isRetry, isEditMode = isEditMode, metadata = metadata)
         val title =
             StoryRepository.getStoryAtIndex(storyIndex).title ?: context.getString(R.string.story_saving_untitled)
 

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
@@ -14,6 +14,7 @@ class StorySaveEvents {
         var storyIndex: StoryIndex = 0,
         val frameSaveResult: MutableList<FrameSaveResult> = mutableListOf(),
         val isRetry: Boolean = false,
+        val isEditMode: Boolean = false,
         var elapsedTime: Long = 0,
         val metadata: Bundle? = null
     ) : Parcelable {


### PR DESCRIPTION
Title has it - part of the work needed for Stories editing processing - when a Story is edited,  a flag will be kept and shall be passed on through to the caller through the `StorySaveResult` as well.