### PR TITLE
Keep added views tappable after closing discard dialog

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -919,8 +919,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                     onBackPressed()
                 }
                 !backgroundSurfaceManager.cameraVisible() -> {
-                    addCurrentViewsToFrameAtIndex(storyViewModel.getSelectedFrameIndex())
-
                     // Show discard dialog
                     FrameSaveErrorDialog.newInstance(
                         title = getString(R.string.dialog_discard_story_title),
@@ -928,6 +926,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                         okButtonLabel = getString(R.string.dialog_discard_story_ok_button),
                         listener = object : FrameSaveErrorDialogOk {
                             override fun OnOkClicked(dialog: DialogFragment) {
+                                addCurrentViewsToFrameAtIndex(storyViewModel.getSelectedFrameIndex())
                                 dialog.dismiss()
                                 // discard the whole story
                                 safelyDiscardCurrentStoryAndCleanUpIntent()


### PR DESCRIPTION
Fixes #568.

`addCurrentViewsToFrameAtIndex()` ends up unsetting the click listeners for added views. I don't see any reason to call that function until the user has actually confirmed the cancellation, so I moved it down. @mzorz let me know if there was a specific reason we were doing that earlier that I may have missed.

To test:
Follow the steps in #568, confirm you can now edit added views immediately after dismissing the discard dialog.