### PR TITLE
Update eventbus version to v3.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,11 +10,11 @@ android {
 
     signingConfigs {
         release {
-            if (rootProject.hasProperty("storeFile") 
-                && rootProject.hasProperty("storePassword") 
-                && rootProject.hasProperty("keyAlias") 
+            if (rootProject.hasProperty("storeFile")
+                && rootProject.hasProperty("storePassword")
+                && rootProject.hasProperty("keyAlias")
                 && rootProject.hasProperty("keyPassword")
-            ) { 
+            ) {
                 storeFile file("${rootDir}/${rootProject.storeFile}")
                 storePassword rootProject.storePassword
                 keyAlias rootProject.keyAlias
@@ -78,7 +78,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.10.0'
     kapt 'com.github.bumptech.glide:compiler:4.10.0'
 
-    implementation 'org.greenrobot:eventbus:3.1.1'
+    implementation 'org.greenrobot:eventbus:3.2.0'
 
     implementation 'io.sentry:sentry-android:1.7.27'
     // this dependency is not required if you are already using your own

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
     implementation 'jp.wasabeef:glide-transformations:4.3.0'
 
-    implementation 'org.greenrobot:eventbus:3.1.1'
+    implementation 'org.greenrobot:eventbus:3.2.0'
 
     implementation project(path: ':photoeditor')
 


### PR DESCRIPTION
Follow up to https://github.com/wordpress-mobile/WordPress-Android/pull/14272

Updates eventBus to v3.2.0.

To test (smoke test)
1. create a few slides with the demo app
2. tap on the finish button on the right-top corner of tthe screen
3. verify the snackbars for Uploading / saved appear (these are connected through EventBus)
