### PR TITLE
Video player: catching more exceptions if we can't set the data source properly

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
@@ -276,12 +276,13 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
             Log.d(TAG, e.message)
         } catch (e: IllegalArgumentException) {
             playerPreparedListener?.onPlayerError()
-            Log.e(TAG, "Can't read duration of the video.", e);
+            Log.e(TAG, "Can't read duration of the video.", e)
         } catch (e: RuntimeException) {
             playerPreparedListener?.onPlayerError()
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5431
             Log.e(TAG,
-                    "Can't calculateVideoSizeAndOrientation due to a Runtime Exception happened setting the datasource", e);
+                    "Can't calculateVideoSizeAndOrientation due to a" +
+                            "Runtime Exception happened setting the datasource", e)
         } finally {
             metadataRetriever.release()
         }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
@@ -269,9 +269,19 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
             videoWidth = java.lang.Float.parseFloat(width)
             videoOrientation = rotation
         } catch (e: IOException) {
+            playerPreparedListener?.onPlayerError()
             Log.d(TAG, e.message)
         } catch (e: NumberFormatException) {
+            playerPreparedListener?.onPlayerError()
             Log.d(TAG, e.message)
+        } catch (e: IllegalArgumentException) {
+            playerPreparedListener?.onPlayerError()
+            Log.e(TAG, "Can't read duration of the video.", e);
+        } catch (e: RuntimeException) {
+            playerPreparedListener?.onPlayerError()
+            // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5431
+            Log.e(TAG,
+                    "Can't calculateVideoSizeAndOrientation due to a Runtime Exception happened setting the datasource", e);
         } finally {
             metadataRetriever.release()
         }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
@@ -414,17 +414,19 @@ class BackgroundSurfaceManager(
                     }
 
                     override fun onPlayerError() {
-                        photoEditorView.hideLoading()
-                        ErrorDialog.newInstance(requireNotNull(videoPlayerHandling.context)
-                                .getString(R.string.toast_error_playing_video),
+                        photoEditorView.post {
+                            photoEditorView.hideLoading()
+                            ErrorDialog.newInstance(requireNotNull(videoPlayerHandling.context)
+                                    .getString(R.string.toast_error_playing_video),
                                     object : ErrorDialogOk {
                                         override fun OnOkClicked(dialog: DialogFragment) {
                                             dialog.dismiss()
                                         }
                                     }
-                                ).show(supportFragmentManager,
-                                        FRAGMENT_DIALOG
-                                )
+                            ).show(supportFragmentManager,
+                                    FRAGMENT_DIALOG
+                            )
+                        }
                     }
                 }
 


### PR DESCRIPTION
When testing with different videos (especially mov and remote videos), it could be seen that trying to retrieve metadata after setting the datasource would end up resulting in various errors, that would make the app crash.

This PR aims at catching more exceptions and calling the error handler, given most of the time these errors should not crash the app and often these can be retried (for example, if the video is behind an https url, it should be possible to retry if the network conditions weren't proper at first).

To test:
1. download [this file](https://cloudup.com/cvjNmBmx7bV) to your handset / emulator (I used a Pixel 3 XL emulator with API level 29). It's 
2. try to add it in a Story from the device itself
3. observe it  doesn't crash but an error is displayed.

**BEFORE (observe it goes ANR and then crashes):**

![crash_before](https://user-images.githubusercontent.com/6597771/101223250-65f63680-366a-11eb-8c24-bfdf5fe78cb7.gif)

**AFTER (observe it does not crash any more and shows a proper error):**

![crash_after](https://user-images.githubusercontent.com/6597771/101223328-8b834000-366a-11eb-92e2-097051923f48.gif)


