### PR TITLE
Pan / zoom improvements: using glide-transformations library to add blurried background

### DIFF
--- a/photoeditor/build.gradle
+++ b/photoeditor/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.10.0'
     kapt 'com.github.bumptech.glide:compiler:4.10.0'
 
+    implementation 'jp.wasabeef:glide-transformations:4.3.0'
+    
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 
     implementation project(path: ':mp4compose')

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
@@ -79,6 +79,9 @@ class PhotoEditorView : RelativeLayout {
     val source: ImageView
         get() = backgroundImage
 
+    val sourceBlurredBkg: ImageView
+        get() = backgroundImageBlurred
+
     val brush: BrushDrawingView
         get() = brushDrawingView
 
@@ -118,6 +121,10 @@ class PhotoEditorView : RelativeLayout {
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         attachedToWindow = true
+    }
+
+    fun onComposerDestroyed() {
+        attachedToWindow = false
     }
 
     @SuppressLint("Recycle")

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
@@ -292,11 +292,13 @@ class PhotoEditorView : RelativeLayout {
 
     internal fun turnTextureViewOn() {
         backgroundImage.visibility = View.INVISIBLE
+        backgroundImageBlurred.visibility = View.INVISIBLE
         autoFitTextureView.visibility = View.VISIBLE
     }
 
     internal fun turnTextureViewOff() {
         backgroundImage.visibility = View.VISIBLE
+        backgroundImageBlurred.visibility = View.VISIBLE
         autoFitTextureView.visibility = View.INVISIBLE
     }
 
@@ -304,11 +306,13 @@ class PhotoEditorView : RelativeLayout {
         backgroundImage.visibility = autoFitTextureView.visibility.also {
             autoFitTextureView.visibility = backgroundImage.visibility
         }
+        backgroundImageBlurred.visibility = backgroundImage.visibility
         return autoFitTextureView.visibility == View.VISIBLE
     }
 
     internal fun turnTextureAndImageViewOff() {
         backgroundImage.visibility = View.INVISIBLE
+        backgroundImageBlurred.visibility = View.INVISIBLE
         autoFitTextureView.visibility = View.INVISIBLE
     }
 

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
@@ -12,10 +12,12 @@ import android.view.TextureView.SurfaceTextureListener
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.ImageView.ScaleType.CENTER_CROP
 import android.widget.ImageView.ScaleType.FIT_CENTER
 import android.widget.ProgressBar
 import android.widget.RelativeLayout
 import androidx.annotation.RequiresApi
+import androidx.appcompat.widget.AppCompatImageView
 import com.automattic.photoeditor.OnSaveBitmap
 import com.automattic.photoeditor.R.styleable
 import com.automattic.photoeditor.views.background.fixed.BackgroundImageView
@@ -24,6 +26,9 @@ import com.automattic.photoeditor.views.brush.BrushDrawingView
 import com.automattic.photoeditor.views.filter.CustomEffect
 import com.automattic.photoeditor.views.filter.ImageFilterView
 import com.automattic.photoeditor.views.filter.PhotoFilter
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.RequestOptions
+import jp.wasabeef.glide.transformations.BlurTransformation
 
 /**
  *
@@ -40,9 +45,11 @@ import com.automattic.photoeditor.views.filter.PhotoFilter
 class PhotoEditorView : RelativeLayout {
     private lateinit var autoFitTextureView: AutoFitTextureView
     private lateinit var backgroundImage: BackgroundImageView
+    private lateinit var backgroundImageBlurred: AppCompatImageView
     private lateinit var brushDrawingView: BrushDrawingView
     private lateinit var imageFilterView: ImageFilterView
     private lateinit var progressBar: ProgressBar
+    private var attachedToWindow: Boolean = false
 
     private var surfaceListeners: ArrayList<SurfaceTextureListener> = ArrayList()
 
@@ -103,8 +110,24 @@ class PhotoEditorView : RelativeLayout {
         init(attrs)
     }
 
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        attachedToWindow = false
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        attachedToWindow = true
+    }
+
     @SuppressLint("Recycle")
     private fun init(attrs: AttributeSet?) {
+        backgroundImageBlurred = AppCompatImageView(context).apply {
+            id = imgBlurSrcId
+            adjustViewBounds = true
+            scaleType = CENTER_CROP
+        }
+
         // Setup image attributes
         backgroundImage = BackgroundImageView(context).apply {
             id = imgSrcId
@@ -159,6 +182,11 @@ class PhotoEditorView : RelativeLayout {
 
         backgroundImage.setOnImageChangedListener(object : BackgroundImageView.OnImageChangedListener {
             override fun onBitmapLoaded(sourceBitmap: Bitmap?) {
+                if (attachedToWindow) {
+                    Glide.with(context).load(sourceBitmap)
+                            .apply(RequestOptions.bitmapTransform(BlurTransformation(25, 3)))
+                            .into(backgroundImageBlurred)
+                }
                 imageFilterView.setFilterEffect(PhotoFilter.NONE)
                 imageFilterView.setSourceBitmap(sourceBitmap)
                 Log.d(TAG, "onBitmapLoaded() called with: sourceBitmap = [$sourceBitmap]")
@@ -178,6 +206,9 @@ class PhotoEditorView : RelativeLayout {
 
         // Add camera preview
         addView(autoFitTextureView, cameraParam)
+
+        // Add image source
+        addView(backgroundImageBlurred, imgSrcParam)
 
         // Add image source
         addView(backgroundImage, imgSrcParam)
@@ -286,6 +317,7 @@ class PhotoEditorView : RelativeLayout {
 
     companion object {
         private val TAG = "PhotoEditorView"
+        private val imgBlurSrcId = 5
         private val imgSrcId = 1
         private val brushSrcId = 2
         private val glFilterId = 3

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -52,6 +52,8 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.10.0'
     kapt 'com.github.bumptech.glide:compiler:4.10.0'
 
+    implementation 'jp.wasabeef:glide-transformations:4.3.0'
+
     implementation 'org.greenrobot:eventbus:3.1.1'
 
     implementation project(path: ':photoeditor')

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -766,6 +766,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     override fun onDestroy() {
+        photoEditorView.onComposerDestroyed()
         doUnbindService()
         EventBus.getDefault().unregister(this)
         super.onDestroy()

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
@@ -289,7 +289,7 @@ class FrameSaveManager(
         frame: StoryFrameItem,
         originalMatrix: Matrix,
         ghostPhotoEditorView: PhotoEditorView
-    ): Pair<FutureTarget<Bitmap>, FutureTarget<Bitmap>>  {
+    ): Pair<FutureTarget<Bitmap>, FutureTarget<Bitmap>> {
         // prepare background
         val uri = (frame.source as? UriBackgroundSource)?.contentUri
             ?: (frame.source as FileBackgroundSource).file


### PR DESCRIPTION
This builds on top of #651 (last step to pan / zoom improvements)

>  On all phones, allow pinch to zoom, and when either height or width is now larger than the image bounds, **show a blur which will be included in the exported image.**

I first tried to reuse PhotoEditor's [PhotoFilter](https://github.com/burhanrashid52/PhotoEditor/blob/master/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoFilter.java), which is based on Android's Media package [EffectFactory](https://developer.android.com/reference/android/media/effect/EffectFactory) but it doesn't have a Blur effect builtin so, we can't rely on that (see https://github.com/burhanrashid52/PhotoEditor/wiki/Filter-Effect).

After checking a bit I decided to fo with [`glide-transformations`](https://github.com/wasabeef/glide-transformations) library which had a handy blur transformation for Glide.

Once that's sorted out we need to decide on an architecture to comply with two things:
- [x] each time the Story frame is changed, we need to present the blurry background, the source image, and the Added Views on top.
- [x] the resulting output file should also have the blurried background in it

We're taking advantage of the pre-existing [`OnImageChangeListener`](https://github.com/Automattic/stories-android/blob/df17e8c19d4e5584a7002e042adef4a5d4c32f9c/photoeditor/src/main/java/com/automattic/photoeditor/views/background/fixed/BackgroundImageView.kt#L38-L40) interface, which has one callback `OnBitmapLoaded` which gets called on several / all overridden setter methods that may have a visual impact on the underlying ImageView.

With this, each time an image background is set, we also make a call to draw the transformed /  blurred image on the background (deeper z-level).

**Example**
For these 2 original background images:
![512x512 PNG Landscape Texture - Rocky Stream](https://user-images.githubusercontent.com/6597771/109872216-e0732a00-7c4a-11eb-8caa-f5d1bdda0647.png)
![Icon_Bird_512x512](https://user-images.githubusercontent.com/6597771/109872221-e23ced80-7c4a-11eb-8cb4-ad62fa4a2be9.png)

This is the resulting output on a Pixel 3 XL (see it's normalized to 9:16):
![wp_story1614805120565_2](https://user-images.githubusercontent.com/6597771/109872261-f385fa00-7c4a-11eb-805e-ead3fea0fca7.jpg)
![wp_story1614805120758_1](https://user-images.githubusercontent.com/6597771/109872274-f84aae00-7c4a-11eb-8872-8622067fbbdc.jpg)




Notes:
~- Still need to figure out changes to FrameSaveManager, given we now need to paint both the blurred background and the background on the ghostPhotoEditor and we may need to wait and chain these together with Glide's [listener](https://bumptech.github.io/glide/javadocs/440/com/bumptech/glide/request/RequestListener.html#onResourceReady).~ this wasn't needed, just loading both is ok given it's z-index will paint them correctly, and also we're using sequential calls within our coroutines (which means async callback chaining wasn't going to be possible nor needed anyway)
- There's a small (but noticeable) delay on the Samsung J2 I'm using for testing after the main image is shown and before the blurred background is shown.
