### PR TITLE
Always reorder AddedViewList according to z-index order in getter

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -1046,7 +1046,24 @@ class PhotoEditor private constructor(builder: Builder) :
     }
 
     fun getViewsAdded(): AddedViewList {
+        // always make sure to return a freshly z-index-ordered AddedViewList
+        reorderAddedViewListAccordingToZIndex()
         return addedViews
+    }
+
+    private fun reorderAddedViewListAccordingToZIndex() {
+        val reorderedAddedViewList = AddedViewList()
+        for (oneView in parentView.zIndexOrderedAddedViews) {
+            when (oneView.tag) {
+                TEXT, EMOJI, ViewType.STICKER_ANIMATED -> {
+                    addedViews.getAddedViewForNativeView(oneView)?.let {
+                        reorderedAddedViewList.add(it)
+                    }
+                }
+            }
+        }
+        addedViews.clear()
+        addedViews.addAll(reorderedAddedViewList)
     }
 
     /**

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
@@ -18,6 +18,7 @@ import android.widget.ProgressBar
 import android.widget.RelativeLayout
 import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.view.children
 import com.automattic.photoeditor.OnSaveBitmap
 import com.automattic.photoeditor.R.styleable
 import com.automattic.photoeditor.views.background.fixed.BackgroundImageView
@@ -90,6 +91,9 @@ class PhotoEditorView : RelativeLayout {
 
     val listeners: ArrayList<SurfaceTextureListener>
         get() = surfaceListeners
+
+    val zIndexOrderedAddedViews: Sequence<View>
+        get() = children
 
     constructor(context: Context) : super(context) {
         init(null)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/added/AddedViewList.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/added/AddedViewList.kt
@@ -45,6 +45,16 @@ class AddedViewList : ArrayList<AddedView>() {
         }
         return -1
     }
+    fun getAddedViewForNativeView(element: View): AddedView? {
+        for (oneView in this) {
+            oneView.view?.let {
+                if (it == element) {
+                    return oneView
+                }
+            }
+        }
+        return null
+    }
 
     fun containsAnyAddedViewsOfType(type: ViewType): Boolean {
         for (oneView: AddedView in this) {


### PR DESCRIPTION
Fix #534 

This PR introduces a change to make sure to always keep an `AddedViewList` that is up to date with the order in which added views are appearing on screen.

At first, I explored overriding [`getChildDrawingOrder()`](https://developer.android.com/reference/android/view/ViewGroup#getChildDrawingOrder(int,%20int)) to keep a list of z-index ordered views at the `PhotoEditorView` level but it turned out not to be necessary, given the order in which the views are returned by the `children` property in `ViewGroup` is already z-index ordered.

Hence, I went ahead and only added a helper method in `PhotoEditor.getViewsAdded()` called `reorderAddedViewListAccordingToZIndex()`, which will just iterate over the actual ViewGroup's `children` collection and find its corresponding `AddedView` object from its referenced native Android `View` and re-build the `AddedViewList` accordingly before returning it to the saving / re-drawing function.

### Before

https://user-images.githubusercontent.com/6597771/115372443-45ee8c00-a1a1-11eb-9781-b0a4a92ad17a.mp4



### After

https://user-images.githubusercontent.com/6597771/115372406-38d19d00-a1a1-11eb-8903-a1b6f4e026e8.mp4


To test:

1. run the demo app, tap on + to add a new slide
2. take a picture or choose from the picker
3. add one view (Text), make sure to remember it was the first view you added
4. add another view (Text), make sure to remember it was the second one you added
5. add a new slide
6. select the previous slide, observe the order in which views are drawn
7. tap on the first view and make it overlap, so you know the first view you added is now on the front
8. switch slides, then switch back to the slide where you added views
9. observe the z-index order is kept (i.e. the last touched added view is drawn on top)
