### PR TITLE
Add hideCancel flag to FrameSaveErrorDialog

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/FrameSaveErrorDialog.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/FrameSaveErrorDialog.kt
@@ -17,7 +17,10 @@ class FrameSaveErrorDialog : DialogFragment() {
             .setMessage(arguments?.getString(ARG_MESSAGE))
 
         okListener?.let {
-            builder.setNegativeButton(android.R.string.cancel) { _, _ -> dismiss() }
+            val hideCancel = arguments?.getBoolean(ARG_HIDE_CANCEL) ?: false
+            if (!hideCancel) {
+                builder.setNegativeButton(android.R.string.cancel) { _, _ -> dismiss() }
+            }
             builder.setPositiveButton(
                     arguments?.getString(ARG_OK_LABEL) ?: activity?.getString(android.R.string.ok)) {
                     _, _ -> okListener?.OnOkClicked(this)
@@ -33,18 +36,21 @@ class FrameSaveErrorDialog : DialogFragment() {
         @JvmStatic private val ARG_MESSAGE = "message"
         @JvmStatic private val ARG_TITLE = "title"
         @JvmStatic private val ARG_OK_LABEL = "ok_label"
+        @JvmStatic private val ARG_HIDE_CANCEL = "hide_cancel"
 
         @JvmStatic fun newInstance(
             title: String,
             message: String,
             okButtonLabel: String? = null,
-            listener: FrameSaveErrorDialogOk? = null
+            listener: FrameSaveErrorDialogOk? = null,
+            hideCancelButton: Boolean = false
         ): FrameSaveErrorDialog =
             FrameSaveErrorDialog().apply {
                 arguments = Bundle().apply {
                     putString(ARG_TITLE, title)
                     putString(ARG_MESSAGE, message)
                     putString(ARG_OK_LABEL, okButtonLabel)
+                    putBoolean(ARG_HIDE_CANCEL, hideCancelButton)
                 }
                 okListener = listener
             }


### PR DESCRIPTION
In some situations, we need an `okListener` but we don't want the `cancel` button to appear on the dialog. Added a flag to indicate so in this PR.

To test: see related WPAndroid PR with a specific use case https://github.com/wordpress-mobile/WordPress-Android/pull/13287