### PR TITLE
mp4Composer: replace throw error with logging error instead

### DIFF
--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.kt
@@ -246,9 +246,7 @@ internal class Mp4ComposerEngine {
                     mediaExtractor = null
                 }
             } catch (e: RuntimeException) {
-                // Too fatal to make alive the app, because it may leak native resources.
-
-                throw Error("Could not shutdown mediaExtractor, codecs and mediaMuxer pipeline.", e)
+                Log.e(TAG, "Could not shutdown mediaExtractor, codecs and mediaMuxer pipeline.", e)
             }
 
             try {


### PR DESCRIPTION
Fix https://github.com/wordpress-mobile/WordPress-Android/issues/13694

I wasn't able to reproduce this one. Decided to check what the oirginal mp4Composer library is doing and realized the line of code where the error is thrown has changed from `throw Error()` to a log entry.

In this [commit](https://github.com/MasayukiSuda/Mp4Composer-android/commit/9c4edd1c1814d02859df6e1f4ace46342e496fd6) they have downgraded from aggressively throwing an app Error to just logging. It was released in [v0.3.2](https://github.com/MasayukiSuda/Mp4Composer-android/releases/tag/v0.3.2) of the library, in August 2019, and hasn't changed since then so given this is only affecting 8 users with a total of 12 events in our case I believe it should be fine to just log as per the change in the original library.

To test:
N/A



