### PR TITLE
Fix RelativeOverlap lint error in text editor

### DIFF
--- a/stories/src/main/res/layout/add_text_dialog.xml
+++ b/stories/src/main/res/layout/add_text_dialog.xml
@@ -50,7 +50,7 @@
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_below="@+id/add_text_done_button"
-            android:layout_above="@+id/color_picker_button"
+            android:layout_above="@+id/bottom_controls_container"
             android:layout_alignParentEnd="true"
             android:layout_marginEnd="@dimen/text_size_slider_margin"
             android:orientation="vertical">
@@ -62,43 +62,55 @@
                 android:layout_width="match_parent" />
         </com.wordpress.stories.util.SeekBarRotator>
 
-        <ImageButton
-            android:id="@+id/text_alignment_button"
-            android:contentDescription="@string/label_text_alignment_button"
-            android:layout_width="@dimen/normal_button_medium"
-            android:layout_height="@dimen/normal_button_medium"
-            android:layout_alignParentBottom="true"
-            android:layout_alignParentStart="true"
-            android:layout_margin="@dimen/normal_button_margin"
-            android:background="@android:color/transparent"
-            android:tint="@android:color/white"
-            android:src="@drawable/ic_gridicons_align_left_32" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/bottom_controls_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true">
 
-    <Button
-        android:id="@+id/text_style_toggle_button"
-        android:layout_width="wrap_content"
-        android:layout_height="@dimen/normal_button_medium"
-        android:layout_alignParentBottom="true"
-        android:layout_centerHorizontal="true"
-        android:layout_margin="@dimen/normal_button_margin"
-        android:gravity="center"
-        android:background="@drawable/transparent_text_button_selector"
-        android:backgroundTint="@android:color/white"
-        android:textColor="@android:color/white"
-        android:textAllCaps="false"
-        android:text="@string/typeface_label_nunito"
-        tools:text="@string/typeface_label_nunito" />
+            <ImageButton
+                android:id="@+id/text_alignment_button"
+                android:contentDescription="@string/label_text_alignment_button"
+                android:layout_width="@dimen/normal_button_medium"
+                android:layout_height="@dimen/normal_button_medium"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:layout_margin="@dimen/normal_button_margin"
+                android:background="@android:color/transparent"
+                android:tint="@android:color/white"
+                android:src="@drawable/ic_gridicons_align_left_32" />
 
-        <ImageButton
-            android:id="@+id/color_picker_button"
-            android:contentDescription="@string/label_text_color_button"
-            android:layout_width="@dimen/normal_button_medium"
-            android:layout_height="@dimen/normal_button_medium"
-            android:layout_alignParentBottom="true"
-            android:layout_alignParentEnd="true"
-            android:layout_margin="@dimen/normal_button_margin"
-            android:background="@android:color/transparent"
-            android:src="@drawable/ic_textcolor_replaceme" />
+            <Button
+                android:id="@+id/text_style_toggle_button"
+                android:layout_width="wrap_content"
+                android:layout_height="@dimen/normal_button_medium"
+                android:layout_alignParentBottom="true"
+                app:layout_constraintStart_toEndOf="@+id/text_alignment_button"
+                app:layout_constraintEnd_toStartOf="@+id/color_picker_button"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:layout_centerHorizontal="true"
+                android:layout_margin="@dimen/normal_button_margin"
+                android:gravity="center"
+                android:background="@drawable/transparent_text_button_selector"
+                android:backgroundTint="@android:color/white"
+                android:textColor="@android:color/white"
+                android:textAllCaps="false"
+                android:text="@string/typeface_label_nunito"
+                tools:text="@string/typeface_label_nunito" />
+
+            <ImageButton
+                android:id="@+id/color_picker_button"
+                android:contentDescription="@string/label_text_color_button"
+                android:layout_width="@dimen/normal_button_medium"
+                android:layout_height="@dimen/normal_button_medium"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:layout_margin="@dimen/normal_button_margin"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_textcolor_replaceme" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
     </RelativeLayout>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout


### PR DESCRIPTION
We were getting a lint warning which on WPAndroid is an error:

```
WordPress/build/reports/lint-results-vanillaRelease.xml-    <issue
WordPress/build/reports/lint-results-vanillaRelease.xml-        id="RelativeOverlap"
WordPress/build/reports/lint-results-vanillaRelease.xml:        severity="Error"
WordPress/build/reports/lint-results-vanillaRelease.xml-        message="`@id/text_style_toggle_button` can overlap `@id/color_picker_button` if @string/typeface_label_nunito grows due to localized text expansion"
WordPress/build/reports/lint-results-vanillaRelease.xml-        category="Internationalization"
WordPress/build/reports/lint-results-vanillaRelease.xml-        priority="3"
WordPress/build/reports/lint-results-vanillaRelease.xml-        summary="Overlapping items in RelativeLayout"
WordPress/build/reports/lint-results-vanillaRelease.xml-        explanation="If relative layout has text or button items aligned to left and right sides they can overlap each other due to localized text expansion unless they have mutual constraints like `toEndOf`/`toStartOf`."
WordPress/build/reports/lint-results-vanillaRelease.xml-        errorLine1="    &lt;Button"
WordPress/build/reports/lint-results-vanillaRelease.xml-        errorLine2="     ~~~~~~">
WordPress/build/reports/lint-results-vanillaRelease.xml-        <location
WordPress/build/reports/lint-results-vanillaRelease.xml-            file="/home/circleci/project/libs/stories-android/stories/src/main/res/layout/add_text_dialog.xml"
WordPress/build/reports/lint-results-vanillaRelease.xml-            line="77"
WordPress/build/reports/lint-results-vanillaRelease.xml-            column="6"/>
WordPress/build/reports/lint-results-vanillaRelease.xml-    </issue>
WordPress/build/reports/lint-results-vanillaRelease.xml-
WordPress/build/reports/lint-results-vanillaRelease.xml-</issues>
```

I fixed this by wrapping the text editor controls in a `ConstraintLayout` and setting the alignment and color buttons as bounds for the text style button.

To test:
1. Build `develop`
2. Run `./gradlew lintDebug`, confirm that you see a `RelativeOverlap` lint warning involving the `text_style_toggle_button`
3. Build this branch
4. Run `./gradlew lintDebug` again, confirm that the warning is gone
5. Build the demo app, confirm that the text editor controls look/behave the same as before