### PR TITLE
Added null check for frameSaveResult[index] before accessing its members

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
@@ -124,9 +124,11 @@ object StoryRepository {
         // iterate over the StorySaveResult, check their indexes, and set the corresponding frame result
         if (isStoryIndexValid(storyIndex)) {
             for (index in 0..saveResult.frameSaveResult.size - 1) {
-                val frameIdxToSet = saveResult.frameSaveResult[index].frameIndex
-                stories[storyIndex].frames[frameIdxToSet].saveResultReason =
-                        saveResult.frameSaveResult[index].resultReason
+                if (saveResult.frameSaveResult[index] != null) {
+                    val frameIdxToSet = saveResult.frameSaveResult[index].frameIndex
+                    stories[storyIndex].frames[frameIdxToSet].saveResultReason =
+                            saveResult.frameSaveResult[index].resultReason
+                }
             }
         }
     }


### PR DESCRIPTION
Fix https://github.com/wordpress-mobile/WordPress-Android/issues/13695

This one is tricky.

I haven't been able to reproduce, but I believe that the only way this Exception

```
NullPointerException
Attempt to invoke virtual method 'int com.wordpress.stories.compose.frame.StorySaveEvents$FrameSaveResult.getFrameIndex()' on a null object reference
```

would exist at this point after finishing saving a Story in `setCurrentStorySaveResultOnFrames` would be when the passed `saveResult` would have an array with one or more `frameSaveResult` objects set to `null`:

```
                val frameIdxToSet = saveResult.frameSaveResult[index].frameIndex
```


### Dissecting code

These objects are assigned in 3 places:
- `onFrameSaveCompleted` override in `FrameSaveService`
- `onFrameSaveCanceled` override in `FrameSaveService`
- `onFrameSaveFailed` override in `FrameSaveService`

So basically, we're adding a new result object to the `saveResult.frameSaveResult` array accordingly, every time we know a frame has finished being saved (either successfully or cancelled or failed).

If the objects are being added, then there needs to exist an object at the index being referenced, and indeed it is, otherwise we would be getting an `IndexOutOfBoundsException`, and we are not getting that. What we are getting is a NPE when trying to access method `getFrameIndex()` on a null `frameSaveResult[index]`.

Looking into the code, there is no place where we're explicitly setting a given position of the `frameSaveResult` ArrayList to `null`. So, how can this possibly be?

Could it be possible that the object in the array is obtained first, but then the context in which it lives is destroyed, and as such we're trying to access a method on a `null` object?

One thing that I've seen seems to be a pattern across the cases reported in Sentry is that those cases would attempt to add several slides to a Story (i.e. 10 or more), which tells me processing times are more likely to affect the chances of running into this problem.

I thought we were calling `stopSelf()` on the FrameSaveService when the FrameSaveNotifier detects there's no other frames being saved, but the Service will be stopped only when no StorySaveProcessors are still running, [here](https://github.com/Automattic/stories-android/blob/21263ce37d10219b3f48dead1f815e3de8103e52/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt#L160-L163):
```
            // also if more than one processor is running, let's not stop the Service just now.
            if (storySaveProcessors.isEmpty()) {
                stopSelf()
            }
```
so it wasn't the case.

How this would related to the nullity of an object for which an index is valid, I still don't know.

For the time being, I decided to go ahead and add the null check. When I tried to do so, the language plugin strangely suggests that this value can never be null:

<img width="930" alt="Screen Shot 2021-04-16 at 20 34 20" src="https://user-images.githubusercontent.com/6597771/115071149-43074900-9ecc-11eb-9cbd-8a6d16f3739d.png">


However, the `frameSaveResult` is declared to be a `MutableList`, and [instantiated with `mutableListOf()`](https://github.com/Automattic/stories-android/blob/21263ce37d10219b3f48dead1f815e3de8103e52/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt#L15), for which the implementation is a java ArrayList:

```
/**
 * Returns an empty new [MutableList].
 * @sample samples.collections.Collections.Lists.emptyMutableList
 */
@SinceKotlin("1.1")
@kotlin.internal.InlineOnly
public inline fun <T> mutableListOf(): MutableList<T> = ArrayList()

```

An [`ArrayList`](https://developer.android.com/reference/java/util/ArrayList) can also accept `null` among its contained objects:

> Resizable-array implementation of the List interface. Implements all optional list operations, and permits all elements, including null.

Hence, the check should still be valid on runtime. Even if this misses a result, it shouldn't be harmful given at this point all the slides have been processed and finished with either a successful result or a canceled/failed one. There's a slight chance (I'm not even 100% sure about this) an errored slide would be lost if run into this situation, but it should be way better than crashing the app.

### To test:
1. on WPAndroid, create a Story with many slides
2. Publish it
3. Observe the app doesn't crash





