### PR TITLE
Only show current selected frame in onStart() if there's no pending TextureView launch request

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -597,7 +597,9 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             showGenericAnnouncementDialogWhenReady = false
             genericAnnouncementDialogProvider?.showGenericAnnouncementDialog()
         }
-        if (storyViewModel.getCurrentStorySize() > 0) {
+        if (storyViewModel.getCurrentStorySize() > 0 &&
+                !launchCameraRequestPending &&
+                !launchVideoPlayerRequestPending) {
             showCurrentSelectedFrame()
         }
     }


### PR DESCRIPTION
Fix https://github.com/wordpress-mobile/WordPress-Android/issues/14531

With the change introduced in https://github.com/Automattic/stories-android/pull/655, we're forcing the selected slide to be shown in onStart(). This means that, when coming back from the media picker and waiting for a request for TextureView to be rendered, we override such request by hiding the surface almost immediately after the request to render.

This simple fix checks there is no pending request to launch the camera before attempting to show the currently selected frame.

**To test:**
1. create a Story and publish it
2. go to the Post list, edit the Post
3. tap on the Story block twice to open the Story in the Story composer
4. tap on the "+" control on the right end of the Story frame selector to add a new slide
5. when the media picker opens, tap on the camera icon
6. observe it correctly shows the camera preview mode
7. take a picture and observe the slide gets correctly added to the Story.

