### PR TITLE
Move font loading to background thread

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -341,6 +341,9 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             }
         }
 
+        // Pre-load the custom fonts if necessary
+        TextStyleGroupManager.preloadFonts(this)
+
         workingAreaRect = calculateWorkingArea()
         photoEditor = PhotoEditor.Builder(this, photoEditorView)
             .setPinchTextScalable(true) // set flag to make text scalable when pinch

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -430,7 +430,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
         photoEditor.setFontResolver(object : FontResolver {
             override fun resolve(@TypefaceId typefaceId: Int): IdentifiableTypeface {
-                return TextStyleGroupManager.getIdentifiableTypefaceForId(typefaceId, this@ComposeLoopFrameActivity)
+                return TextStyleGroupManager.getIdentifiableTypefaceForId(typefaceId)
             }
         })
 

--- a/stories/src/main/java/com/wordpress/stories/compose/text/FontRequester.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/FontRequester.kt
@@ -8,6 +8,7 @@ import androidx.annotation.FontRes
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.content.res.ResourcesCompat.FontCallback
 import androidx.core.provider.FontsContractCompat.FontRequestCallback.FontRequestFailReason
+import java.util.Collections
 
 /**
  * Handles dispatching requests to ResourcesCompat.getFont() asynchronously. These requests can take a long time,
@@ -22,7 +23,7 @@ import androidx.core.provider.FontsContractCompat.FontRequestCallback.FontReques
 object FontRequester {
     private val TAG = FontRequester::class.java.simpleName
 
-    val fontMap = mutableMapOf<Int, Typeface>()
+    val fontMap: MutableMap<Int, Typeface> = Collections.synchronizedMap(mutableMapOf<Int, Typeface>())
 
     fun registerFont(context: Context, @FontRes fontRes: Int, fallback: Typeface) {
         // Set the font to the fallback right away in case it's requested before getFont completes.

--- a/stories/src/main/java/com/wordpress/stories/compose/text/FontRequester.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/FontRequester.kt
@@ -1,0 +1,72 @@
+package com.wordpress.stories.compose.text
+
+import android.content.Context
+import android.content.res.Resources.NotFoundException
+import android.graphics.Typeface
+import android.util.Log
+import androidx.annotation.FontRes
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.content.res.ResourcesCompat.FontCallback
+import androidx.core.provider.FontsContractCompat.FontRequestCallback.FontRequestFailReason
+
+/**
+ * Handles dispatching requests to ResourcesCompat.getFont() asynchronously. These requests can take a long time,
+ * for example when the font is downloadable and there are connection issues.
+ *
+ * When registering or requesting a font from FontRequester, a fallback Typeface must be specified which will
+ * be returned if:
+ * - The request to ResourcesCompat hasn't completed yet
+ * - The request to ResourcesCompat failed for any reason
+ * - The font being requested wasn't previously registered with FontRequester
+ */
+object FontRequester {
+    private val TAG = FontRequester::class.java.simpleName
+
+    val fontMap = mutableMapOf<Int, Typeface>()
+
+    fun registerFont(context: Context, @FontRes fontRes: Int, fallback: Typeface) {
+        // Set the font to the fallback right away in case it's requested before getFont completes.
+        fontMap[fontRes] = fallback
+        try {
+            ResourcesCompat.getFont(context, fontRes, fontCallbackFor(context, fontRes), null)
+        } catch (e: NotFoundException) {
+            Log.e(TAG, "Font ${context.resources.getResourceEntryName(fontRes)} not found")
+        }
+    }
+
+    fun getFont(@FontRes fontRes: Int, fallback: Typeface): Typeface {
+        return fontMap[fontRes] ?: fallback
+    }
+
+    private fun fontCallbackFor(context: Context, @FontRes fontRes: Int): FontCallback {
+        return object : FontCallback() {
+            /**
+             * Called when an asynchronous font was finished loading.
+             *
+             * @param typeface The font that was loaded.
+             */
+            override fun onFontRetrieved(typeface: Typeface) {
+                fontMap[fontRes] = typeface
+            }
+
+            /**
+             * Called when an asynchronous font failed to load.
+             *
+             * @param reason The reason the font failed to load. One of
+             * [FontRequestFailReason.FAIL_REASON_PROVIDER_NOT_FOUND],
+             * [FontRequestFailReason.FAIL_REASON_WRONG_CERTIFICATES],
+             * [FontRequestFailReason.FAIL_REASON_FONT_LOAD_ERROR],
+             * [FontRequestFailReason.FAIL_REASON_SECURITY_VIOLATION],
+             * [FontRequestFailReason.FAIL_REASON_FONT_NOT_FOUND],
+             * [FontRequestFailReason.FAIL_REASON_FONT_UNAVAILABLE] or
+             * [FontRequestFailReason.FAIL_REASON_MALFORMED_QUERY].
+             */
+            @Suppress("KDocUnresolvedReference")
+            override fun onFontRetrievalFailed(@FontRequestFailReason reason: Int) {
+                // Just log the failure - the font mapping is already pointed to the fallback font.
+                Log.e(TAG, "Font retrieval for ${context.resources.getResourceEntryName(fontRes)} failed. " +
+                        "FontRequestFailReason error code: $reason.")
+            }
+        }
+    }
+}

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextStyleGroupManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextStyleGroupManager.kt
@@ -1,7 +1,6 @@
 package com.wordpress.stories.compose.text
 
 import android.content.Context
-import android.content.res.Resources.NotFoundException
 import android.graphics.Typeface
 import android.util.TypedValue
 import android.widget.TextView
@@ -12,7 +11,6 @@ import androidx.annotation.Dimension.SP
 import androidx.annotation.FontRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
-import androidx.core.content.res.ResourcesCompat
 import com.automattic.photoeditor.text.IdentifiableTypeface
 import com.automattic.photoeditor.text.IdentifiableTypeface.TypefaceId
 import com.automattic.photoeditor.text.RoundedBackgroundColorSpan
@@ -219,6 +217,20 @@ class TextStyleGroupManager(val context: Context) {
             return IdentifiableTypeface(typefaceId, resolveTypeface(typefaceId, context))
         }
 
+        /**
+         * Initializes the custom fonts, including possibly downloading some of them for the first time.
+         * This is so they're ready when the text editor is eventually opened and we don't have to block
+         * the main thread or use the fallback fonts.
+         */
+        fun preloadFonts(context: Context) {
+            FontRequester.registerFont(context, R.font.nunito_bold, Typeface.SANS_SERIF)
+            FontRequester.registerFont(context, R.font.libre_baskerville, Typeface.SERIF)
+            FontRequester.registerFont(context, R.font.oswald_upper, Typeface.SANS_SERIF)
+            FontRequester.registerFont(context, R.font.pacifico, Typeface.SERIF)
+            FontRequester.registerFont(context, R.font.space_mono_bold, Typeface.MONOSPACE)
+            FontRequester.registerFont(context, R.font.shrikhand, Typeface.DEFAULT_BOLD)
+        }
+
         private fun resolveTypeface(@TypefaceId typefaceId: Int, context: Context): Typeface? {
             return when (typefaceId) {
                 TYPEFACE_ID_NUNITO -> getFontWithFallback(context, R.font.nunito_bold, Typeface.SANS_SERIF)
@@ -231,12 +243,8 @@ class TextStyleGroupManager(val context: Context) {
             }
         }
 
-        private fun getFontWithFallback(context: Context, @FontRes fontRes: Int, fallback: Typeface?): Typeface? {
-            return try {
-                ResourcesCompat.getFont(context, fontRes)
-            } catch (e: NotFoundException) {
-                fallback
-            }
+        private fun getFontWithFallback(context: Context, @FontRes fontRes: Int, fallback: Typeface): Typeface {
+            return FontRequester.getFont(fontRes, fallback)
         }
     }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextStyleGroupManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextStyleGroupManager.kt
@@ -103,7 +103,7 @@ class TextStyleGroupManager(val context: Context) {
         )
     }
 
-    private fun getFont(@TypefaceId typefaceId: Int) = resolveTypeface(typefaceId, context)
+    private fun getFont(@TypefaceId typefaceId: Int) = resolveTypeface(typefaceId)
 
     private fun getString(@StringRes stringRes: Int) = context.resources.getString(stringRes)
 
@@ -213,8 +213,8 @@ class TextStyleGroupManager(val context: Context) {
         const val TYPEFACE_ID_SPACE_MONO = 1005
         const val TYPEFACE_ID_SHRIKHAND = 1006
 
-        fun getIdentifiableTypefaceForId(@TypefaceId typefaceId: Int, context: Context): IdentifiableTypeface {
-            return IdentifiableTypeface(typefaceId, resolveTypeface(typefaceId, context))
+        fun getIdentifiableTypefaceForId(@TypefaceId typefaceId: Int): IdentifiableTypeface {
+            return IdentifiableTypeface(typefaceId, resolveTypeface(typefaceId))
         }
 
         /**
@@ -231,19 +231,19 @@ class TextStyleGroupManager(val context: Context) {
             FontRequester.registerFont(context, R.font.shrikhand, Typeface.DEFAULT_BOLD)
         }
 
-        private fun resolveTypeface(@TypefaceId typefaceId: Int, context: Context): Typeface? {
+        private fun resolveTypeface(@TypefaceId typefaceId: Int): Typeface? {
             return when (typefaceId) {
-                TYPEFACE_ID_NUNITO -> getFontWithFallback(context, R.font.nunito_bold, Typeface.SANS_SERIF)
-                TYPEFACE_ID_LIBRE_BASKERVILLE -> getFontWithFallback(context, R.font.libre_baskerville, Typeface.SERIF)
-                TYPEFACE_ID_OSWALD -> getFontWithFallback(context, R.font.oswald_upper, Typeface.SANS_SERIF)
-                TYPEFACE_ID_PACIFICO -> getFontWithFallback(context, R.font.pacifico, Typeface.SERIF)
-                TYPEFACE_ID_SPACE_MONO -> getFontWithFallback(context, R.font.space_mono_bold, Typeface.MONOSPACE)
-                TYPEFACE_ID_SHRIKHAND -> getFontWithFallback(context, R.font.shrikhand, Typeface.DEFAULT_BOLD)
+                TYPEFACE_ID_NUNITO -> getFontWithFallback(R.font.nunito_bold, Typeface.SANS_SERIF)
+                TYPEFACE_ID_LIBRE_BASKERVILLE -> getFontWithFallback(R.font.libre_baskerville, Typeface.SERIF)
+                TYPEFACE_ID_OSWALD -> getFontWithFallback(R.font.oswald_upper, Typeface.SANS_SERIF)
+                TYPEFACE_ID_PACIFICO -> getFontWithFallback(R.font.pacifico, Typeface.SERIF)
+                TYPEFACE_ID_SPACE_MONO -> getFontWithFallback(R.font.space_mono_bold, Typeface.MONOSPACE)
+                TYPEFACE_ID_SHRIKHAND -> getFontWithFallback(R.font.shrikhand, Typeface.DEFAULT_BOLD)
                 else -> null
             }
         }
 
-        private fun getFontWithFallback(context: Context, @FontRes fontRes: Int, fallback: Typeface): Typeface {
+        private fun getFontWithFallback(@FontRes fontRes: Int, fallback: Typeface): Typeface {
             return FontRequester.getFont(fontRes, fallback)
         }
     }


### PR DESCRIPTION
Should fix https://github.com/wordpress-mobile/WordPress-Android/issues/13693.

Stories relies on several downloadable fonts. It seems the problem was that on slow connections (or perhaps if the Google font server was unavailable to the user for any reason), obtaining the fonts can take a while, and we were making the request on the UI thread - leading to an ANR.

`ResourcesCompat#getFont()` turns out to support asynchronous font requests for this reason. However, asynchronously downloading when the text editor launches is too late; we'd always be using the fallback fonts instead of the custom fonts on first run of the story feature, which we don't want.

My solution is to cue the font loading ahead of time, when the story creator is started up. This will trigger the font download (if they're not already downloaded - otherwise `ResourcesCompat` will serve up the cached local font reference) and save the resolved font reference in the new `FontRequester`. Later requests to display the font are handled by `FontRequester`, which will serve up whatever it got from `ResourcesCompat` (or the fallback font in case of errors or if the callback hasn't been called yet).

Note: `FontRequester` behaves like a singleton - it should really be a dagger module and injected into `ComposeLoopFrameActivity` and `TextStyleGroupManager`, but that was starting to become too big a diversion. I think this is okay for now and we should plan a bigger dagger refactor for this and other areas where we need it (see #357 also).

### To test

Try things out on an emulator wiped clean (so any locally saved fonts are removed). If you filter for `font` in the log and run the app, you should see this when the creator is launched:

(The `V` logs from `com.automattic.loop` are temporary logging I added for testing and not included in the PR - the first set inside `registerFont()`, the second set in `onFontRetrieved()`).

```
com.automattic.loop V/FontRequester: Registering font: 2131296257
com.automattic.loop V/FontRequester: Registering font: 2131296256
com.automattic.loop V/FontRequester: Registering font: 2131296258
com.automattic.loop V/FontRequester: Registering font: 2131296259
com.automattic.loop V/FontRequester: Registering font: 2131296261
com.automattic.loop V/FontRequester: Registering font: 2131296260
com.google.android.gms I/FontsContentProvider: Received query name=Nunito&weight=700, URI content://com.google.android.gms.fonts
com.google.android.gms I/FontsContentProvider: Query [name=Nunito&weight=700] resolved to {Nunito, wdth 100.0, wght 700, ital 0.0, bestEffort false}
com.google.android.gms I/FontsContentProvider: Fetch {Nunito, wdth 100.0, wght 700, ital 0.0, bestEffort false} end status Status{statusCode=SUCCESS, resolution=null}
com.google.android.gms I/FontsContentProvider: Pulling font file for id = 6, cache size = 5
com.google.android.gms I/FontsContentProvider: Received query Libre Baskerville, URI content://com.google.android.gms.fonts
com.google.android.gms I/FontsContentProvider: Query [Libre Baskerville] resolved to {Libre Baskerville, wdth 100.0, wght 400, ital 0.0, bestEffort false}
com.google.android.gms I/FontsContentProvider: Fetch {Libre Baskerville, wdth 100.0, wght 400, ital 0.0, bestEffort false} end status Status{statusCode=SUCCESS, resolution=null}
com.google.android.gms I/FontsContentProvider: Pulling font file for id = 7, cache size = 6
com.google.android.gms I/FontsContentProvider: Received query Pacifico, URI content://com.google.android.gms.fonts
com.google.android.gms I/FontsContentProvider: Query [Pacifico] resolved to {Pacifico, wdth 100.0, wght 400, ital 0.0, bestEffort false}
com.google.android.gms I/FontsContentProvider: Fetch {Pacifico, wdth 100.0, wght 400, ital 0.0, bestEffort false} end status Status{statusCode=SUCCESS, resolution=null}
com.google.android.gms I/FontsContentProvider: Pulling font file for id = 8, cache size = 7
com.google.android.gms I/FontsContentProvider: Received query name=Space Mono&weight=700, URI content://com.google.android.gms.fonts
com.google.android.gms I/FontsContentProvider: Query [name=Space Mono&weight=700] resolved to {Space Mono, wdth 100.0, wght 700, ital 0.0, bestEffort false}
com.google.android.gms I/FontsContentProvider: Fetch {Space Mono, wdth 100.0, wght 700, ital 0.0, bestEffort false} end status Status{statusCode=SUCCESS, resolution=null}
com.google.android.gms I/FontsContentProvider: Pulling font file for id = 9, cache size = 6
com.google.android.gms I/FontsContentProvider: Received query Shrikhand, URI content://com.google.android.gms.fonts
com.google.android.gms I/FontsContentProvider: Query [Shrikhand] resolved to {Shrikhand, wdth 100.0, wght 400, ital 0.0, bestEffort false}
com.google.android.gms I/FontsContentProvider: Fetch {Shrikhand, wdth 100.0, wght 400, ital 0.0, bestEffort false} end status Status{statusCode=SUCCESS, resolution=null}
com.google.android.gms I/FontsContentProvider: Pulling font file for id = 10, cache size = 7
com.automattic.loop V/FontRequester: Font retrieved from ResourcesCompat: 2131296258
com.automattic.loop V/FontRequester: Font retrieved from ResourcesCompat: 2131296257
com.automattic.loop V/FontRequester: Font retrieved from ResourcesCompat: 2131296256
com.automattic.loop V/FontRequester: Font retrieved from ResourcesCompat: 2131296259
com.automattic.loop V/FontRequester: Font retrieved from ResourcesCompat: 2131296261
com.automattic.loop V/FontRequester: Font retrieved from ResourcesCompat: 2131296260
```

If after that you open the text editor, you should see the fonts already preloaded, and no new requests to `FontsContentProvider` in the log.