### PR TITLE
Added onFrameRemove method to StoryDiscardListener

### DIFF
--- a/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
@@ -168,6 +168,11 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         Toast.makeText(this, "Story has been discarded!", Toast.LENGTH_SHORT).show()
     }
 
+    override fun onFrameRemove(storyIndex: StoryIndex, storyFrameIndex: Int) {
+        Toast.makeText(this, "Story frame has been discarded!: index: " + storyFrameIndex,
+                Toast.LENGTH_SHORT).show()
+    }
+
     override fun onStorySaveButtonPressed() {
         processStorySaving()
     }

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -178,6 +178,7 @@ interface GenericAnnouncementDialogProvider {
 
 interface StoryDiscardListener {
     fun onStoryDiscarded()
+    fun onFrameRemove(storyIndex: StoryIndex, storyFrameIndex: Int) // called right before actual removal
 }
 
 abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelectorTappedListener {
@@ -1023,10 +1024,13 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                             if (storyViewModel.getCurrentStorySize() == 1) {
                                 // discard the whole story
                                 safelyDiscardCurrentStoryAndCleanUpIntent()
+                                storyDiscardListener?.onStoryDiscarded()
                             } else {
                                 // get currentFrame value as it will change after calling onAboutToDeleteStoryFrame
                                 val currentFrameToDeleteIndex = storyViewModel.getSelectedFrameIndex()
                                 onAboutToDeleteStoryFrame(currentFrameToDeleteIndex)
+                                storyDiscardListener?.onFrameRemove(storyViewModel.getCurrentStoryIndex(),
+                                        currentFrameToDeleteIndex)
                                 // now discard it from the viewModel
                                 storyViewModel.removeFrameAt(currentFrameToDeleteIndex)
                             }


### PR DESCRIPTION
This PR adds a listener interface when the user is just about to remove a slide from the story.
Comes in handy to do any cleanup needed on the host app side.