### PR TITLE
Update opaque bar height in OnApplyWindowInsetsListener

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -356,6 +356,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             workingAreaRect = calculateWorkingArea()
             photoEditor.updateWorkAreaRect(workingAreaRect)
             bottomOpaqueBarHeight = preCalculateOpaqueBarHeight()
+            setOpaqueBarHeight()
             screenSizeRatio = getSizeRatio(screenWidth, screenHeight)
             delete_view.addBottomOffset(bottomNavigationBarMargin)
             delete_slide_view.addBottomOffset(bottomNavigationBarMargin)
@@ -583,8 +584,12 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     private fun setOpaqueBarHeight() {
+        bottom_opaque_bar.layoutParams.height = bottomOpaqueBarHeight
+    }
+
+    private fun showOpaqueBarIfNeeded() {
         if (bottomOpaqueBarHeight > 0) {
-            bottom_opaque_bar.layoutParams.height = bottomOpaqueBarHeight
+            bottom_opaque_bar.visibility = View.VISIBLE
         } else {
             bottom_opaque_bar.visibility = View.GONE
         }
@@ -1640,7 +1645,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     private fun showStoryFrameSelector() {
         setOpaqueBarHeight()
-        bottom_opaque_bar.visibility = View.VISIBLE
+        showOpaqueBarIfNeeded()
         (bottom_strip_view as StoryFrameSelectorFragment).show()
     }
 


### PR DESCRIPTION
Fix #664 

The calculated opaque bar height was not being correctly applied after having changed so this PR fixes that by making sure the height is set on the opaque bar view right after calculating it in the `OnApplyWindowInsetsListener`.

Then, instead of setting the height at a later moment when the bar needs to be shown, we're only setting the `visibility` attribute to handle show/hide behavior, making it more precise.

To test:
Using a Pixel 4a (device with a screen taller than 9:16)
1. On WPAndroid: create a Story, add a slide, publish it
2. open the post and edit the Story
3. observe the opaque bar is correctly drawn



