### PR TITLE
Improve dark mode contrast for color picker bottom sheet

### DIFF
--- a/stories/src/main/res/layout/color_picker_bottom_sheet.xml
+++ b/stories/src/main/res/layout/color_picker_bottom_sheet.xml
@@ -24,7 +24,8 @@
         android:layout_marginBottom="@dimen/color_picker_bottom_sheet_label_bottom_margin"
         android:textSize="18sp"
         android:textStyle="bold"
-        android:textColor="#DE000000"
+        android:textColor="?android:attr/textColorPrimary"
+        android:alpha="0.87"
         android:text="@string/color_picker_label_text" />
 
     <androidx.recyclerview.widget.RecyclerView
@@ -48,7 +49,8 @@
         android:layout_marginBottom="@dimen/color_picker_bottom_sheet_label_bottom_margin"
         android:textSize="18sp"
         android:textStyle="bold"
-        android:textColor="#DE000000"
+        android:textColor="?android:attr/textColorPrimary"
+        android:alpha="0.87"
         android:text="@string/color_picker_label_background" />
 
     <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
Fixes #622.

I thought I'd already done this but I guess not 😅. Changed the text color for the color picker bottom sheet to use `textColorPrimary` (and moved the opacity to the `alpha` property).

![622-beforeafter](https://user-images.githubusercontent.com/9613966/116174446-5f677900-a749-11eb-80c5-5d26e8745322.png)


(No change in light mode.)