### PR TITLE
Show delete button when long pressing a slide

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -1912,6 +1912,10 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         toggleDeleteSlideMode()
     }
 
+    override fun onStoryFrameMovedLongPressed() {
+        disableDeleteSlideMode()
+    }
+
     private fun toggleDeleteSlideMode() {
         if (delete_slide_view.visibility == View.VISIBLE) {
             disableDeleteSlideMode()

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -1900,6 +1900,19 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     override fun onCurrentFrameTapped() {
+        toggleDeleteSlideMode()
+    }
+
+    override fun onStoryFrameLongPressed(oldIndex: Int, newIndex: Int) {
+        // On long press we want to switch to that frame and show the delete slide move all together.
+        if (oldIndex != newIndex) {
+            // The long-pressed frame was not the one already in focus - switch to it first.
+            onStoryFrameSelected(oldIndex, newIndex)
+        }
+        toggleDeleteSlideMode()
+    }
+
+    private fun toggleDeleteSlideMode() {
         if (delete_slide_view.visibility == View.VISIBLE) {
             disableDeleteSlideMode()
         } else {

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorAdapter.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorAdapter.kt
@@ -80,15 +80,21 @@ class StoryFrameSelectorAdapter : RecyclerView.Adapter<StoryFrameSelectorAdapter
 
         class StoryFrameHolderItem(v: View) : StoryFrameHolder(v) {
             private var onFrameSelected: (() -> Unit)? = null
+            private var onFrameLongPressed: (() -> Unit)? = null
 
             init {
                 clickableView.setOnClickListener {
                     onFrameSelected?.invoke()
                 }
+                clickableView.setOnLongClickListener {
+                    onFrameLongPressed?.invoke()
+                    true
+                }
             }
 
             override fun onBind(uiState: StoryFrameListItemUiState) {
                 onFrameSelected = requireNotNull(uiState.onItemTapped) { "OnItemTapped is required." }
+                onFrameLongPressed = requireNotNull(uiState.onItemLongPressed) { "OnItemLongPressed is required." }
                 uiState as StoryFrameListItemUiStateFrame
 
                 val loadThumbnailImage = {

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
@@ -25,6 +25,7 @@ interface OnStoryFrameSelectorTappedListener {
     fun onStoryFrameAddTapped()
     fun onCurrentFrameTapped()
     fun onStoryFrameLongPressed(oldIndex: Int, newIndex: Int)
+    fun onStoryFrameMovedLongPressed()
 }
 
 class StoryFrameSelectorFragment : Fragment() {
@@ -55,6 +56,10 @@ class StoryFrameSelectorFragment : Fragment() {
         storyViewModel.onUserLongPressedFrame.observe(this, Observer { selectedFrameIndexChange ->
             storyFrameTappedListener?.onStoryFrameLongPressed(
                     selectedFrameIndexChange.first, selectedFrameIndexChange.second)
+        })
+
+        storyViewModel.onUserMovedLongPressedFrame.observe(this, Observer {
+            storyFrameTappedListener?.onStoryFrameMovedLongPressed()
         })
 
         storyViewModel.onFrameIndexMoved.observe(this, Observer<Pair<Int, Int>> { positionFrameIndexChange ->

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
@@ -24,6 +24,7 @@ interface OnStoryFrameSelectorTappedListener {
     fun onStoryFrameSelected(oldIndex: Int, newIndex: Int)
     fun onStoryFrameAddTapped()
     fun onCurrentFrameTapped()
+    fun onStoryFrameLongPressed(oldIndex: Int, newIndex: Int)
 }
 
 class StoryFrameSelectorFragment : Fragment() {
@@ -49,6 +50,11 @@ class StoryFrameSelectorFragment : Fragment() {
 
         storyViewModel.onUserTappedCurrentFrame.observe(this, Observer {
             storyFrameTappedListener?.onCurrentFrameTapped()
+        })
+
+        storyViewModel.onUserLongPressedFrame.observe(this, Observer { selectedFrameIndexChange ->
+            storyFrameTappedListener?.onStoryFrameLongPressed(
+                    selectedFrameIndexChange.first, selectedFrameIndexChange.second)
         })
 
         storyViewModel.onFrameIndexMoved.observe(this, Observer<Pair<Int, Int>> { positionFrameIndexChange ->

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
@@ -47,6 +47,9 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
     private val _onUserTappedCurrentFrame = SingleLiveEvent<Unit>()
     val onUserTappedCurrentFrame = _onUserTappedCurrentFrame
 
+    private val _onUserLongPressedFrame = SingleLiveEvent<Pair<Int, Int>>()
+    val onUserLongPressedFrame = _onUserLongPressedFrame
+
     fun createNewStory() {
         loadStory(StoryRepository.DEFAULT_NONE_SELECTED)
     }
@@ -102,6 +105,12 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
         } else {
             _onUserSelectedFrame.value = Pair(oldIndex, index)
         }
+    }
+
+    private fun setLongPressedFrame(index: Int) {
+        val oldIndex = currentSelectedFrameIndex
+        setSelectedFrame(index)
+        _onUserLongPressedFrame.value = Pair(oldIndex, index)
     }
 
     fun updateCurrentSelectedFrameOnRetryResult(frameSaveResult: FrameSaveResult) {
@@ -291,6 +300,9 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
             oneFrameUiState.onItemTapped = {
                 setSelectedFrameByUser(index, userInitiated = true)
             }
+            oneFrameUiState.onItemLongPressed = {
+                setLongPressedFrame(index)
+            }
             uiStateItems.add(oneFrameUiState)
         }
         return newUiState
@@ -300,6 +312,7 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
 
     sealed class StoryFrameListItemUiState() {
         var onItemTapped: (() -> Unit)? = null
+        var onItemLongPressed: (() -> Unit)? = null
 
         data class StoryFrameListItemUiStateFrame(
             var selected: Boolean = false,

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
@@ -50,6 +50,9 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
     private val _onUserLongPressedFrame = SingleLiveEvent<Pair<Int, Int>>()
     val onUserLongPressedFrame = _onUserLongPressedFrame
 
+    private val _onUserMovedLongPressedFrame = SingleLiveEvent<Unit>()
+    val onUserMovedLongPressedFrame = _onUserMovedLongPressedFrame
+
     fun createNewStory() {
         loadStory(StoryRepository.DEFAULT_NONE_SELECTED)
     }
@@ -111,6 +114,10 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
         val oldIndex = currentSelectedFrameIndex
         setSelectedFrame(index)
         _onUserLongPressedFrame.value = Pair(oldIndex, index)
+    }
+
+    private fun setMovedLongPressedFrame() {
+        _onUserMovedLongPressedFrame.call()
     }
 
     fun updateCurrentSelectedFrameOnRetryResult(frameSaveResult: FrameSaveResult) {
@@ -221,6 +228,7 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
     }
 
     fun swapItemsInPositions(pos1: Int, pos2: Int) {
+        setMovedLongPressedFrame()
         repository.swapItemsInPositions(pos1, pos2)
         // adjust currentSelectedFrameIndex so it reflects the movement only
         // if the movement occurred entierly to the left of the selection, don't update it


### PR DESCRIPTION
Closes #583. In addition to tapping the current slide to show the delete button, this PR also adds long press behavior. Long pressing any slide (no matter which slide you're currently on) will switch to that slide and show the delete button.

This build has been tested and 👍 'd by @megsfulton . She had some suggested improvements which we can make in the future - recorded those in #599 .

### To test:
1. Create a story with multiple slides
2. Verify that long pressing the current slide shows the delete button and you can delete the slide
3. Verify that long pressing a slide you're not on switches to that slide and shows the delete button (and you can delete the slide)
4. Verify that long pressing the active slide again after step 2 or 3 hides the delete button
5. Verify that dragging to swap slides still works
6. Check that when slides are swapped, the delete button is hidden (since the long press action has been completed)