### PR TITLE
Hide keyboard and bottom sheet on TextEditorDialogFragment on onstop()

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -34,6 +34,7 @@ class TextEditorDialogFragment : DialogFragment() {
 
     private var analyticsListener: StoriesAnalyticsListener? = null
     private var textEditorAnalyticsHandler: TextEditorAnalyticsHandler? = null
+    private var bottomSheetHandler: ColorPickerBottomSheetHandler? = null
 
     interface TextEditor {
         fun onDone(inputText: String, textStyler: TextStyler)
@@ -63,10 +64,16 @@ class TextEditorDialogFragment : DialogFragment() {
         return inflater.inflate(R.layout.add_text_dialog, container, false)
     }
 
+    override fun onStop() {
+        dialog?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN)
+        bottomSheetHandler?.hideBottomSheet()
+        super.onStop()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val bottomSheetHandler = activity?.let {
+        bottomSheetHandler = activity?.let {
             ColorPickerBottomSheetHandler(it, view)
         }
 


### PR DESCRIPTION
Builds on top of #545 

Prevents the issue described in https://github.com/Automattic/stories-android/pull/545#issuecomment-704267234, where leaving the bottom sheet up (but the cursor is blinking on the EditText) then locking the phone, then unlocking, would show the keyboard (because the EditText id focused) and then also push the bottom sheet up, showing both at the same time.

This PR just ensures that both are hidden when the view is about to be stopped in `onStop()`.
![hidekeybwhenlock](https://user-images.githubusercontent.com/6597771/95222191-a05c6800-07ce-11eb-84c5-5f36521bf71e.gif)

