### PR TITLE
Fix greyed out images after uninstall

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/FileUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/FileUtils.kt
@@ -2,6 +2,7 @@ package com.automattic.photoeditor.util
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.os.Environment
 import android.util.Size
 import android.view.View
 import com.automattic.photoeditor.R
@@ -24,8 +25,9 @@ class FileUtils {
         /** Use external media if it is available, our app's file directory otherwise */
         fun getOutputDirectory(context: Context): File {
             val appContext = context.applicationContext
-            val mediaDir = context.externalMediaDirs.firstOrNull()?.let {
-                File(it, appContext.resources.getString(R.string.app_name)).apply { mkdirs() } }
+            val mediaDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)?.let {
+                File(it, appContext.resources.getString(R.string.app_name)).apply { mkdirs() }
+            }
             return if (mediaDir != null && mediaDir.exists())
                 mediaDir else appContext.filesDir
         }


### PR DESCRIPTION
Fixes #591 

This PR uses `Environment.DIRECTORY_PICTURES` to save slides so these are kept trough uninstalls

We were using [`getExternalMediaDirs`](https://developer.android.com/reference/android/content/Context#getExternalMediaDirs()) which, as the documentation states:
> This is like getExternalFilesDirs(String) in that these files will be deleted when the application is uninstalled, however there are some important differences [...]

Since Android Q we should use MediaStore API (See https://developer.android.com/training/data-storage), but given we're currently targeting API 29 we can still use this to prevent the media from being inaccessible after an uninstall.

To test:
1. using this branch: install WPAndroid, log in, create a story by capturing at least one picture with stories capture mode
2. add some text to it, save the story (publish)
3. now go to media section and tap + to add
4. observe the newly created slide can be seen there
5. uninstall the app, and reinstall
6. log in to WPAndroid
7. go to media section and tap + to add
8. observe you can now see the pictured captured with the Stories library (these are no longer greyed out meaning, these are now accessible through reinstalls).

