### PR TITLE
Hide sticker button

### DIFF
--- a/stories/src/main/res/layout/content_composer.xml
+++ b/stories/src/main/res/layout/content_composer.xml
@@ -191,6 +191,7 @@
             android:contentDescription="@string/stickers_button_alt"
             android:background="@drawable/edit_mode_controls_circle_selector"
             android:layout_marginStart="@dimen/edit_mode_button_group_margin_between"
+            android:visibility="gone"
             />
 
         <ImageButton


### PR DESCRIPTION
Since we've decided the sticker feature isn't polished enough but also necessary for v1, we'll hide the button for now.

We can restore it if/when we find time to implement emoji search, extend the emoji set, and fix several 2D handling issues.