### PR TITLE
Update current selected frame in onStart() to make sure touch listeners are set on AddedViews

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -597,6 +597,9 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             showGenericAnnouncementDialogWhenReady = false
             genericAnnouncementDialogProvider?.showGenericAnnouncementDialog()
         }
+        if (storyViewModel.getCurrentStorySize() > 0) {
+            showCurrentSelectedFrame()
+        }
     }
 
     private fun setupStoryViewModelObservers() {


### PR DESCRIPTION
Fix #659 

I've observed this issue appeared every time the story composer would be presented both with lock/unlock but also if you had a slide, then tapped on + to add another slide, but tapped back on the photo picker without making any selection.

I workarounded this by adding a call to update the current slide in `onStart()`, which works alright. I spent some time trying to understand how this would happen - I haven't been able to get exactly to why the listeners wouldn't get triggered, as apparently the touch events are being handled correctly by the background surface, and if you touch directly on top of the added views these events don't get through to the background image (indicating that these events are being captured but not handled correctly at the AddedView level somehow).

To test:
1. run the demo app
2. add a slide
3. add an added view
4. lock / unlock phone
5. observe you can tap and drag the added view
