### PR TITLE
Fix composed frame file assignment

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
@@ -132,6 +132,7 @@ class FrameSaveManager(
                     // don't process the video but return the original file if no added views in this Story frame
                     frameFile = (frame.source as FileBackgroundSource).file
                 }
+                frame.composedFrameFile = frameFile
             }
             is IMAGE -> {
                 // check whether there are any GIF stickers - if there are, we need to produce a video instead
@@ -143,6 +144,7 @@ class FrameSaveManager(
                         // create ghost PhotoEditorView to be used for saving off-screen
                         val ghostPhotoEditorView = createGhostPhotoEditor(context, photoEditor.composedCanvas)
                         frameFile = saveImageFrame(context, frame, ghostPhotoEditorView, frameIndex)
+                        frame.composedFrameFile = frameFile
                         saveProgressListener?.onFrameSaveCompleted(frameIndex, frame)
                     } catch (ex: Exception) {
                         saveProgressListener?.onFrameSaveFailed(frameIndex, frame, ex.message)
@@ -158,7 +160,6 @@ class FrameSaveManager(
                 }
             }
         }
-        frame.composedFrameFile = frameFile
         return frameFile
     }
 

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
@@ -217,6 +217,7 @@ class FrameSaveManager(
                 override fun onSuccess(filePath: String) {
                     // all good here, continue success path
                     file = File(filePath)
+                    frame.composedFrameFile = file
                     saveProgressListener?.onFrameSaveCompleted(frameIndex, frame)
                     listenerDone = true
                 }


### PR DESCRIPTION
Title has it - we were sending a null `composedFrameFile` property with the frame when `onFrameSaveCompleted()` was being called. This PR fixes that by assigning the value before the call is made.