### PR TITLE
Remove setImageMatrix override, don't call onBitmapLoaded

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/background/fixed/BackgroundImageView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/background/fixed/BackgroundImageView.kt
@@ -49,11 +49,6 @@ class BackgroundImageView : PhotoView {
         mOnImageChangedListener?.onBitmapLoaded(bitmap)
     }
 
-    override fun setImageMatrix(matrix: Matrix) {
-        super.setImageMatrix(matrix)
-        mOnImageChangedListener?.onBitmapLoaded(bitmap)
-    }
-
     override fun setImageState(state: IntArray, merge: Boolean) {
         super.setImageState(state, merge)
         mOnImageChangedListener?.onBitmapLoaded(bitmap)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/background/fixed/BackgroundImageView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/background/fixed/BackgroundImageView.kt
@@ -3,7 +3,6 @@ package com.automattic.photoeditor.views.background.fixed
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Bitmap
-import android.graphics.Matrix
 import android.graphics.PorterDuff
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable


### PR DESCRIPTION
While investigating #659, found out we were calling `onBitmapLoaded` on each matrix rearrangement (pinch to zoom on the background image), causing the call to load the blurry background countless times unnecessarily.

The logcat entries would appear as follows when pinch-to-zoom would be performed:

```
2021-04-20 13:02:08.424 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.523 27437-27437/com.automattic.loop I/chatty: uid=10317(com.automattic.loop) identical 6 lines
2021-04-20 13:02:08.539 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.556 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.658 27437-27437/com.automattic.loop I/chatty: uid=10317(com.automattic.loop) identical 6 lines
2021-04-20 13:02:08.674 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.690 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.706 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.723 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.739 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.756 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.805 27437-27437/com.automattic.loop I/chatty: uid=10317(com.automattic.loop) identical 3 lines
2021-04-20 13:02:08.823 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.839 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.873 27437-27437/com.automattic.loop I/chatty: uid=10317(com.automattic.loop) identical 2 lines
2021-04-20 13:02:08.874 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.884 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.892 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.922 27437-27437/com.automattic.loop I/chatty: uid=10317(com.automattic.loop) identical 2 lines
2021-04-20 13:02:08.938 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:08.955 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
2021-04-20 13:02:09.072 27437-27437/com.automattic.loop I/chatty: uid=10317(com.automattic.loop) identical 7 lines
2021-04-20 13:02:09.089 27437-27437/com.automattic.loop D/PhotoEditorView: onBitmapLoaded() called with: sourceBitmap = [android.graphics.Bitmap@1f677f8]
```

To test:
1. run the demo app
2. capture an image
3. use pinch-to-zoom to zoom in/out on the background image
4. observe this doesn't lead to `onBitmapLoaded()` being called (also observe the logcat)



