### PR TITLE
Added new method replaceCurrentStory instead of loadStory

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -522,7 +522,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             firstIntentLoaded = savedInstanceState.getBoolean(STATE_KEY_FIRST_INTENT_LOADED)
             permissionsRequestForCameraInProgress = savedInstanceState.getBoolean(STATE_KEY_PERMISSION_REQ_IN_PROGRESS)
 
-            storyViewModel.loadStory(
+            storyViewModel.replaceCurrentStory(
                 StorySerializerUtils.deserializeStory(
                         requireNotNull(savedInstanceState.getString(STATE_KEY_STORY_SAVE_STATE))
                 )

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
@@ -45,6 +45,15 @@ object StoryRepository {
         return currentStoryIndex
     }
 
+    fun replaceCurrentStory(story: Story): StoryIndex {
+        if (isStoryIndexValid(currentStoryIndex)) {
+            stories[currentStoryIndex] = story
+            return currentStoryIndex
+        } else {
+            return loadStory(story)
+        }
+    }
+
     private fun isStoryIndexValid(storyIndex: StoryIndex): Boolean {
         return storyIndex > DEFAULT_NONE_SELECTED && stories.size > storyIndex
     }

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryViewModel.kt
@@ -65,8 +65,8 @@ class StoryViewModel(private val repository: StoryRepository, val storyIndex: St
         }
     }
 
-    fun loadStory(story: Story) {
-        repository.loadStory(story).let {
+    fun replaceCurrentStory(story: Story) {
+        repository.replaceCurrentStory(story).let {
             updateUiState(createUiStateFromModelState(repository.getImmutableCurrentStoryFrames()))
             // default selected frame when loading a new Story
             _onSelectedFrameIndex.value = Pair(DEFAULT_SELECTION, DEFAULT_SELECTION)


### PR DESCRIPTION
### Problem
With `don't keep activities` set to ON, the stories library would duplicate Stories as they get loaded, and new slides would get added to the new copy, but the calling Activity (the block Editor) would still only keep the index of the first one so, no slides would end up being added at all (copy 0 has 1 slide, copy 1 has 2 slides, copy 3 has 3 slides...)
Take this example:
1. Open a 1-slide Story in the Gutenberg Editor
2. the Story gets passed its index to the StoryComposer, which renders it, populating the StoryRepository for first time (stories.length == 1)
3. tap + to add a slide, the PhotoPicker activity shows up. This in turn kills the Story Composer activity, and makes the onSaveInstanceState code to run, serializing the current story with key `STATE_KEY_STORY_SAVE_STATE`
4. when we get back from the PhotoPicker, we once again load the story with `loadStory()` but now we do so from the deserialized data that comes in the saved state (same as in step 3). But the StoryRepository already is loaded, so actually calling `loadStory()` makes a new copy of the same Story get loaded in the StoryRepository (StoryRepository has 2 stories now)
5. the new Story slide (StoryFrameItem) gets added to the NEW copy of the Story in the StoryRepository, which has an index of 1 (not zero).
6. when we get back to the Gutenberg Editor, it thinks the index of the current Story being edited is zero (because that's the index it passed down to StoryComposer in the first place). So, this old Story copy has no references to the new slide that was added in step 5, so it doesn't find it, and as such there may come other problems down the line (for example, it not only is losing slides but also if they do get saved, sometimes we may get null ids because the frame Ids were assigned to the wrong Story's copy frames).

### Solution
With this change, we are now able to assign temporary ids to each frame correctly in `buildStoryMediaFileDataListFromStoryFrameIndexes()` in the host app, before triggering the save process. Basically, if the host app only holds an Index to a Story in the StoryRepository, we can rest assured that the Story we operate on in the ComposerLoopFrameActivity is still the same Story being referenced from the outside world.

To test:
- (using WPANdroid 16.3 but pointing to this branch in the stories lib folder)
- set don't keep activities dev option to ON on your emu / device
1. open an existing post with a story block in it
2. tap on it to edit
3. observe the index for this story is 0 when first loaded and goes through `loadStory(story)` method as specified in StoryRepository class (see method `replaceCurrentStory()`). Might be handy to place a breakpoint there.
4. add a slide to the story
5. when you exit the composer and than try editing the block a second time, observe the code now flows through the first part of the `if` clause in `replaceCurrentStory()`, effectively replacing the Story that lies in index zero of the `stories` internal array.

