### PR TITLE
Color picker v2: 1 - Add bottom sheet

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/text/ColorPickerBottomSheetHandler.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/ColorPickerBottomSheetHandler.kt
@@ -53,7 +53,7 @@ class ColorPickerBottomSheetHandler(val activity: Activity, val view: View) {
                     heightDifference -= activity.resources.getDimensionPixelSize(resourceIdStatus)
                 }
 
-                if (heightDifference > 150) {
+                if (heightDifference > KEYBOARD_MINIMUM_HEIGHT) {
                     keyboardHeight = heightDifference
                     rootView.viewTreeObserver?.removeOnGlobalLayoutListener(this)
                 }
@@ -143,5 +143,10 @@ class ColorPickerBottomSheetHandler(val activity: Activity, val view: View) {
 
     companion object {
         const val BOTTOM_SHEET_DISPLAY_DELAY_MS = 300L
+
+        // A minimum valid keyboard height.
+        // If the screen height changes by at least this amount, we assume it's because a software keyboard
+        // has been displayed.
+        const val KEYBOARD_MINIMUM_HEIGHT = 150
     }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/text/ColorPickerBottomSheetHandler.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/ColorPickerBottomSheetHandler.kt
@@ -21,6 +21,14 @@ class ColorPickerBottomSheetHandler(val activity: Activity, val view: View) {
     private val bottomSheetLayout: View = view.findViewById(R.id.bottom_sheet_layout)
     private val bottomSheetContainer: ViewGroup = view.findViewById(R.id.bottom_sheet_container)
 
+    private val defaultBottomSheetHeight by lazy {
+        activity.resources.getDimensionPixelSize(R.dimen.color_picker_bottom_sheet_default_height)
+    }
+
+    private val maxBottomSheetMargin by lazy {
+        activity.resources.getDimensionPixelSize(R.dimen.color_picker_bottom_sheet_height_max_margin)
+    }
+
     init {
         captureKeyboardHeight()
     }
@@ -91,10 +99,6 @@ class ColorPickerBottomSheetHandler(val activity: Activity, val view: View) {
 
         rootView.postDelayed({
             // Set bottom sheet to the keyboard height
-            val defaultBottomSheetHeight =
-                    activity.resources.getDimensionPixelSize(R.dimen.color_picker_bottom_sheet_default_height)
-            val maxBottomSheetMargin =
-                    activity.resources.getDimensionPixelSize(R.dimen.color_picker_bottom_sheet_height_max_margin)
             with(bottomSheetLayout.layoutParams) {
                 // Resize the bottom sheet to match the keyboard height, so the text is kept at around the same
                 // height on the screen.

--- a/stories/src/main/java/com/wordpress/stories/compose/text/ColorPickerBottomSheetHandler.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/ColorPickerBottomSheetHandler.kt
@@ -1,0 +1,133 @@
+package com.wordpress.stories.compose.text
+
+import android.app.Activity
+import android.content.Context
+import android.graphics.Rect
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewTreeObserver
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.wordpress.stories.R
+
+class ColorPickerBottomSheetHandler(val activity: Activity, val view: View) {
+    private val bottomSheetBehavior by lazy { initBottomSheet() }
+    private var keyboardHeight: Int = 0
+    private var originalViewHeight: Int = 0
+
+    private val editText: EditText = view.findViewById(R.id.add_text_edit_text)
+    private val mainLayout: View = view.findViewById(R.id.main_layout)
+    private val bottomSheetLayout: View = view.findViewById(R.id.bottom_sheet_layout)
+    private val bottomSheetContainer: ViewGroup = view.findViewById(R.id.bottom_sheet_container)
+
+    init {
+        captureKeyboardHeight()
+    }
+
+    private fun captureKeyboardHeight() {
+        val rootView = activity.window?.decorView?.rootView
+
+        rootView?.viewTreeObserver?.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+            override fun onGlobalLayout() {
+                val r = Rect()
+                rootView.getWindowVisibleDisplayFrame(r)
+                val screenHeight: Int = rootView.height
+                var heightDifference = screenHeight - (r.bottom - r.top)
+
+                val resourceIdNav = activity.resources.getIdentifier("navigation_bar_height", "dimen", "android")
+                if (resourceIdNav > 0) {
+                    heightDifference -= activity.resources.getDimensionPixelSize(resourceIdNav)
+                }
+
+                if (heightDifference > 150) {
+                    keyboardHeight = heightDifference
+                    rootView.viewTreeObserver?.removeOnGlobalLayoutListener(this)
+                }
+            }
+        })
+    }
+
+    private fun initBottomSheet(): BottomSheetBehavior<out ViewGroup> {
+        val bottomSheetCallback = object : BottomSheetBehavior.BottomSheetCallback() {
+            override fun onStateChanged(bottomSheet: View, newState: Int) {
+                if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
+                    // Restore the view's original size
+                    with(mainLayout.layoutParams) { height = originalViewHeight }
+
+                    // Show the keyboard
+                    editText.requestFocus()
+                    with(activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager) {
+                        showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT)
+                    }
+                }
+            }
+
+            override fun onSlide(bottomSheet: View, slideOffset: Float) {}
+        }
+
+        val bottomSheetBehavior = BottomSheetBehavior.from(bottomSheetContainer).apply {
+            addBottomSheetCallback(bottomSheetCallback)
+        }
+
+        originalViewHeight = mainLayout.measuredHeight + keyboardHeight
+
+        return bottomSheetBehavior
+    }
+
+    fun toggleBottomSheet() {
+        if (bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+            hideBottomSheet()
+        } else {
+            showBottomSheet(view)
+        }
+    }
+
+    private fun showBottomSheet(rootView: View) {
+        // Hide the software keyboard
+        with(activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager) {
+            hideSoftInputFromWindow(rootView.windowToken, 0)
+        }
+
+        rootView.postDelayed({
+            // Set bottom sheet to the keyboard height
+            val defaultBottomSheetHeight =
+                    activity.resources.getDimensionPixelSize(R.dimen.color_picker_bottom_sheet_default_height)
+            val maxBottomSheetMargin =
+                    activity.resources.getDimensionPixelSize(R.dimen.color_picker_bottom_sheet_height_max_margin)
+            with(bottomSheetLayout.layoutParams) {
+                // Resize the bottom sheet to match the keyboard height, so the text is kept at around the same
+                // height on the screen.
+                // Fall back to default height if there's no keyboard, or the keyboard is too short or too tall.
+                if (keyboardHeight > defaultBottomSheetHeight &&
+                        keyboardHeight < defaultBottomSheetHeight + maxBottomSheetMargin) {
+                    height = keyboardHeight
+                    bottomSheetLayout.layoutParams = this
+                }
+            }
+
+            // Shift layout up so text is still centered on screen
+            with(mainLayout.layoutParams) {
+                val bottomSheetHeight = if (bottomSheetLayout.layoutParams.height > 0) {
+                    bottomSheetLayout.layoutParams.height
+                } else {
+                    defaultBottomSheetHeight
+                }
+                height = originalViewHeight - bottomSheetHeight
+                mainLayout.layoutParams = this
+            }
+
+            // Show the bottom sheet
+            bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+        }, BOTTOM_SHEET_DISPLAY_DELAY_MS)
+    }
+
+    fun hideBottomSheet() {
+        // This will trigger additional view adjustment logic via BottomSheetCallback
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+    }
+
+    companion object {
+        const val BOTTOM_SHEET_DISPLAY_DELAY_MS = 300L
+    }
+}

--- a/stories/src/main/java/com/wordpress/stories/compose/text/ColorPickerBottomSheetHandler.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/ColorPickerBottomSheetHandler.kt
@@ -48,6 +48,11 @@ class ColorPickerBottomSheetHandler(val activity: Activity, val view: View) {
                     heightDifference -= activity.resources.getDimensionPixelSize(resourceIdNav)
                 }
 
+                val resourceIdStatus = activity.resources.getIdentifier("status_bar_height", "dimen", "android")
+                if (resourceIdStatus > 0 && r.top != 0) {
+                    heightDifference -= activity.resources.getDimensionPixelSize(resourceIdStatus)
+                }
+
                 if (heightDifference > 150) {
                     keyboardHeight = heightDifference
                     rootView.viewTreeObserver?.removeOnGlobalLayoutListener(this)

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -105,6 +105,12 @@ class TextEditorDialogFragment : DialogFragment() {
         val layoutManager = LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
         addTextColorPickerRecyclerView.layoutManager = layoutManager
         addTextColorPickerRecyclerView.setHasFixedSize(true)
+
+        // Hide the bottom sheet if the user taps in the EditText
+        add_text_edit_text.setOnClickListener {
+            hideBottomSheet()
+        }
+
         activity?.let {
             val colorPickerAdapter = ColorPickerAdapter(it)
             // This listener will change the text color when clicked on any color from picker

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -34,6 +34,7 @@ class TextEditorDialogFragment : DialogFragment() {
 
     private var analyticsListener: StoriesAnalyticsListener? = null
     private var textEditorAnalyticsHandler: TextEditorAnalyticsHandler? = null
+    private var bottomSheetHandler: ColorPickerBottomSheetHandler? = null
 
     interface TextEditor {
         fun onDone(inputText: String, textStyler: TextStyler)
@@ -63,10 +64,16 @@ class TextEditorDialogFragment : DialogFragment() {
         return inflater.inflate(R.layout.add_text_dialog, container, false)
     }
 
+    override fun onStop() {
+        dialog?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN)
+        bottomSheetHandler?.hideBottomSheet()
+        super.onStop()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val bottomSheetHandler = activity?.let {
+        bottomSheetHandler = activity?.let {
             ColorPickerBottomSheetHandler(it, view)
         }
 

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -2,12 +2,14 @@ package com.wordpress.stories.compose.text
 
 import android.content.Context
 import android.content.DialogInterface
+import android.graphics.Rect
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -35,6 +37,8 @@ class TextEditorDialogFragment : DialogFragment() {
     private var analyticsListener: StoriesAnalyticsListener? = null
     private var textEditorAnalyticsHandler: TextEditorAnalyticsHandler? = null
 
+    private var keyboardHeight: Int = 0
+
     interface TextEditor {
         fun onDone(inputText: String, textStyler: TextStyler)
     }
@@ -43,6 +47,31 @@ class TextEditorDialogFragment : DialogFragment() {
         super.onAttach(context)
 
         textStyleGroupManager = TextStyleGroupManager(context)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val rootView = activity?.window?.decorView?.rootView
+
+        rootView?.viewTreeObserver?.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+            override fun onGlobalLayout() {
+                val r = Rect()
+                rootView.getWindowVisibleDisplayFrame(r)
+                val screenHeight: Int = rootView.height
+                var heightDifference = screenHeight - (r.bottom - r.top)
+
+                val resourceIdNav = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+                if (resourceIdNav > 0) {
+                    heightDifference -= resources.getDimensionPixelSize(resourceIdNav)
+                }
+
+                if (heightDifference > 150) {
+                    keyboardHeight = heightDifference
+                    rootView.viewTreeObserver?.removeOnGlobalLayoutListener(this)
+                }
+            }
+        })
     }
 
     override fun onStart() {

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -2,24 +2,19 @@ package com.wordpress.stories.compose.text
 
 import android.content.Context
 import android.content.DialogInterface
-import android.graphics.Rect
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewTreeObserver
 import android.view.WindowManager
-import android.view.inputmethod.InputMethodManager
-import android.widget.RelativeLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.automattic.photoeditor.text.IdentifiableTypeface.TypefaceId
 import com.automattic.photoeditor.text.TextStyler
-import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.wordpress.stories.R
 import com.wordpress.stories.compose.StoriesAnalyticsListener
 import kotlinx.android.synthetic.main.add_text_dialog.*
@@ -40,10 +35,6 @@ class TextEditorDialogFragment : DialogFragment() {
     private var analyticsListener: StoriesAnalyticsListener? = null
     private var textEditorAnalyticsHandler: TextEditorAnalyticsHandler? = null
 
-    private var bottomSheetBehavior: BottomSheetBehavior<RelativeLayout>? = null
-    private var keyboardHeight: Int = 0
-    private var originalViewHeight: Int = 0
-
     interface TextEditor {
         fun onDone(inputText: String, textStyler: TextStyler)
     }
@@ -52,31 +43,6 @@ class TextEditorDialogFragment : DialogFragment() {
         super.onAttach(context)
 
         textStyleGroupManager = TextStyleGroupManager(context)
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        val rootView = activity?.window?.decorView?.rootView
-
-        rootView?.viewTreeObserver?.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
-            override fun onGlobalLayout() {
-                val r = Rect()
-                rootView.getWindowVisibleDisplayFrame(r)
-                val screenHeight: Int = rootView.height
-                var heightDifference = screenHeight - (r.bottom - r.top)
-
-                val resourceIdNav = resources.getIdentifier("navigation_bar_height", "dimen", "android")
-                if (resourceIdNav > 0) {
-                    heightDifference -= resources.getDimensionPixelSize(resourceIdNav)
-                }
-
-                if (heightDifference > 150) {
-                    keyboardHeight = heightDifference
-                    rootView.viewTreeObserver?.removeOnGlobalLayoutListener(this)
-                }
-            }
-        })
     }
 
     override fun onStart() {
@@ -100,6 +66,10 @@ class TextEditorDialogFragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val bottomSheetHandler = activity?.let {
+            ColorPickerBottomSheetHandler(it, view)
+        }
+
         // Setup the color picker for text color
         val addTextColorPickerRecyclerView = view.add_text_color_picker_recycler_view
         val layoutManager = LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
@@ -108,7 +78,7 @@ class TextEditorDialogFragment : DialogFragment() {
 
         // Hide the bottom sheet if the user taps in the EditText
         add_text_edit_text.setOnClickListener {
-            hideBottomSheet()
+            bottomSheetHandler?.hideBottomSheet()
         }
 
         activity?.let {
@@ -136,14 +106,7 @@ class TextEditorDialogFragment : DialogFragment() {
         }
 
         color_picker_button.setOnClickListener {
-            activity?.let {
-                if (bottomSheetBehavior == null) { initBottomSheet() }
-                if (bottomSheetBehavior?.state == BottomSheetBehavior.STATE_EXPANDED) {
-                    hideBottomSheet()
-                } else {
-                    showBottomSheet(view)
-                }
-            }
+            bottomSheetHandler?.toggleBottomSheet()
         }
 
         arguments?.let {
@@ -206,75 +169,6 @@ class TextEditorDialogFragment : DialogFragment() {
         })
     }
 
-    private fun initBottomSheet() {
-        val bottomSheetCallback = object : BottomSheetBehavior.BottomSheetCallback() {
-            override fun onStateChanged(bottomSheet: View, newState: Int) {
-                if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
-                    // Restore the view's original size
-                    with(main_layout.layoutParams) { height = originalViewHeight }
-
-                    // Show the keyboard
-                    add_text_edit_text.requestFocus()
-                    with(activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager) {
-                        showSoftInput(add_text_edit_text, InputMethodManager.SHOW_IMPLICIT)
-                    }
-                }
-            }
-
-            override fun onSlide(bottomSheet: View, slideOffset: Float) {}
-        }
-
-        bottomSheetBehavior = BottomSheetBehavior.from(bottom_sheet_container).apply {
-            addBottomSheetCallback(bottomSheetCallback)
-        }
-
-        originalViewHeight = main_layout.measuredHeight + keyboardHeight
-    }
-
-    private fun showBottomSheet(view: View) {
-        // Hide the software keyboard
-        with(activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager) {
-            hideSoftInputFromWindow(view.windowToken, 0)
-        }
-
-        view.postDelayed({
-            // Set bottom sheet to the keyboard height
-            val defaultBottomSheetHeight =
-                    resources.getDimensionPixelSize(R.dimen.color_picker_bottom_sheet_default_height)
-            val maxBottomSheetMargin =
-                    resources.getDimensionPixelSize(R.dimen.color_picker_bottom_sheet_height_max_margin)
-            with(bottom_sheet_layout.layoutParams) {
-                // Resize the bottom sheet to match the keyboard height, so the text is kept at around the same
-                // height on the screen.
-                // Fall back to default height if there's no keyboard, or the keyboard is too short or too tall.
-                if (keyboardHeight > defaultBottomSheetHeight &&
-                        keyboardHeight < defaultBottomSheetHeight + maxBottomSheetMargin) {
-                    height = keyboardHeight
-                    bottom_sheet_layout.layoutParams = this
-                }
-            }
-
-            // Shift layout up so text is still centered on screen
-            with(main_layout.layoutParams) {
-                val bottomSheetHeight = if (bottom_sheet_layout.layoutParams.height > 0) {
-                    bottom_sheet_layout.layoutParams.height
-                } else {
-                    defaultBottomSheetHeight
-                }
-                height = originalViewHeight - bottomSheetHeight
-                main_layout.layoutParams = this
-            }
-
-            // Show the bottom sheet
-            bottomSheetBehavior?.state = BottomSheetBehavior.STATE_EXPANDED
-        }, BOTTOM_SHEET_DISPLAY_DELAY_MS)
-    }
-
-    private fun hideBottomSheet() {
-        // This will trigger additional view adjustment logic via BottomSheetCallback
-        bottomSheetBehavior?.state = BottomSheetBehavior.STATE_COLLAPSED
-    }
-
     private fun trackTextStyleToggled() {
         textEditorAnalyticsHandler?.trackTextStyleToggled(textStyleGroupManager.getAnalyticsLabelFor(typefaceId))
     }
@@ -285,8 +179,6 @@ class TextEditorDialogFragment : DialogFragment() {
         const val EXTRA_COLOR_CODE = "extra_color_code"
         const val EXTRA_TEXT_ALIGNMENT = "extra_text_alignment"
         const val EXTRA_TYPEFACE = "extra_typeface"
-
-        const val BOTTOM_SHEET_DISPLAY_DELAY_MS = 300L
 
         // Show dialog with provide text and text color
         @JvmOverloads

--- a/stories/src/main/res/layout/add_text_dialog.xml
+++ b/stories/src/main/res/layout/add_text_dialog.xml
@@ -3,54 +3,60 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="#00000000"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/add_text_done_tv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentTop="true"
-        android:layout_margin="20dp"
-        android:paddingTop="10dp"
-        android:paddingBottom="10dp"
-        android:paddingLeft="20dp"
-        android:paddingRight="20dp"
-        android:text="@string/label_done"
-        android:textAllCaps="true"
-        android:textColor="@color/white" />
-
-    <com.wordpress.stories.compose.text.StoriesEditText
-        android:id="@+id/add_text_edit_text"
-        style="@style/EditText"
-        android:textColor="@color/white"
+    <RelativeLayout
+        android:id="@+id/main_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@+id/add_text_done_tv"
-        android:paddingStart="@dimen/text_view_padding"
-        android:paddingEnd="@dimen/text_view_padding"
-        android:textCursorDrawable="@null"
-        android:background="@null"
-        android:gravity="center"
-        android:inputType="textCapSentences|textMultiLine"
-        android:textSize="@dimen/editor_initial_text_size"
-        tools:text="Some text checking line span 1 2 3 4 5 6 7 8 9"
-        tools:textColor="@android:color/black"
-        tools:textSize="22sp" />
+        android:layout_alignParentTop="true"
+        android:background="#00000000"
+        android:orientation="vertical">
 
-    <ImageButton
-        android:id="@+id/text_alignment_button"
-        android:contentDescription="@string/label_text_alignment_button"
-        android:layout_width="@dimen/normal_button_medium"
-        android:layout_height="@dimen/normal_button_medium"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentStart="true"
-        android:layout_margin="@dimen/normal_button_margin"
-        android:background="@android:color/transparent"
-        android:tint="@android:color/white"
-        android:src="@drawable/ic_gridicons_align_left_32" />
+        <TextView
+            android:id="@+id/add_text_done_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentTop="true"
+            android:layout_margin="20dp"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
+            android:text="@string/label_done"
+            android:textAllCaps="true"
+            android:textColor="@color/white" />
+
+        <com.wordpress.stories.compose.text.StoriesEditText
+            android:id="@+id/add_text_edit_text"
+            style="@style/EditText"
+            android:textColor="@color/white"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@+id/add_text_done_tv"
+            android:paddingStart="@dimen/text_view_padding"
+            android:paddingEnd="@dimen/text_view_padding"
+            android:textCursorDrawable="@null"
+            android:background="@null"
+            android:gravity="center"
+            android:inputType="textCapSentences|textMultiLine"
+            android:textSize="@dimen/editor_initial_text_size"
+            tools:text="Some text checking line span 1 2 3 4 5 6 7 8 9"
+            tools:textColor="@android:color/black"
+            tools:textSize="22sp" />
+
+        <ImageButton
+            android:id="@+id/text_alignment_button"
+            android:contentDescription="@string/label_text_alignment_button"
+            android:layout_width="@dimen/normal_button_medium"
+            android:layout_height="@dimen/normal_button_medium"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentStart="true"
+            android:layout_margin="@dimen/normal_button_margin"
+            android:background="@android:color/transparent"
+            android:tint="@android:color/white"
+            android:src="@drawable/ic_gridicons_align_left_32" />
 
     <Button
         android:id="@+id/text_style_toggle_button"
@@ -67,29 +73,52 @@
         android:text="@string/typeface_label_nunito"
         tools:text="@string/typeface_label_nunito" />
 
-    <ImageButton
-        android:id="@+id/color_picker_button"
-        android:contentDescription="@string/label_text_color_button"
-        android:layout_width="@dimen/normal_button_medium"
-        android:layout_height="@dimen/normal_button_medium"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentEnd="true"
-        android:layout_margin="@dimen/normal_button_margin"
-        android:background="@android:color/transparent"
-        android:src="@drawable/ic_textcolor_replaceme" />
+        <ImageButton
+            android:id="@+id/color_picker_button"
+            android:contentDescription="@string/label_text_color_button"
+            android:layout_width="@dimen/normal_button_medium"
+            android:layout_height="@dimen/normal_button_medium"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentEnd="true"
+            android:layout_margin="@dimen/normal_button_margin"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_textcolor_replaceme" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/add_text_color_picker_recycler_view"
-        android:layout_width="wrap_content"
+        <!-- TODO Delete -->
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/add_text_color_picker_recycler_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/color_picker_item_margin"
+            android:layout_centerHorizontal="true"
+            android:layout_alignParentBottom="true"
+            android:layout_toStartOf="@id/color_picker_button"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            tools:background="@android:color/black"
+            tools:listitem="@layout/color_picker_list_item" />
+    </RelativeLayout>
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/color_picker_item_margin"
-        android:layout_centerHorizontal="true"
-        android:layout_alignParentBottom="true"
-        android:layout_toStartOf="@id/color_picker_button"
-        android:orientation="horizontal"
-        android:visibility="gone"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        tools:background="@android:color/black"
-        tools:listitem="@layout/color_picker_list_item" />
+        android:id="@+id/bottom_sheet_layout"
+        android:layout_alignParentBottom="true">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/bottom_sheet_container"
+            android:background="?android:attr/colorBackground"
+            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+            app:behavior_peekHeight="0dp"
+            app:behavior_hideable="true">
+
+            <include
+                layout="@layout/color_picker_bottom_sheet"
+                android:id="@+id/color_picker_bottom_sheet" />
+        </RelativeLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
 </RelativeLayout>

--- a/stories/src/main/res/layout/color_picker_bottom_sheet.xml
+++ b/stories/src/main/res/layout/color_picker_bottom_sheet.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/color_picker_bottom_sheet_default_height"
+    android:orientation="vertical">
+
+</LinearLayout>

--- a/stories/src/main/res/values/dimens.xml
+++ b/stories/src/main/res/values/dimens.xml
@@ -18,6 +18,7 @@
 
     <!-- Color picker bottom sheet -->
     <dimen name="color_picker_bottom_sheet_default_height">250dp</dimen>
+    <dimen name="color_picker_bottom_sheet_height_max_margin">75dp</dimen>
 
     <dimen name="shutter_button_margin">68dp</dimen>
 

--- a/stories/src/main/res/values/dimens.xml
+++ b/stories/src/main/res/values/dimens.xml
@@ -16,6 +16,9 @@
     <dimen name="color_picker_filler_size">22dp</dimen>
     <dimen name="color_picker_item_margin">8dp</dimen>
 
+    <!-- Color picker bottom sheet -->
+    <dimen name="color_picker_bottom_sheet_default_height">250dp</dimen>
+
     <dimen name="shutter_button_margin">68dp</dimen>
 
     <dimen name="delete_button_margin_bottom">96dp</dimen>


### PR DESCRIPTION
First (big) step of #465. Replaces the color picker RecyclerView with an (empty) bottom sheet. I'll add the actual color picker UI in a subsequent PR, but the bottom sheet behavior alone ended up being a lot of (tricky) code.

![stories-bottom-sheet](https://user-images.githubusercontent.com/9613966/93965973-72266380-fd9e-11ea-8183-b3a762db35cb.gif)

I had to do some extra work to get the bottom sheet to play nice with the keyboard. Not only is there no easy way to hide the keyboard when the bottom sheet appears, but the layout recalculation when the keyboard disappears doesn't account for the bottom sheet correctly, so the text ends up being behind the bottom sheet sometimes.

The approach I went for is to manually trigger keyboard showing and hiding events when the bottom sheet is called/dismissed. Also, the view is adjusted to the bottom sheet's new height, and the height of the bottom sheet matches the keyboard's height to keep jank to a minimum.

Interested in any better ways there might be to approach all this, and more importantly if there are any breaking issues with the current behavior (at this point it's working pretty well for me).

### To test:
1. Open up the text editor, tap the color icon on the right
2. Observe that keyboard goes down, bottom sheet comes up
3. Try dismissing the bottom sheet in each of three ways:
  i. Press the color icon again
  ii. Swipe the bottom sheet down
  iii. Tap on the EditText
4. Observe that the bottom sheet goes away, and the keyboard comes back up