### PR TITLE
Use task avoidance for creating build config fields

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,10 +9,16 @@ android {
 
     signingConfigs {
         release {
-            storeFile file("${rootDir}/${rootProject.storeFile}")
-            storePassword rootProject.storePassword
-            keyAlias rootProject.keyAlias
-            keyPassword rootProject.keyPassword
+            if (rootProject.hasProperty("storeFile") 
+                && rootProject.hasProperty("storePassword") 
+                && rootProject.hasProperty("keyAlias") 
+                && rootProject.hasProperty("keyPassword")
+            ) { 
+                storeFile file("${rootDir}/${rootProject.storeFile}")
+                storePassword rootProject.storePassword
+                keyAlias rootProject.keyAlias
+                keyPassword rootProject.keyPassword
+            }
         }
     }
 
@@ -92,22 +98,26 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
-android.buildTypes.all { buildType ->
+tasks.register('createBuildConfigFieldsFromProperties') {
     // Add properties named "loop.xxx" to our BuildConfig
-    def properties = rootProject.loadGradleProperties()
-    properties.any { property ->
-    if (property.key.toLowerCase().startsWith("loop.")) {
-            buildType.buildConfigField "String", property.key.replace("loop.", "").replace(".", "_").toUpperCase(),
-                    "\"${property.value}\""
-        }
-        else if (property.key.toLowerCase().startsWith("sentry.dsn")) {
-            buildType.buildConfigField "String", property.key.replace(".", "_").toUpperCase(),
-                    "\"${property.value}\""
-        }
-        else if (property.key.toLowerCase().startsWith("loop.res.")) {
-            buildType.resValue "string", property.key.replace("loop.res.", "").replace(".", "_").toLowerCase(),
-                    "${property.value}"
+    android.buildTypes.all { buildType ->
+        def properties = rootProject.loadGradleProperties()
+        properties.any { property ->
+        if (property.key.toLowerCase().startsWith("loop.")) {
+                buildType.buildConfigField "String", property.key.replace("loop.", "").replace(".", "_").toUpperCase(),
+                        "\"${property.value}\""
+            }
+            else if (property.key.toLowerCase().startsWith("sentry.dsn")) {
+                buildType.buildConfigField "String", property.key.replace(".", "_").toUpperCase(),
+                        "\"${property.value}\""
+            }
+            else if (property.key.toLowerCase().startsWith("loop.res.")) {
+                buildType.resValue "string", property.key.replace("loop.res.", "").replace(".", "_").toLowerCase(),
+                        "${property.value}"
+            }
         }
     }
 }
+
+preBuild.dependsOn(tasks.named("createBuildConfigFieldsFromProperties"))
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,18 +9,10 @@ android {
 
     signingConfigs {
         release {
-
-            if (!rootProject.gradleProperties.exists()) {
-                println "Unable to read ${gradleProperties}"
-                return
-            }
-
-            def properties = loadPropertiesFromFile(rootProject.gradleProperties)
-
-            storeFile file("${rootDir}/${properties.storeFile}")
-            storePassword properties.storePassword
-            keyAlias = properties.keyAlias
-            keyPassword properties.keyPassword
+            storeFile file("${rootDir}/${rootProject.storeFile}")
+            storePassword rootProject.storePassword
+            keyAlias rootProject.keyAlias
+            keyPassword rootProject.keyPassword
         }
     }
 
@@ -102,10 +94,7 @@ dependencies {
 
 android.buildTypes.all { buildType ->
     // Add properties named "loop.xxx" to our BuildConfig
-    if (!rootProject.gradleProperties.exists()) {
-        return
-    }
-    def properties = loadPropertiesFromFile(rootProject.gradleProperties)
+    def properties = rootProject.loadGradleProperties()
     properties.any { property ->
     if (property.key.toLowerCase().startsWith("loop.")) {
             buildType.buildConfigField "String", property.key.replace("loop.", "").replace(".", "_").toUpperCase(),
@@ -122,10 +111,3 @@ android.buildTypes.all { buildType ->
     }
 }
 
-static def loadPropertiesFromFile(inputFile) {
-    def properties = new Properties()
-    inputFile.withInputStream { stream ->
-        properties.load(stream)
-    }
-    return properties
-}

--- a/build.gradle
+++ b/build.gradle
@@ -96,10 +96,21 @@ ext {
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'
     navComponentVersion = '2.0.0'
-
-    gradleProperties = file("${rootDir}/gradle.properties")
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+def loadGradleProperties() {
+    def inputFile = file("${rootDir}/gradle.properties")
+    if (!inputFile.exists()) {
+        throw new StopActionException("Build configuration file gradle.properties doesn't exist, follow README instructions")
+    }
+    def properties = new Properties()
+    inputFile.withInputStream { stream ->
+        properties.load(stream)
+    }
+    return properties
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -113,4 +113,3 @@ def loadGradleProperties() {
     }
     return properties
 }
-

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -71,27 +71,28 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
-android.buildTypes.all { buildType ->
+tasks.register('createBuildConfigFieldsFromProperties') {
     // Add properties named "loop.xxx" to our BuildConfig
-    def properties = rootProject.loadGradleProperties()
-    properties.any { property ->
-        if (property.key.toLowerCase().startsWith("wp.stories.use.")) {
-            buildType.buildConfigField "boolean", property.key.replace("wp.stories.", "").replace(".", "_").toUpperCase(),
-                    "${property.value}"
+    android.buildTypes.all { buildType ->
+        def properties = rootProject.loadGradleProperties()
+        properties.any { property ->
+            if (property.key.toLowerCase().startsWith("wp.stories.use.")) {
+                buildType.buildConfigField "boolean", property.key.replace("wp.stories.", "").replace(".", "_").toUpperCase(), "${property.value}"
+            }
+            else if (property.key.toLowerCase().startsWith("wp.stories.")) {
+                buildType.buildConfigField "String", property.key.replace("wp.stories.", "").replace(".", "_").toUpperCase(), "\"${property.value}\""
+            }
+            else if (property.key.toLowerCase().startsWith("wp.stories.res.")) {
+                buildType.resValue "string", property.key.replace("wp.stories.res.", "").replace(".", "_").toLowerCase(), "${property.value}"
+            }
         }
-        else if (property.key.toLowerCase().startsWith("wp.stories.")) {
-            buildType.buildConfigField "String", property.key.replace("wp.stories.", "").replace(".", "_").toUpperCase(),
-                    "\"${property.value}\""
-        }
-        else if (property.key.toLowerCase().startsWith("wp.stories.res.")) {
-            buildType.resValue "string", property.key.replace("wp.stories.res.", "").replace(".", "_").toLowerCase(),
-                    "${property.value}"
-        }
-    }
 
-    if (properties.getProperty("wp.stories.use.cameraX") == null) {
-        // use cameraX implementation by default if no gradle.properties set
-        buildType.buildConfigField "boolean", "USE_CAMERAX", "true"
+        if (properties.getProperty("wp.stories.use.cameraX") == null) {
+            // use cameraX implementation by default if no gradle.properties set
+            buildType.buildConfigField "boolean", "USE_CAMERAX", "true"
+        }
     }
 }
+
+preBuild.dependsOn(tasks.named("createBuildConfigFieldsFromProperties"))
 

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -73,11 +73,7 @@ dependencies {
 
 android.buildTypes.all { buildType ->
     // Add properties named "loop.xxx" to our BuildConfig
-    if (!rootProject.gradleProperties.exists()) {
-        return
-    }
-
-    def properties = loadPropertiesFromFile(rootProject.gradleProperties)
+    def properties = rootProject.loadGradleProperties()
     properties.any { property ->
         if (property.key.toLowerCase().startsWith("wp.stories.use.")) {
             buildType.buildConfigField "boolean", property.key.replace("wp.stories.", "").replace(".", "_").toUpperCase(),
@@ -99,10 +95,3 @@ android.buildTypes.all { buildType ->
     }
 }
 
-static def loadPropertiesFromFile(inputFile) {
-    def properties = new Properties()
-    inputFile.withInputStream { stream ->
-        properties.load(stream)
-    }
-    return properties
-}


### PR DESCRIPTION
This PR contains suggestions for #635 with some minor refactors. One of the issues with creating a dependency to a file such as `gradle.properties` during the project configuration stage is that our task that wants to create this file can not be run manually. (it probably could be done automatically, but this an optional task) This issue was referenced several times by @jkmassel in these comments: [#](https://github.com/Automattic/stories-android/pull/635/files#r565840273), [#](https://github.com/Automattic/stories-android/pull/635/files#r565840333), [#](https://github.com/Automattic/stories-android/pull/635/files#r565840622)

What we need is a way to be able to run the `applyConfiguration` task without triggering the build failures that'd be caused by the missing `gradle.properties` file, but also make sure this error is handled for regular builds. And the way to achieve that is what Gradle calls [Task Configuration Avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html). Basically, we can register a task and make another task depend on it while also avoiding the evaluation of this task if it won't be run. For `applyConfiguration` task, that's exactly the case as it shouldn't depend on anything else in the build, neither should it create a dependency to the build as it's an optional task. (more on that later)

The PR also makes some minor refactors to `signingConfigs` block as we don't need a `gradleProperties` property in the root project [after moving the `gradle.properties` file to the project root](https://github.com/Automattic/stories-android/pull/635/commits/3682896985a582c00176ed26d1d39878bdd92c85).

**To test:**
1. Delete `gradle.properties` file and run `./gradlew applyConfiguration` and verify that it successfully creates the `gradle.properties` file.
2. Delete `gradle.properties` file and run `./gradlew build`, `./gradlew :stories:build` and `./gradlew :app:build` and verify that all of them tells us that we are missing the `gradle.properties` file. (Another alternative is to just run `./gradlew build --dry-run` and check that `createBuildConfigFieldsFromProperties` task would be run for both `stories` and `app` modules)
3. Delete `gradle.properties` file, run `./gradlew applyConfiguration` and `./gradlew build` and verify that everything builds successfully.

We can probably test the installable build after (if?) we merge this to the original PR.

**Further possible improvements**
1. It'd be great to use task configuration avoidance for the `configure` task so it's not evaluated unless it's directly called.
2. This might be overkill, but we can move the release signing properties to its own file as its done in the [Google docs](https://developer.android.com/studio/publish/app-signing#secure-shared-keystore). Since I made some changes there, I thought I'd bring it up, but I don't think it's worth it.
3. We can improve the error message we get from `configure` task when the `.mobile-secrets` repo is not up to date. I am currently getting the error below. It'd be good to remind developers that this might be resolved by pulling in `.mobile-secrets` repo. (This suggestion belongs to the original PR, but I wanted to group the suggestions)

```
02:06:00 [DEBUG] (1) configure::fs: Reading keys from "~/.mobile-secrets/keys.json"
thread 'main' panicked at 'Unable to decrypt and copy files: MissingProjectKey', src/configure.rs:176:53
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```