### PR TITLE
Sending FrameSaveCompleted and FrameSaveFailed events as sticky events

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -329,7 +329,7 @@ class FrameSaveService : Service() {
             storySaveResult.frameSaveResult.add(FrameSaveResult(applyFrameIndexOverride(frameIndex), SaveSuccess))
 
             // dispatch FrameSaveCompleted event
-            EventBus.getDefault().post(FrameSaveCompleted(storyIndex, frameIndex, frame.id))
+            EventBus.getDefault().postSticky(FrameSaveCompleted(storyIndex, frameIndex, frame.id))
         }
 
         override fun onFrameSaveCanceled(frameIndex: FrameIndex, frame: StoryFrameItem) {
@@ -361,7 +361,7 @@ class FrameSaveService : Service() {
             storySaveResult.frameSaveResult.add(FrameSaveResult(applyFrameIndexOverride(frameIndex), SaveError(reason)))
 
             // dispatch FrameSaveFailed event
-            EventBus.getDefault().post(FrameSaveFailed(storyIndex, frameIndex, frame.id))
+            EventBus.getDefault().postSticky(FrameSaveFailed(storyIndex, frameIndex, frame.id))
         }
 
         fun attachProgressListener() {


### PR DESCRIPTION
Title has it - small change to overcome Activities / listeners getting killed on the host app.
See - https://github.com/wordpress-mobile/WordPress-Android/pull/13699