### PR TITLE
Fixed bug that made launching the camera impossible if a story was previously loaded

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -534,7 +534,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     override fun onStart() {
         super.onStart()
         val selectedFrameIndex = storyViewModel.getSelectedFrameIndex()
-        if (selectedFrameIndex < storyViewModel.getCurrentStorySize()) {
+        if (!launchCameraRequestPending && !launchVideoPlayerRequestPending
+                && selectedFrameIndex < storyViewModel.getCurrentStorySize()) {
             updateBackgroundSurfaceUIWithStoryFrame(selectedFrameIndex)
         }
         // upon loading an existing Story, show the generic announcement dialog if present

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -534,8 +534,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     override fun onStart() {
         super.onStart()
         val selectedFrameIndex = storyViewModel.getSelectedFrameIndex()
-        if (!launchCameraRequestPending && !launchVideoPlayerRequestPending
-                && selectedFrameIndex < storyViewModel.getCurrentStorySize()) {
+        if (!launchCameraRequestPending && !launchVideoPlayerRequestPending &&
+                selectedFrameIndex < storyViewModel.getCurrentStorySize()) {
             updateBackgroundSurfaceUIWithStoryFrame(selectedFrameIndex)
         }
         // upon loading an existing Story, show the generic announcement dialog if present


### PR DESCRIPTION
Fixed bug that made launching the camera impossible if a story was previously loaded
This PR does that by only refreshing the selected frame (which we do by default on start) if and only if there is no pending request to show the textureview (by means of `launchCameraRequestPending` or `launchVideoPlayerRequestPending`)

To test:
Using WPAndroid and latest PRs https://github.com/wordpress-mobile/WordPress-Android/pull/12982
1. edit an existing story via gutenberg
2. try adding a new slide
3. when the media picker shows up, tap on the FAB camera icon
4. observe the camera preview mode is correctly displayed
(before this fix, it would appear as if nothing happened and the previous story was shown, apparently not allowing to add frames)