### PR TITLE
Fix: make sure to run onStoryFrameSelected in onLoadFromIntent

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -726,6 +726,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         } else if (!partialCameraOperationInProgress && storyIndexToSelect != StoryRepository.DEFAULT_NONE_SELECTED &&
                 StoryRepository.getStoryAtIndex(storyIndexToSelect).frames.isNotEmpty()) {
             storyViewModel.loadStory(storyIndexToSelect)
+            onStoryFrameSelected(oldIndex = StoryRepository.DEFAULT_FRAME_NONE_SELECTED, newIndex = 0)
             showGenericAnnouncementDialogWhenReady = true
             return
         }


### PR DESCRIPTION
I wasn't able to pinpoint exactly when this started happening, but when you load an existing Story the first frame won't be refreshed. We're now forcing that refresh with this PR. so first frame is loaded when loading from intent

To test:
1. create a Story on WPAndroid
2. try editing it
3. observe the first frame appears correctly