### PR TITLE
Added method to find a Story in the StoryRepository that contains a given frame id

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
@@ -60,8 +60,18 @@ object StoryRepository {
     fun findStoryContainingStoryFrameItemsByIds(ids: ArrayList<String>): StoryIndex {
         // now look for a Story in the StoryRepository that contains a matching frame id and return the story index
         for ((index, story) in stories.withIndex()) {
-            // find the MediaModel for a given Uri from composedFrameFile
             if (story.frames.filter { ids.contains(it.id) }.size == ids.size) {
+                // here we found the story whose frames collection contains all of the passed ids
+                return index
+            }
+        }
+        return DEFAULT_NONE_SELECTED
+    }
+
+    fun findFirstStoryContainingAtLeastOneStoryFrameItemWithId(id: String): StoryIndex {
+        // now look for a Story in the StoryRepository that contains a matching frame id and return the story index
+        for ((index, story) in stories.withIndex()) {
+            if (story.frames.filter { it.id == id }.size > 0) {
                 // here we found the story whose frames collection contains all of the passed ids
                 return index
             }


### PR DESCRIPTION
In the host app, we may identify a Story by a specific mediaId given each flattened media produced belongs to one and only one Story. Hence, finding a Story that contains a frame with such an id should suffice to say we've found _the_ Story to which the media id belongs.

This method is needed when interacting with the host app for upload cancelation, where instead of verifying all of the mediaIds involved in a Story frame collection, we only have one mediaId being passed around (and as such should be enough to infer which Story the frame belongs to).

To test:
- N/A will provide specific use case test conditions on other PRs.