### PR TITLE
Fix: add touchlistener by default on newly added text added views

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -1278,7 +1278,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     private fun addNewText() {
-        photoEditor.addText("")
+        photoEditor.addText("", addTouchListener = true)
     }
 
     private fun testEmoji() {


### PR DESCRIPTION
In https://github.com/Automattic/stories-android/pull/663 we added an optional addition of the touch listeners to added view, with the parameter being `false` by default. I omitted making it explicit `true` when adding new text to a Slide 🤦 

To test:
1. create a Story
2. add a slide
3. add text
4. try to drag it around, touch to edit, zoom, etc. and verify it works