### PR TITLE
Text editor: Add text size slider

### DIFF
--- a/photoeditor/src/main/res/values/dimens.xml
+++ b/photoeditor/src/main/res/values/dimens.xml
@@ -1,14 +1,22 @@
 <resources>
     <!-- Begin text spacing -->
-    <!-- These two sets of dimens should match, i.e. padding + horizontal_margin should equal the same for both.
-    This ensures that text is wrapped at the same point in the text editor and in the added view.
+    <!-- The pairs of padding and horizontal margin for the TextView and EditText are interrelated - we want the
+    resulting width of each view to be the same, so that long text added in the EditText wraps in the same places
+    when added as a TextView.
+
+    If adjusting one, make sure to check the other.
+
     If using RoundedBackgroundColorSpan, changing these values may require tweaking the default padding
-    in that class so prevent any artifacts from showing up at line edges when applying the span. -->
+    in that class so prevent any artifacts from showing up at line edges when applying the span.
+
+    Note that the EditText doesn't take up the full width of the editor, since some space is taken by the SeekBar.
+    The SeekBar takes up about ~40dp of horizontal space, so the TextView needs to add that much extra margin
+    for the text to wrap at the same place as the EditText. -->
     <dimen name="text_view_padding">8dp</dimen>
-    <dimen name="text_view_horizontal_margin">16dp</dimen>
+    <dimen name="text_view_horizontal_margin">36dp</dimen>
 
     <dimen name="edit_text_padding">@dimen/text_view_padding</dimen>
-    <dimen name="edit_text_horizontal_margin">@dimen/text_view_horizontal_margin</dimen>
+    <dimen name="edit_text_horizontal_margin">16dp</dimen>
 
     <dimen name="rounded_background_color_span_padding">@dimen/text_view_padding</dimen>
     <dimen name="rounded_background_color_span_radius">4dp</dimen>

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextSizeSlider.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextSizeSlider.kt
@@ -1,0 +1,42 @@
+package com.wordpress.stories.compose.text
+
+import android.content.res.Resources
+import android.util.TypedValue
+import android.widget.SeekBar
+import android.widget.SeekBar.OnSeekBarChangeListener
+import android.widget.TextView
+
+class TextSizeSlider(
+    private val seekBar: SeekBar,
+    private val textView: TextView,
+    private val resources: Resources,
+    onProgressCallback: () -> Unit = {}
+) {
+    init {
+        seekBar.max = TEXT_SIZE_SLIDER_MAX // This corresponds to a font size of MAX + MIN_VALUE sp
+
+        seekBar.setOnSeekBarChangeListener(object : OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                if (!fromUser) return
+                textView.setTextSize(TypedValue.COMPLEX_UNIT_SP,
+                        (progress * TEXT_SIZE_SLIDER_STEP + TEXT_SIZE_SLIDER_MIN_VALUE).toFloat())
+                onProgressCallback()
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) {}
+
+            override fun onStopTrackingTouch(seekBar: SeekBar?) {}
+        })
+    }
+
+    fun update() {
+        val fontSizeSp = (textView.textSize / resources.displayMetrics.scaledDensity).toInt()
+        seekBar.progress = (fontSizeSp - TEXT_SIZE_SLIDER_MIN_VALUE) / TEXT_SIZE_SLIDER_STEP
+    }
+
+    companion object {
+        const val TEXT_SIZE_SLIDER_MAX = 20
+        const val TEXT_SIZE_SLIDER_MIN_VALUE = 14
+        const val TEXT_SIZE_SLIDER_STEP = 2
+    }
+}

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextStyleGroupManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextStyleGroupManager.kt
@@ -45,6 +45,9 @@ class TextStyleGroupManager(val context: Context) {
 
     private var supportedTypefaces = TreeMap<Int, TextStyleRule>()
 
+    // Tracks whether the user has changed the font size
+    var customFontSizeApplied = false
+
     init {
         supportedTypefaces[TYPEFACE_ID_NUNITO] = TextStyleRule(
                 id = TYPEFACE_ID_NUNITO,
@@ -108,7 +111,7 @@ class TextStyleGroupManager(val context: Context) {
 
     @ColorInt private fun getColor(@ColorRes colorRes: Int) = ContextCompat.getColor(context, colorRes)
 
-    fun styleTextView(@TypefaceId typefaceId: Int, textView: TextView) {
+    fun styleTextView(@TypefaceId typefaceId: Int, textView: TextView, fontSizePx: Float = 0F) {
         val textStyleRule = supportedTypefaces[typefaceId] ?: return
 
         with(textStyleRule) {
@@ -126,7 +129,17 @@ class TextStyleGroupManager(val context: Context) {
             textView.setLineSpacing(0F, lineSpacingMultiplier)
             textView.letterSpacing = letterSpacing
 
-            textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, defaultFontSize)
+            if (customFontSizeApplied) {
+                // No op: leave the textView's font size intact
+            } else if (fontSizePx > 0 && fontSizePx != defaultFontSize.spToPx()) {
+                // We were given a specific font size, and it's not the default for this font, so it's been
+                // customized by the user at some point.
+                // Apply the font and toggle on custom font size mode.
+                textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, fontSizePx)
+                customFontSizeApplied = true
+            } else {
+                textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, defaultFontSize)
+            }
         }
     }
 

--- a/stories/src/main/java/com/wordpress/stories/util/SeekBarRotator.java
+++ b/stories/src/main/java/com/wordpress/stories/util/SeekBarRotator.java
@@ -1,0 +1,74 @@
+
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.wordpress.stories.util;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+/*
+ *  This ViewGroup contains a single view, which will be rotated by 90 degrees counterclockwise.
+ *
+ * From Android MusicFX app source.
+ */
+public class SeekBarRotator extends ViewGroup {
+    public SeekBarRotator(Context context) {
+        super(context);
+    }
+    public SeekBarRotator(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+    public SeekBarRotator(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+    public SeekBarRotator(Context context, AttributeSet attrs, int defStyleAttr,
+                          int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        final View child = getChildAt(0);
+        if (child.getVisibility() != GONE) {
+            // swap width and height for child
+            //noinspection SuspiciousNameCombination
+            measureChild(child, heightMeasureSpec, widthMeasureSpec);
+            setMeasuredDimension(
+                    child.getMeasuredHeightAndState(),
+                    child.getMeasuredWidthAndState());
+        } else {
+            setMeasuredDimension(
+                    resolveSizeAndState(0, widthMeasureSpec, 0),
+                    resolveSizeAndState(0, heightMeasureSpec, 0));
+        }
+    }
+    @SuppressWarnings("UnnecessaryLocalVariable") @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        final View child = getChildAt(0);
+        if (child.getVisibility() != GONE) {
+            // rotate the child 90 degrees counterclockwise around its upper-left
+            child.setPivotX(0);
+            child.setPivotY(0);
+            child.setRotation(-90);
+            // place the child below this view, so it rotates into view
+            int mywidth = r - l;
+            int myheight = b - t;
+            int childwidth = myheight;
+            int childheight = mywidth;
+            child.layout(0, myheight, childwidth, myheight + childheight);
+        }
+    }
+}

--- a/stories/src/main/res/layout/add_text_dialog.xml
+++ b/stories/src/main/res/layout/add_text_dialog.xml
@@ -35,6 +35,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_below="@+id/add_text_done_tv"
+            android:layout_toStartOf="@+id/slider_container"
             android:padding="@dimen/edit_text_padding"
             android:layout_marginHorizontal="@dimen/edit_text_horizontal_margin"
             android:textCursorDrawable="@null"

--- a/stories/src/main/res/layout/add_text_dialog.xml
+++ b/stories/src/main/res/layout/add_text_dialog.xml
@@ -46,6 +46,22 @@
             tools:textColor="@android:color/black"
             tools:textSize="22sp" />
 
+        <com.wordpress.stories.util.SeekBarRotator
+            android:id="@+id/slider_container"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_below="@+id/add_text_done_tv"
+            android:layout_above="@+id/color_picker_button"
+            android:layout_alignParentEnd="true"
+            android:layout_marginEnd="@dimen/text_size_slider_margin"
+            android:orientation="vertical">
+
+            <androidx.appcompat.widget.AppCompatSeekBar
+                android:id="@+id/text_size_slider"
+                android:layout_height="wrap_content"
+                android:layout_width="match_parent" />
+        </com.wordpress.stories.util.SeekBarRotator>
+
         <ImageButton
             android:id="@+id/text_alignment_button"
             android:contentDescription="@string/label_text_alignment_button"

--- a/stories/src/main/res/layout/add_text_dialog.xml
+++ b/stories/src/main/res/layout/add_text_dialog.xml
@@ -58,6 +58,7 @@
 
             <androidx.appcompat.widget.AppCompatSeekBar
                 android:id="@+id/text_size_slider"
+                style="@style/StoriesSeekBar"
                 android:layout_height="wrap_content"
                 android:layout_width="match_parent" />
         </com.wordpress.stories.util.SeekBarRotator>

--- a/stories/src/main/res/values/dimens.xml
+++ b/stories/src/main/res/values/dimens.xml
@@ -12,6 +12,8 @@
     <dimen name="top_button_group_margin">@dimen/normal_button_margin</dimen>
     <dimen name="main_button_elevation">2dp</dimen>
 
+    <dimen name="text_size_slider_margin">23dp</dimen>
+
     <!-- START: Color picker bottom sheet -->
 
     <dimen name="color_picker_bottom_sheet_default_height">250dp</dimen>

--- a/stories/src/main/res/values/styles.xml
+++ b/stories/src/main/res/values/styles.xml
@@ -37,4 +37,11 @@
         <item name="android:textColor">?attr/colorOnSurface</item>
     </style>
 
+    <style name="StoriesSeekBar" parent="Widget.AppCompat.SeekBar">
+        <item name="android:progressTint">@android:color/white</item>
+        <item name="android:progressBackgroundTint">@android:color/white</item>
+        <item name="android:colorControlActivated">@android:color/white</item>
+        <item name="android:thumbTint">@android:color/white</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Adds a slider to the editor screen which modifies the text size.

![loop-text-size-slider](https://user-images.githubusercontent.com/9613966/95533666-b6606780-0a1e-11eb-8994-ef0e4236431d.png)

This is done using a `SeekBar`. `SeekBars` aren't built to be vertical, but the common approach I found is to reuse a class from the AOSP which wraps and rotates the SeekBar, so I went with that.

(Note: There exists a newer Material component, the [Slider](https://material.io/components/sliders#theming). However it's quite new, doesn't support vertical alignment either, and seemed to misbehave when I tried it. We don't really need more than the SeekBar so I didn't go any further

This kind of addresses #532 - at least enough to make it less of an issue, and we can group it with the rest of the 2D handling issues we may address later on (or may be moot with Kanvas).

### To test:
1. Check that if you never touch the slider, default text sizes are respected for the various fonts as you cycle through them
2. Check that once the slider is used, the new size is remembered as you toggle through fonts
3. Check that the behavior of step 2 is true if you dismiss the editor and edit the resized text