### PR TITLE
Remove text editor dialog padding on Android 11

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -44,6 +44,9 @@ class TextEditorDialogFragment : DialogFragment() {
     override fun onStart() {
         super.onStart()
         dialog?.window?.apply {
+            // It seems some default padding is applied to DialogFragment DecorViews in Android 11 - get rid of it.
+            decorView.setPadding(0, 0, 0, 0)
+
             setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
             setBackgroundDrawable(ColorDrawable(android.graphics.Color.TRANSPARENT))
             setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)


### PR DESCRIPTION
After updating my phone to Android 11, I noticed the text editor screen had padding added all around it.

I haven't been able to find documentation on this anywhere - I assume it's an Android 11 thing because I've never seen it before and it still doesn't happen anywhere else.

By inspecting in Flipper, I see the padding is coming from the `DecorView` wrapping the fragment layout, so to solve it I'm setting the decor view's padding to 0 🤷‍♂️

![padding-issue-beforeafter](https://user-images.githubusercontent.com/9613966/95167101-01456980-07ea-11eb-8658-9c4491eec254.png)

To test:
1. On an Android 11 device, load the app without this PR and open the text editor - confirm you see the extra padding
2. With this PR, confirm padding is removed