### PR TITLE
CameraX update (part3) using setTargetResolution with normalized values on VideoCapture

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -34,6 +34,7 @@ import com.automattic.photoeditor.text.IdentifiableTypeface
 import com.automattic.photoeditor.text.TextStyler
 import com.automattic.photoeditor.util.BitmapUtil
 import com.automattic.photoeditor.util.FileUtils
+import com.automattic.photoeditor.util.VideoUtils
 import com.automattic.photoeditor.views.PhotoEditorView
 import com.automattic.photoeditor.views.ViewType
 import com.automattic.photoeditor.views.ViewType.EMOJI
@@ -797,7 +798,7 @@ class PhotoEditor private constructor(builder: Builder) :
             // the black parts of the screen.
             // .size(originalCanvasWidth, originalCanvasHeight)
             // normalize output video size if actual screen size does not match a "normal" video size
-            .size(normalizeTargetVideoSize(originalCanvasWidth, originalCanvasHeight))
+            .size(VideoUtils.normalizeTargetVideoSize(originalCanvasWidth, originalCanvasHeight))
             .fillMode(FillMode.PRESERVE_ASPECT_FIT)
             .filter(if (customAddedViews.isNotEmpty()) GlFilterGroup(filterCollection) else null)
             .mute(muteAudio)
@@ -823,54 +824,6 @@ class PhotoEditor private constructor(builder: Builder) :
                 }
             })
             .start()
-    }
-
-    private fun normalizeTargetVideoSize(
-        requestedWidth: Int,
-        requestedHeight: Int
-    ): Size {
-        var adjustedSize = Size(requestedWidth, requestedHeight)
-        // As per CDD, all android devices running API level 21 (our minSdk) with H.264 codec must support 720 x 480 px.
-        // see https://source.android.com/compatibility/5.0/android-5.0-cdd#5_2_video_encoding
-        // MUST
-        // - 320 x 240 px
-        // - 720 x 480 px
-        // SHOULD (when hardware available)
-        // - 1280 x 720 px
-        // - 1920 x 1080 px
-
-        // the other formats (2160p, 1440p, 1080p etc) are "popular" ones found on many devices
-        // note we reverse the width/height given we support portrait mode only.
-        when {
-            // 2160p = 3840x2160
-            (requestedWidth % 2160 == 0) -> {
-                adjustedSize = Size(2160, 3840)
-            }
-
-            // 1440p = 2560x1440
-            (requestedWidth % 1440 == 0) -> {
-                adjustedSize = Size(1440, 2560)
-            }
-
-            // 1080p = 1920x1080
-            (requestedWidth % 1080 == 0) -> {
-                adjustedSize = Size(1080, 1920)
-            }
-
-            // 720p = 1280x720
-            (requestedWidth % 720 == 0) -> {
-                adjustedSize = Size(720, 1280)
-            }
-
-            (requestedWidth % 480 == 0) -> {
-                adjustedSize = Size(480, 720)
-            }
-
-            (requestedWidth % 240 == 0) -> {
-                adjustedSize = Size(240, 320)
-            }
-        }
-        return adjustedSize
     }
 
     /**

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt
@@ -8,6 +8,7 @@ import android.hardware.camera2.CameraManager
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
+import android.util.DisplayMetrics
 import android.util.Log
 import android.util.Size
 import android.view.Surface
@@ -44,6 +45,7 @@ import com.automattic.photoeditor.camera.interfaces.cameraXLensFacingFromStories
 import com.automattic.photoeditor.camera.interfaces.cameraXflashModeFromStoriesFlashState
 import com.automattic.photoeditor.camera.interfaces.storiesCameraSelectionFromCameraXLensFacing
 import com.automattic.photoeditor.util.FileUtils
+import com.automattic.photoeditor.util.VideoUtils
 import com.automattic.photoeditor.views.background.video.AutoFitTextureView
 import com.google.common.util.concurrent.ListenableFuture
 
@@ -250,11 +252,14 @@ class CameraXBasicHandling : VideoRecorderFragment() {
                 }
             }
 
+            val metrics = DisplayMetrics().also { textureView.display.getRealMetrics(it) }
+            val videoTargetResolution = VideoUtils.normalizeTargetVideoSize(metrics.widthPixels, metrics.heightPixels)
             // Set up the capture use case to allow users to take photos
             videoCapture = VideoCapture.Builder()
                     // We request aspect ratio but no resolution to match preview config but letting
                     // CameraX optimize for whatever specific resolution best fits requested capture mode
-                    .setTargetAspectRatio(AspectRatio.RATIO_16_9)
+                    // .setTargetAspectRatio(AspectRatio.RATIO_16_9)
+                    .setTargetResolution(videoTargetResolution)
                     // Set initial target rotation, we will have to call this again if rotation changes
                     // during the lifecycle of this use case
                     .setTargetRotation(textureView.display.rotation)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/VideoUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/VideoUtils.kt
@@ -1,0 +1,55 @@
+package com.automattic.photoeditor.util
+
+import android.util.Size
+
+class VideoUtils {
+    companion object {
+        fun normalizeTargetVideoSize(
+            requestedWidth: Int,
+            requestedHeight: Int
+        ): Size {
+            var adjustedSize = Size(requestedWidth, requestedHeight)
+            // As per CDD, all android devices running API level 21 (our minSdk) with H.264 codec must support 720 x 480 px.
+            // see https://source.android.com/compatibility/5.0/android-5.0-cdd#5_2_video_encoding
+            // MUST
+            // - 320 x 240 px
+            // - 720 x 480 px
+            // SHOULD (when hardware available)
+            // - 1280 x 720 px
+            // - 1920 x 1080 px
+
+            // the other formats (2160p, 1440p, 1080p etc) are "popular" ones found on many devices
+            // note we reverse the width/height given we support portrait mode only.
+            when {
+                // 2160p = 3840x2160
+                (requestedWidth % 2160 == 0) -> {
+                    adjustedSize = Size(2160, 3840)
+                }
+
+                // 1440p = 2560x1440
+                (requestedWidth % 1440 == 0) -> {
+                    adjustedSize = Size(1440, 2560)
+                }
+
+                // 1080p = 1920x1080
+                (requestedWidth % 1080 == 0) -> {
+                    adjustedSize = Size(1080, 1920)
+                }
+
+                // 720p = 1280x720
+                (requestedWidth % 720 == 0) -> {
+                    adjustedSize = Size(720, 1280)
+                }
+
+                (requestedWidth % 480 == 0) -> {
+                    adjustedSize = Size(480, 720)
+                }
+
+                (requestedWidth % 240 == 0) -> {
+                    adjustedSize = Size(240, 320)
+                }
+            }
+            return adjustedSize
+        }
+    }
+}


### PR DESCRIPTION
This PR explores using a combination of:
- target aspect ratio for Preview & ImageCapture use cases
- target _resolution_ for the VideoCapture use case instead
- passing a normalized target resolution to it, which is the same normalized resolution being used to generate the resulting stories video slide in mp4composer

In general, it seemed to get us better results on the tested handsets (see https://github.com/Automattic/stories-android/pull/638), but leaving this exploration as an experiment only for now