### PR TITLE
Replace arrow with checkmark as finish action in edit mode

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -67,6 +67,7 @@ import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.wordpress.stories.BuildConfig
 import com.wordpress.stories.R
 import com.wordpress.stories.compose.ComposeLoopFrameActivity.ExternalMediaPickerRequestCodesAndExtraKeys
+import com.wordpress.stories.compose.FinishButton.FinishButtonMode.DONE
 import com.wordpress.stories.compose.ScreenTouchBlockMode.BLOCK_TOUCH_MODE_DELETE_SLIDE
 import com.wordpress.stories.compose.ScreenTouchBlockMode.BLOCK_TOUCH_MODE_FULL_SCREEN
 import com.wordpress.stories.compose.ScreenTouchBlockMode.BLOCK_TOUCH_MODE_NONE
@@ -507,6 +508,10 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         updateFlashModeSelectionIcon()
 
         setupStoryViewModelObservers()
+
+        if (intent.getBooleanExtra(KEY_STORY_EDIT_MODE, false)) {
+            next_button.buttonMode = DONE
+        }
 
         if (savedInstanceState != null) {
             currentOriginalCapturedFile =


### PR DESCRIPTION
Correcting something missed during a merge (from https://github.com/Automattic/stories-android/pull/563 and https://github.com/Automattic/stories-android/pull/543).

When editing a story, the white arrow button on the top right is replaced with a checkmark.

To test:
1. Build WPAndroid with this branch
2. Create a story
3. Notice the top right button is an arrow
4. Edit a story
5. Notice the top right button is now a checkmark