### PR TITLE
Added helper method to get `alt` text composed of all added text views on a given frame

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameItem.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameItem.kt
@@ -92,7 +92,7 @@ data class StoryFrameItem(
 
         @JvmStatic
         fun getAltTextFromFrameAddedViews(frame: StoryFrameItem): String {
-            return frame.addedViews.joinToString(separator = " ") { it -> "${it.viewInfo.addedViewTextInfo.text}" }
+            return frame.addedViews.joinToString(separator = " ") { it.viewInfo.addedViewTextInfo.text }
         }
     }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameItem.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameItem.kt
@@ -89,5 +89,10 @@ data class StoryFrameItem(
                     }
             )
         }
+
+        @JvmStatic
+        fun getAltTextFromFrameAddedViews(frame: StoryFrameItem): String {
+            return frame.addedViews.joinToString(separator = " ") { it -> "${it.viewInfo.addedViewTextInfo.text}" }
+        }
     }
 }


### PR DESCRIPTION
Title has it - this PR only adds the ability to obtain a string with the text that was set for each and all added Text views for a given frame.

