### PR TITLE
Ensure delete button overlays added views

### DIFF
--- a/stories/src/main/res/layout/content_composer.xml
+++ b/stories/src/main/res/layout/content_composer.xml
@@ -18,20 +18,7 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         android:animateLayoutChanges="true"
-        android:background="@color/black"
-        >
-
-        <!-- this is the delete view  -->
-        <com.wordpress.stories.compose.DeleteButton
-            android:id="@+id/delete_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/delete_button_margin_bottom"
-            android:visibility="gone"
-            android:layout_centerHorizontal="true"
-            android:layout_alignParentBottom="true"/>
-
-    </com.automattic.photoeditor.views.PhotoEditorView>
+        android:background="@color/black" />
 
     <FrameLayout
         android:id="@+id/translucent_error_view"
@@ -41,6 +28,19 @@
         android:background="@color/black_transp_error_scrim">
     </FrameLayout>
 
+    <!-- Delete added view button -->
+    <com.wordpress.stories.compose.DeleteButton
+        android:id="@+id/delete_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/delete_button_margin_bottom"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        android:layout_alignParentBottom="true"/>
+
+    <!-- Delete slide button  -->
     <com.wordpress.stories.compose.DeleteButton
         android:id="@+id/delete_slide_view"
         android:layout_width="wrap_content"


### PR DESCRIPTION
Fixes #604. Moves the added view delete button later in the editor layout, so that views added to the `PhotoEditorView` are always stacked under the delete button when it's shown.

@mzorz I'm not sure if there was any reason I missed that we used to wrap the added view delete button inside the PhotoEditorView. Everything seems to be working correctly but let me know if you think of a problematic case I missed.

### To test:
Verify the original issue, and then:

1. Add a text view with background color, enlarge it a bit
2. Drag it to the bottom of the screen so it overlaps where the delete button would be (try not to trigger long press and delete it accidentally)
3. Add a new text view
4. Long press the new text view
5. Notice that the delete button appears, and isn't hidden under the first text view
6. Ensure that views can be deleted as before by dragging them to the delete button while long pressing