### PR TITLE
Make loadGradleProperties method static so it can be used in different rootProjects

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,8 @@ dependencies {
 tasks.register('createBuildConfigFieldsFromProperties') {
     // Add properties named "loop.xxx" to our BuildConfig
     android.buildTypes.all { buildType ->
-        def properties = rootProject.loadGradleProperties()
+        def inputFile = file("${rootDir}/gradle.properties")
+        def properties = loadGradleProperties(inputFile)
         properties.any { property ->
         if (property.key.toLowerCase().startsWith("loop.")) {
                 buildType.buildConfigField "String", property.key.replace("loop.", "").replace(".", "_").toUpperCase(),

--- a/build.gradle
+++ b/build.gradle
@@ -102,8 +102,7 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
-def loadGradleProperties() {
-    def inputFile = file("${rootDir}/gradle.properties")
+static def loadGradleProperties(inputFile) {
     if (!inputFile.exists()) {
         throw new StopActionException("Build configuration file gradle.properties doesn't exist, follow README instructions")
     }

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -74,7 +74,8 @@ dependencies {
 tasks.register('createBuildConfigFieldsFromProperties') {
     // Add properties named "loop.xxx" to our BuildConfig
     android.buildTypes.all { buildType ->
-        def properties = rootProject.loadGradleProperties()
+        def inputFile = file("${rootDir}/gradle.properties")
+        def properties = loadGradleProperties(inputFile)
         properties.any { property ->
             if (property.key.toLowerCase().startsWith("wp.stories.use.")) {
                 buildType.buildConfigField "boolean", property.key.replace("wp.stories.", "").replace(".", "_").toUpperCase(), "${property.value}"


### PR DESCRIPTION
Title has it - for some reason (*) the latest stories `develop` started failing to build when used in parent project WordPress-Android, given it couldn't find the `loadGradleProperties()` method at `rootProject`. (see this [CircleCI report](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/21321/workflows/295f9d83-2684-4f85-8f2b-17eeef326bb4/jobs/96022))

Defining the method as static and using it from where needed seemed to work (borrowed idea from WordPress [parent project](https://github.com/wordpress-mobile/WordPress-Android/blob/HEAD/WordPress/build.gradle#L464) itself)

(*) I suspect from [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13996) which implements Detekt on WPAndroid although it doesn't really seem to be touching any of this directly. In any case, spent some time figuring things out and decided to move on with this solution which is simple enough

To test:
1. in WPAndroid, update `libs/stories-android` submodule to this branch
2. run `./gradlew lintVanillaRelease` 
3. verify it finishes successfully
