### PR TITLE
CameraX update (part5) using transformInfo listener (EXPERIMENTAL)

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/camerax/view/PreviewTransformation.java
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/camerax/view/PreviewTransformation.java
@@ -1,0 +1,415 @@
+package com.automattic.photoeditor.camera.camerax.view;
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static android.graphics.Paint.ANTI_ALIAS_FLAG;
+import static android.graphics.Paint.DITHER_FLAG;
+import static android.graphics.Paint.FILTER_BITMAP_FLAG;
+import static androidx.camera.view.PreviewView.ScaleType.FILL_CENTER;
+import static androidx.camera.view.PreviewView.ScaleType.FIT_CENTER;
+import static androidx.camera.view.PreviewView.ScaleType.FIT_END;
+import static androidx.camera.view.PreviewView.ScaleType.FIT_START;
+import static com.automattic.photoeditor.camera.camerax.view.TransformUtils.createRotatedVertices;
+import static com.automattic.photoeditor.camera.camerax.view.TransformUtils.is90or270;
+import static com.automattic.photoeditor.camera.camerax.view.TransformUtils.rectToVertices;
+import static com.automattic.photoeditor.camera.camerax.view.TransformUtils.sizeToVertices;
+import static com.automattic.photoeditor.camera.camerax.view.TransformUtils.surfaceRotationToRotationDegrees;
+import static com.automattic.photoeditor.camera.camerax.view.TransformUtils.verticesToRect;
+
+import android.annotation.SuppressLint;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Matrix;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.util.LayoutDirection;
+import android.util.Log;
+import android.util.Size;
+import android.util.SizeF;
+import android.view.Display;
+import android.view.Surface;
+import android.view.SurfaceView;
+import android.view.TextureView;
+import android.view.View;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.annotation.experimental.UseExperimental;
+import androidx.camera.core.ExperimentalUseCaseGroup;
+// import androidx.camera.core.Logger;
+import androidx.camera.core.SurfaceRequest;
+import androidx.camera.core.ViewPort;
+import androidx.camera.view.PreviewView;
+//import androidx.camera.view.PreviewViewMeteringPointFactory;
+import androidx.core.util.Preconditions;
+/**
+ * Handles {@link PreviewView} transformation.
+ *
+ * <p> This class transforms the camera output and display it in a {@link PreviewView}. The goal is
+ * to transform it in a way so that the entire area of
+ * {@link SurfaceRequest.TransformationInfo#getCropRect()} is 1) visible to end users, and 2)
+ * displayed as large as possible.
+ *
+ * <p> The inputs for the calculation are 1) the dimension of the Surface, 2) the crop rect, 3) the
+ * dimension of the PreviewView and 4) rotation degrees:
+ *
+ * <pre>
+ * Source: +-----Surface-----+     Destination:  +-----PreviewView----+
+ *         |                 |                   |                    |
+ *         |  +-crop rect-+  |                   |                    |
+ *         |  |           |  |                   +--------------------+
+ *         |  |           |  |
+ *         |  |    -->    |  |        Rotation:        <-----+
+ *         |  |           |  |                           270°|
+ *         |  |           |  |                               |
+ *         |  +-----------+  |
+ *         +-----------------+
+ *
+ * By mapping the Surface crop rect to match the PreviewView, we have:
+ *
+ *  +------transformed Surface-------+
+ *  |                                |
+ *  |     +----PreviewView-----+     |
+ *  |     |          ^         |     |
+ *  |     |          |         |     |
+ *  |     +--------------------+     |
+ *  |                                |
+ *  +--------------------------------+
+ * </pre>
+ *
+ * <p> The transformed Surface is how the PreviewView's inner view should behave, to make the
+ * crop rect matches the PreviewView.
+ */
+public final class PreviewTransformation {
+    private static final String TAG = "PreviewTransform";
+    private static final PreviewView.ScaleType DEFAULT_SCALE_TYPE = FILL_CENTER;
+    // SurfaceRequest.getResolution().
+    private Size mResolution;
+    // TransformationInfo.getCropRect().
+    private Rect mSurfaceCropRect;
+    // TransformationInfo.getRotationDegrees().
+    private int mPreviewRotationDegrees;
+    // TransformationInfo.getTargetRotation.
+    private int mTargetRotation;
+    // Whether the preview is using front camera.
+    private boolean mIsFrontCamera;
+    private PreviewView.ScaleType mScaleType = DEFAULT_SCALE_TYPE;
+    public PreviewTransformation() {
+    }
+    /**
+     * Sets the inputs.
+     *
+     * <p> All the values originally come from a {@link SurfaceRequest}.
+     */
+    @SuppressLint("RestrictedApi")
+    @UseExperimental(markerClass = ExperimentalUseCaseGroup.class)
+    public void setTransformationInfo(@NonNull SurfaceRequest.TransformationInfo transformationInfo,
+                               Size resolution, boolean isFrontCamera) {
+        Log.d(TAG, "Transformation info set: " + transformationInfo + " " + resolution + " "
+                   + isFrontCamera);
+        mSurfaceCropRect = transformationInfo.getCropRect();
+        mPreviewRotationDegrees = transformationInfo.getRotationDegrees();
+        mTargetRotation = transformationInfo.getTargetRotation();
+        mResolution = resolution;
+        mIsFrontCamera = isFrontCamera;
+    }
+    /**
+     * Creates a matrix that makes {@link TextureView}'s rotation matches the
+     * {@link #mTargetRotation}.
+     *
+     * <p> The value should be applied by calling {@link TextureView#setTransform(Matrix)}. Usually
+     * {@link #mTargetRotation} is the display rotation. In that case, this
+     * matrix will just make a {@link TextureView} works like a {@link SurfaceView}. If not, then
+     * it will further correct it to the desired rotation.
+     *
+     * <p> This method is also needed in {@link #createTransformedBitmap} to correct the screenshot.
+     */
+    @SuppressLint("RestrictedApi")
+    @VisibleForTesting
+    Matrix getTextureViewCorrectionMatrix() {
+        Preconditions.checkState(isTransformationInfoReady());
+        Matrix matrix = new Matrix();
+        float[] surfaceVertices = sizeToVertices(mResolution);
+        float[] rotatedSurfaceVertices = createRotatedVertices(surfaceVertices,
+                -surfaceRotationToRotationDegrees(mTargetRotation));
+        matrix.setPolyToPoly(surfaceVertices, 0, rotatedSurfaceVertices, 0, 4);
+        return matrix;
+    }
+    /**
+     * Calculates the transformation and applies it to the inner view of {@link PreviewView}.
+     *
+     * <p> The inner view could be {@link SurfaceView} or a {@link TextureView}.
+     * {@link TextureView} needs a preliminary correction since it doesn't handle the
+     * display rotation.
+     */
+    public void transformView(Size previewViewSize, int layoutDirection, @NonNull View preview) {
+        if (!isTransformationInfoReady()) {
+            return;
+        }
+        if (preview instanceof TextureView) {
+            // For TextureView, correct the orientation to match the target rotation.
+            ((TextureView) preview).setTransform(getTextureViewCorrectionMatrix());
+        } else {
+            // Logs an error if non-display rotation is used with SurfaceView.
+            Display display = preview.getDisplay();
+            if (display != null && display.getRotation() != mTargetRotation) {
+                Log.e(TAG, "Non-display rotation not supported with SurfaceView / PERFORMANCE "
+                              + "mode.");
+            }
+        }
+        RectF surfaceRectInPreviewView = getTransformedSurfaceRect(previewViewSize,
+                layoutDirection);
+        preview.setPivotX(0);
+        preview.setPivotY(0);
+        preview.setScaleX(surfaceRectInPreviewView.width() / mResolution.getWidth());
+        preview.setScaleY(surfaceRectInPreviewView.height() / mResolution.getHeight());
+        preview.setTranslationX(surfaceRectInPreviewView.left - preview.getLeft());
+        preview.setTranslationY(surfaceRectInPreviewView.top - preview.getTop());
+    }
+    /**
+     * Sets the {@link PreviewView.ScaleType}.
+     */
+    void setScaleType(PreviewView.ScaleType scaleType) {
+        mScaleType = scaleType;
+    }
+    /**
+     * Gets the {@link PreviewView.ScaleType}.
+     */
+    PreviewView.ScaleType getScaleType() {
+        return mScaleType;
+    }
+    /**
+     * Gets the transformed {@link Surface} rect in PreviewView coordinates.
+     *
+     * <p> Returns desired rect of the inner view that once applied, the only part visible to
+     * end users is the crop rect.
+     */
+    @SuppressLint("RestrictedApi")
+    private RectF getTransformedSurfaceRect(Size previewViewSize, int layoutDirection) {
+        Preconditions.checkState(isTransformationInfoReady());
+        Matrix surfaceToPreviewView =
+                getSurfaceToPreviewViewMatrix(previewViewSize, layoutDirection);
+        float[] surfaceVertices = sizeToVertices(mResolution);
+        surfaceToPreviewView.mapPoints(surfaceVertices);
+        return verticesToRect(surfaceVertices);
+    }
+    /**
+     * Calculates the transformation from {@link Surface} coordinates to {@link PreviewView}
+     * coordinates.
+     *
+     * <p> The calculation is based on making the crop rect to fill or fit the {@link PreviewView}.
+     */
+    @SuppressLint("RestrictedApi")
+    private Matrix getSurfaceToPreviewViewMatrix(Size previewViewSize, int layoutDirection) {
+        Preconditions.checkState(isTransformationInfoReady());
+        Matrix matrix = new Matrix();
+        // Get the target of the mapping, the vertices of the crop rect in PreviewView.
+        float[] previewViewCropRectVertices;
+        if (isCropRectAspectRatioMatchPreviewView(previewViewSize)) {
+            // If crop rect has the same aspect ratio as PreviewView, scale the crop rect to fill
+            // the entire PreviewView. This happens if the scale type is FILL_* AND a
+            // PreviewView-based viewport is used.
+            previewViewCropRectVertices = sizeToVertices(previewViewSize);
+        } else {
+            // If the aspect ratios don't match, it could be 1) scale type is FIT_*, 2) the
+            // Viewport is not based on the PreviewView or 3) both.
+            RectF previewViewCropRect = getPreviewViewCropRectForMismatchedAspectRatios(
+                    previewViewSize, layoutDirection);
+            previewViewCropRectVertices = rectToVertices(previewViewCropRect);
+        }
+        float[] rotatedPreviewViewCropRectVertices = createRotatedVertices(
+                previewViewCropRectVertices, mPreviewRotationDegrees);
+        // Get the source of the mapping, the vertices of the crop rect in Surface.
+        float[] surfaceCropRectVertices = rectToVertices(new RectF(mSurfaceCropRect));
+        // Map source to target.
+        matrix.setPolyToPoly(surfaceCropRectVertices, 0, rotatedPreviewViewCropRectVertices, 0, 4);
+        if (mIsFrontCamera) {
+            // SurfaceView/TextureView automatically mirrors the Surface for front camera, which
+            // needs to be compensated by mirroring the Surface around the upright direction of the
+            // output image.
+            if (is90or270(mPreviewRotationDegrees)) {
+                // If the rotation is 90/270, the Surface should be flipped vertically.
+                //   +---+     90 +---+  270 +---+
+                //   | ^ | -->    | < |      | > |
+                //   +---+        +---+      +---+
+                matrix.preScale(1F, -1F, mSurfaceCropRect.centerX(), mSurfaceCropRect.centerY());
+            } else {
+                // If the rotation is 0/180, the Surface should be flipped horizontally.
+                //   +---+      0 +---+  180 +---+
+                //   | ^ | -->    | ^ |      | v |
+                //   +---+        +---+      +---+
+                matrix.preScale(-1F, 1F, mSurfaceCropRect.centerX(), mSurfaceCropRect.centerY());
+            }
+        }
+        return matrix;
+    }
+    /**
+     * Gets the crop rect in {@link PreviewView} coordinates for the case where crop rect's aspect
+     * ratio doesn't match {@link PreviewView}'s aspect ratio.
+     *
+     * <p> When aspect ratios don't match, additional calculation is needed to figure out how to
+     * fit crop rect into the{@link PreviewView}.
+     */
+    RectF getPreviewViewCropRectForMismatchedAspectRatios(Size previewViewSize,
+                                                          int layoutDirection) {
+        RectF previewViewRect = new RectF(0, 0, previewViewSize.getWidth(),
+                previewViewSize.getHeight());
+        SizeF rotatedCropRectSize = getRotatedCropRectSize();
+        RectF rotatedSurfaceCropRect = new RectF(0, 0, rotatedCropRectSize.getWidth(),
+                rotatedCropRectSize.getHeight());
+        Matrix matrix = new Matrix();
+        setMatrixRectToRect(matrix, rotatedSurfaceCropRect, previewViewRect, mScaleType);
+        matrix.mapRect(rotatedSurfaceCropRect);
+        if (layoutDirection == LayoutDirection.RTL) {
+            return flipHorizontally(rotatedSurfaceCropRect, (float) previewViewSize.getWidth() / 2);
+        }
+        return rotatedSurfaceCropRect;
+    }
+    /**
+     * Set the matrix that maps the source rectangle to the destination rectangle.
+     *
+     * <p> This static method is an extension of {@link Matrix#setRectToRect} with an additional
+     * support for FILL_* types.
+     */
+    private static void setMatrixRectToRect(Matrix matrix, RectF source, RectF destination,
+                                            PreviewView.ScaleType scaleType) {
+        Matrix.ScaleToFit matrixScaleType;
+        switch (scaleType) {
+            case FIT_CENTER:
+                // Fallthrough.
+            case FILL_CENTER:
+                matrixScaleType = Matrix.ScaleToFit.CENTER;
+                break;
+            case FIT_END:
+                // Fallthrough.
+            case FILL_END:
+                matrixScaleType = Matrix.ScaleToFit.END;
+                break;
+            case FIT_START:
+                // Fallthrough.
+            case FILL_START:
+                matrixScaleType = Matrix.ScaleToFit.START;
+                break;
+            default:
+                Log.e(TAG, "Unexpected crop rect: " + scaleType);
+                matrixScaleType = Matrix.ScaleToFit.FILL;
+        }
+        boolean isFitTypes =
+                scaleType == FIT_CENTER || scaleType == FIT_START || scaleType == FIT_END;
+        if (isFitTypes) {
+            matrix.setRectToRect(source, destination, matrixScaleType);
+        } else {
+            // android.graphics.Matrix doesn't support fill scale types. The workaround is
+            // mapping inversely from destination to source, then invert the matrix.
+            matrix.setRectToRect(destination, source, matrixScaleType);
+            matrix.invert(matrix);
+        }
+    }
+    /**
+     * Flips the given rect along a vertical line for RTL layout direction.
+     */
+    private static RectF flipHorizontally(RectF original, float flipLineX) {
+        return new RectF(
+                flipLineX + flipLineX - original.right,
+                original.top,
+                flipLineX + flipLineX - original.left,
+                original.bottom);
+    }
+    /**
+     * Returns crop rect size with target rotation applied.
+     */
+    @SuppressLint("RestrictedApi")
+    private SizeF getRotatedCropRectSize() {
+        Preconditions.checkNotNull(mSurfaceCropRect);
+        if (is90or270(mPreviewRotationDegrees)) {
+            return new SizeF(mSurfaceCropRect.height(), mSurfaceCropRect.width());
+        }
+        return new SizeF(mSurfaceCropRect.width(), mSurfaceCropRect.height());
+    }
+    /**
+     * Checks if the crop rect's aspect ratio matches that of the {@link PreviewView}.
+     *
+     * <p> The mismatch could happen if the {@link ViewPort} is not based on the
+     * {@link PreviewView}, or the {@link PreviewView#getScaleType()} is FIT_*. In this case, we
+     * need to calculate how the crop rect should be fitted.
+     */
+    @VisibleForTesting
+    boolean isCropRectAspectRatioMatchPreviewView(Size previewViewSize) {
+        float previewViewRatio = (float) previewViewSize.getWidth() / previewViewSize.getHeight();
+        // In camera-core, when viewport's aspect ratio doesn't match PreviewView's aspect ratio,
+        // the result crop rect is rounded to the nearest integer. Allow 0.5px rounding error for
+        // each x and y axes.
+        SizeF rotatedSize = getRotatedCropRectSize();
+        float upperBound = (rotatedSize.getWidth() + .5F) / (rotatedSize.getHeight() - .5F);
+        float lowerBound = (rotatedSize.getWidth() - .5F) / (rotatedSize.getHeight() + .5F);
+        return previewViewRatio >= lowerBound && previewViewRatio <= upperBound;
+    }
+    /**
+     * Creates a transformed screenshot of {@link PreviewView}.
+     *
+     * <p> Creates the transformed {@link Bitmap} by applying the same transformation applied to
+     * the inner view. T
+     *
+     * @param original a snapshot of the untransformed inner view.
+     */
+    Bitmap createTransformedBitmap(@NonNull Bitmap original, Size previewViewSize,
+                                   int layoutDirection) {
+        if (!isTransformationInfoReady()) {
+            return original;
+        }
+        Matrix textureViewCorrection = getTextureViewCorrectionMatrix();
+        RectF surfaceRectInPreviewView = getTransformedSurfaceRect(previewViewSize,
+                layoutDirection);
+        Bitmap transformed = Bitmap.createBitmap(
+                previewViewSize.getWidth(), previewViewSize.getHeight(), original.getConfig());
+        Canvas canvas = new Canvas(transformed);
+        Matrix canvasTransform = new Matrix();
+        canvasTransform.postConcat(textureViewCorrection);
+        canvasTransform.postScale(surfaceRectInPreviewView.width() / mResolution.getWidth(),
+                surfaceRectInPreviewView.height() / mResolution.getHeight());
+        canvasTransform.postTranslate(surfaceRectInPreviewView.left, surfaceRectInPreviewView.top);
+        canvas.drawBitmap(original, canvasTransform,
+                new Paint(ANTI_ALIAS_FLAG | FILTER_BITMAP_FLAG | DITHER_FLAG));
+        return transformed;
+    }
+    /**
+     * Calculates the mapping from a UI touch point (0, 0) - (width, height) to normalized
+     * sensor rect (0, 0) - (1, 1).
+     *
+     * <p> This is used by {@link PreviewViewMeteringPointFactory}.
+     *
+     * @return null if transformation info is not set.
+     */
+    @Nullable
+    Matrix getPreviewViewToNormalizedSurfaceMatrix(Size previewViewSize, int layoutDirection) {
+        if (!isTransformationInfoReady()) {
+            return null;
+        }
+        Matrix matrix = new Matrix();
+        // Map PreviewView coordinates to Surface coordinates.
+        getSurfaceToPreviewViewMatrix(previewViewSize, layoutDirection).invert(matrix);
+        // Map Surface coordinates to normalized coordinates (0, 0) - (1, 1).
+        Matrix normalization = new Matrix();
+        normalization.setRectToRect(
+                new RectF(0, 0, mResolution.getWidth(), mResolution.getHeight()),
+                new RectF(0, 0, 1, 1), Matrix.ScaleToFit.FILL);
+        matrix.postConcat(normalization);
+        return matrix;
+    }
+    private boolean isTransformationInfoReady() {
+        return mSurfaceCropRect != null && mResolution != null;
+    }
+}

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/camerax/view/TransformUtils.java
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/camerax/view/TransformUtils.java
@@ -1,0 +1,180 @@
+package com.automattic.photoeditor.camera.camerax.view;
+
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import android.graphics.RectF;
+import android.util.Size;
+import android.view.Surface;
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
+/**
+ * Utility class for transform.
+ *
+ * <p> The vertices representation uses a float array to represent a rectangle with arbitrary
+ * rotation and rotation-direction. It could be otherwise represented by a triple of a
+ * {@link RectF}, a rotation degrees integer and a boolean flag for the rotation-direction
+ * (clockwise v.s. counter-clockwise).
+ *
+ * TODO(b/179827713): merge this with {@link androidx.camera.core.internal.utils.ImageUtil}.
+ *
+ * @hide
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+public class TransformUtils {
+    // Each vertex is represented by a pair of (x, y) which is 2 slots in a float array.
+    private static final int FLOAT_NUMBER_PER_VERTEX = 2;
+    private TransformUtils() {
+    }
+    /**
+     * Creates a new quad by rotating {@code original}'s vertices {@code rotationDegrees} clockwise.
+     *
+     * <pre>
+     *  a----b
+     *  |    |
+     *  d----c  vertices = {a.x, a.y, b.x, b.y, c.x, c.y, d.x, d.y}
+     *
+     * After 90° rotation:
+     *
+     *  d----a
+     *  |    |
+     *  c----b  vertices = {d.x, d.y, a.x, a.y, b.x, b.y, c.x, c.y}
+     * </pre>
+     *
+     * @param rotationDegrees multiple of 90.
+     */
+    @NonNull
+    public static float[] createRotatedVertices(@NonNull float[] original, int rotationDegrees) {
+        float[] rotated = new float[original.length];
+        int offset = -rotationDegrees / 90 * FLOAT_NUMBER_PER_VERTEX;
+        for (int originalIndex = 0; originalIndex < original.length; originalIndex++) {
+            int rotatedIndex = (originalIndex + offset) % original.length;
+            rotatedIndex = rotatedIndex < 0 ? rotatedIndex + original.length : rotatedIndex;
+            rotated[rotatedIndex] = original[originalIndex];
+        }
+        return rotated;
+    }
+    /**
+     * Converts an array of vertices to a {@link RectF}.
+     */
+    @NonNull
+    public static RectF verticesToRect(@NonNull float[] vertices) {
+        return new RectF(
+                min(vertices[0], vertices[2], vertices[4], vertices[6]),
+                min(vertices[1], vertices[3], vertices[5], vertices[7]),
+                max(vertices[0], vertices[2], vertices[4], vertices[6]),
+                max(vertices[1], vertices[3], vertices[5], vertices[7])
+        );
+    }
+    /**
+     * Returns the max value.
+     */
+    public static float max(float value1, float value2, float value3, float value4) {
+        return Math.max(Math.max(value1, value2), Math.max(value3, value4));
+    }
+    /**
+     * Returns the min value.
+     */
+    public static float min(float value1, float value2, float value3, float value4) {
+        return Math.min(Math.min(value1, value2), Math.min(value3, value4));
+    }
+    /**
+     * Converts {@link Surface} rotation to rotation degrees: 90, 180, 270 or 0.
+     */
+    public static int surfaceRotationToRotationDegrees(int rotationValue) {
+        switch (rotationValue) {
+            case Surface.ROTATION_0:
+                return 0;
+            case Surface.ROTATION_90:
+                return 90;
+            case Surface.ROTATION_180:
+                return 180;
+            case Surface.ROTATION_270:
+                return 270;
+            default:
+                throw new IllegalStateException("Unexpected rotation value " + rotationValue);
+        }
+    }
+    /**
+     * Returns true if the rotation degrees is 90 or 270.
+     */
+    public static boolean is90or270(int rotationDegrees) {
+        if (rotationDegrees == 90 || rotationDegrees == 270) {
+            return true;
+        }
+        if (rotationDegrees == 0 || rotationDegrees == 180) {
+            return false;
+        }
+        throw new IllegalArgumentException("Invalid rotation degrees: " + rotationDegrees);
+    }
+    /**
+     * Converts a {@link Size} to a float array of vertices.
+     */
+    @NonNull
+    public static float[] sizeToVertices(@NonNull Size size) {
+        return new float[]{0, 0, size.getWidth(), 0, size.getWidth(), size.getHeight(), 0,
+                size.getHeight()};
+    }
+    /**
+     * Converts a {@link RectF} defined by top, left, right and bottom to an array of vertices.
+     */
+    @NonNull
+    public static float[] rectToVertices(@NonNull RectF rectF) {
+        return new float[]{rectF.left, rectF.top, rectF.right, rectF.top, rectF.right, rectF.bottom,
+                rectF.left, rectF.bottom};
+    }
+    /**
+     * Checks if aspect ratio matches while tolerating rounding error.
+     *
+     * <p> One example of the usage is comparing the viewport-based crop rect from different use
+     * cases. The crop rect is rounded because pixels are integers, which may introduce an error
+     * when we check if the aspect ratio matches. For example, when {@link PreviewView}'s
+     * width/height are prime numbers 601x797, the crop rect from other use cases cannot have a
+     * matching aspect ratio even if they are based on the same viewport. This method checks the
+     * aspect ratio while tolerating a rounding error.
+     *
+     * @param size1       the rounded size1
+     * @param isAccurate1 if size1 is accurate. e.g. it's true if it's the PreviewView's
+     *                    dimension which viewport is based on
+     * @param size2       the rounded size2
+     * @param isAccurate2 if size2 is accurate.
+     */
+    public static boolean isAspectRatioMatchingWithRoundingError(
+            @NonNull Size size1, boolean isAccurate1, @NonNull Size size2, boolean isAccurate2) {
+        // The input width/height are rounded values, so they are at most .5 away from their
+        // true values.
+        // First figure out the possible range of the aspect ratio's ture value.
+        float ratio1UpperBound;
+        float ratio1LowerBound;
+        if (isAccurate1) {
+            ratio1UpperBound = (float) size1.getWidth() / size1.getHeight();
+            ratio1LowerBound = ratio1UpperBound;
+        } else {
+            ratio1UpperBound = (size1.getWidth() + .5F) / (size1.getHeight() - .5F);
+            ratio1LowerBound = (size1.getWidth() - .5F) / (size1.getHeight() + .5F);
+        }
+        float ratio2UpperBound;
+        float ratio2LowerBound;
+        if (isAccurate2) {
+            ratio2UpperBound = (float) size2.getWidth() / size2.getHeight();
+            ratio2LowerBound = ratio2UpperBound;
+        } else {
+            ratio2UpperBound = (size2.getWidth() + .5F) / (size2.getHeight() - .5F);
+            ratio2LowerBound = (size2.getWidth() - .5F) / (size2.getHeight() + .5F);
+        }
+        // Then we check if the true value range overlaps.
+        return ratio1UpperBound >= ratio2LowerBound && ratio2UpperBound >= ratio1LowerBound;
+    }
+}


### PR DESCRIPTION
In this PR, I tried to give the [transformationInfo](https://developer.android.com/reference/androidx/camera/core/SurfaceRequest.TransformationInfo) listener a try to exhaust the options I could think of. I did see some improvements in live preview not stretching for the most part, but still it would randomly get stuck when video recording starts (although not so often, perhaps some timing sensitivity there).

I first tried to set the listener and apply the `cropRect` from the live preview to a transform and use it in the TextureView, it kind of worked but gave mixed results (see `applyTransformationInfoOLD()`). Also borrowed ideas form an older [util class](https://android-review.googlesource.com/c/platform/frameworks/support/+/1204869/8/camera/camera-view/src/main/java/androidx/camera/view/ScaleTypeTransform.java#130) in CameraX.

Then I tried a shameless copy/paste of the related internal classes from PreviewView, i.e. [PreviewTransformation](https://android.googlesource.com/platform/frameworks/support/+/HEAD/camera/camera-view/src/main/java/androidx/camera/view/PreviewTransformation.java) which has all the details to cover most of the situations (in our case we can simplify because we’re always portrait and full screen, which makes it harder to understand when you add all the cases / abstractions), but still same results

With this, we end the exploratory PRs for upgrading CameraX to the latest rc-02, but since the VideoCapture use case showed regressions for us, we'll wait some more until an alpha is out (apparently [some time during H1 2021](https://issuetracker.google.com/u/1/issues/178206042#comment2)).
