### PR TITLE
Long press to delete added views

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
@@ -51,8 +51,6 @@ internal class MultiTouchListener(
     // private var onMultiTouchListener: OnMultiTouchListener? = null
     private var mOnGestureControl: OnGestureControl? = null
 
-    private var isLongPressActive: Boolean = false
-
     init {
         mScaleGestureDetector = ScaleGestureDetector(ScaleGestureListener())
         mGestureListener = GestureDetector(GestureListener())
@@ -109,20 +107,18 @@ internal class MultiTouchListener(
                             currY - mPrevY
                         )
                     }
-                    if (isLongPressActive) {
-                        onMultiTouchListener?.let { touchListener ->
-                            deleteView?.let { delView ->
-                                // initialize bitmap for deleteView once
-                                if (deleteViewBitmap == null && deleteView.isLaidOut) {
-                                    deleteViewBitmap = BitmapUtil.createBitmapFromView(deleteView)
-                                }
+                    onMultiTouchListener?.let { touchListener ->
+                        deleteView?.let { deleteView ->
+                            // initialize bitmap for deleteView once
+                            if (deleteViewBitmap == null && deleteView.isLaidOut) {
+                                deleteViewBitmap = BitmapUtil.createBitmapFromView(deleteView)
+                            }
 
-                                deleteViewBitmap?.let {
-                                    val readyForDelete = isViewOverlappingDeleteView(delView, view)
-                                    // fade the view a bit to indicate it's going bye bye
-                                    setAlphaOnView(view, readyForDelete)
-                                    touchListener.onRemoveViewReadyListener(view, readyForDelete)
-                                }
+                            deleteViewBitmap?.let {
+                                val readyForDelete = isViewOverlappingDeleteView(deleteView, view)
+                                // fade the view a bit to indicate it's going bye bye
+                                setAlphaOnView(view, readyForDelete)
+                                touchListener.onRemoveViewReadyListener(view, readyForDelete)
                             }
                         }
                     }
@@ -138,7 +134,6 @@ internal class MultiTouchListener(
                     }
                     delView.visibility = View.GONE
                 }
-                isLongPressActive = false
                 firePhotoEditorSDKListener(view, false)
             }
             MotionEvent.ACTION_POINTER_UP -> {
@@ -181,7 +176,11 @@ internal class MultiTouchListener(
         return outRect?.contains(x, y) ?: false
     }
 
-    fun isViewOverlappingDeleteView(deleteView: View, viewB: View): Boolean {
+    private fun isViewOverlappingDeleteView(deleteView: View, viewB: View): Boolean {
+        if (deleteView.visibility != View.VISIBLE) {
+            return false
+        }
+
         // using the View's matrix so the bitmap also has its content rotated and scaled.
         val bmpForDraggedView = BitmapUtil.createRotatedBitmapFromViewWithMatrix(viewB)
 
@@ -334,7 +333,6 @@ internal class MultiTouchListener(
             super.onLongPress(e)
             mOnGestureControl?.onLongClick()
             deleteView?.visibility = View.VISIBLE
-            isLongPressActive = true
         }
     }
 

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
@@ -193,10 +193,12 @@ internal class MultiTouchListener(
         val globalVisibleRectDelete = Rect()
         deleteView.getGlobalVisibleRect(globalVisibleRectDelete)
 
-        return isPixelOverlapping(
-                requireNotNull(deleteViewBitmap), globalVisibleRectDelete.left, globalVisibleRectDelete.top,
-                bmpForDraggedView, globalVisibleRectB.left, globalVisibleRectB.top
-        )
+        return deleteViewBitmap?.let {
+            isPixelOverlapping(
+                    it, globalVisibleRectDelete.left, globalVisibleRectDelete.top,
+                    bmpForDraggedView, globalVisibleRectB.left, globalVisibleRectB.top
+            )
+        } ?: false
     }
 
     // when we find both pixels on the same coordinate for each bitmap being not transparent, that means

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
@@ -86,6 +86,9 @@ internal class MultiTouchListener(
                 mActivePointerId = event.getPointerId(0)
                 view.bringToFront()
                 firePhotoEditorSDKListener(view, true)
+
+                // Reset delete button state
+                onMultiTouchListener?.onRemoveViewReadyListener(view, false)
             }
             MotionEvent.ACTION_MOVE -> {
                 val pointerIndexMove = event.findPointerIndex(mActivePointerId)


### PR DESCRIPTION
Fixes #394. You now have to long press a view for the delete button to show up - this should prevent accidental deletes while resizing or moving a view.

I started off with a flag to toggle long press state on and off, but I realized there was a simpler way by just checking if the delete view is actually visible in the collision detection logic.

**Also fixes a crash I missed before that was introduced by #512.**

### To test:
1. Confirm that you can't trigger delete by dragging added view around
2. Check that long pressing a view makes the delete button show up, and dragging to delete works as before
3. Add multiple views, delete one, and confirm that when you long press a second one the delete button shows up in the 'not ready' mode (white image, dark background)
4. Confirm that repeated deletes work
5. Check that the crash fix works: Try adding a new text view, then doing a quick tap on it. Before, this would cause a crash [here](https://github.com/Automattic/stories-android/pull/573/commits/e1e1f3de9a2c132944ee94087467c0edbf8a55c4#diff-6bc54f1069649e24610eff29aaef7b2816e4038667175b6266c615599a5eed1dL197), because the delete view hadn't been drawn yet and so the bitmap was still null.