### PR TITLE
Fix color picker bottom sheet clipping

### DIFF
--- a/stories/src/main/res/values/dimens.xml
+++ b/stories/src/main/res/values/dimens.xml
@@ -16,7 +16,7 @@
 
     <!-- START: Color picker bottom sheet -->
 
-    <dimen name="color_picker_bottom_sheet_default_height">250dp</dimen>
+    <dimen name="color_picker_bottom_sheet_default_height">275dp</dimen>
     <dimen name="color_picker_bottom_sheet_height_max_margin">75dp</dimen>
     <dimen name="color_picker_bottom_sheet_handle_width">40dp</dimen>
     <dimen name="color_picker_bottom_sheet_handle_height">4dp</dimen>


### PR DESCRIPTION
Fixes #597.

Since I'm now able to consistently reproduce the issue on a Pixel 5, I did some debugging to try and sort it out. I tried a few approaches but ultimately the extremely simple one in this PR seems best.

Essentially what was happening was that the minimum height for the bottom sheet was just a little too short, but for most devices the keyboard was short enough that we'd match the bottom sheet height to the keyboard height anyway, and that was taller than the minimum height.

The keyboard height on the Pixel 5 though is just tall for this check to be false, so the default height is used, and it's a bit too short.

After this adjustment the bottom sheet will match the keyboard height on a Pixel 5 too. There might be a bit more padding at the bottom than ideal, but in practice having the bottom sheet match the keyboard height makes for a much less janky transition so IMO it's worth it.

Here's the before/after on a Pixel 5:

![pixel-5-beforeafter](https://user-images.githubusercontent.com/9613966/114950919-036e3c00-9e8f-11eb-8fed-c56064a78f65.png)

Checked that nothing's changed on the Pixel 3:

![pixel-3-beforeafter](https://user-images.githubusercontent.com/9613966/114950920-0537ff80-9e8f-11eb-9e79-88e454a5a691.png)

I also checked with @bjtitus and confirmed this fix resolves the issue on his Samsung Galaxy S10 Lite (the source of the original issue report) 🎉 

Side note: I thought the issue might be related to https://github.com/wordpress-mobile/WordPress-Android/issues/12491, which I also see consistently on the Pixel 5 - but given what the problem with the color picker ended up being I'm not so sure.

#### To test

Run the demo app on a few different devices, bring up the text color picker, and make sure it's not clipped/behaves well everywhere.