### PR TITLE
Only set opaque bar height if the calculated result is greater than 0

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -584,7 +584,9 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     private fun setOpaqueBarHeight() {
-        bottom_opaque_bar.layoutParams.height = bottomOpaqueBarHeight
+        if (bottomOpaqueBarHeight > 0) {
+            bottom_opaque_bar.layoutParams.height = bottomOpaqueBarHeight
+        }
     }
 
     private fun showOpaqueBarIfNeeded() {


### PR DESCRIPTION
Fix an issue introduced in https://github.com/Automattic/stories-android/pull/666

When the phone screen is exactly 9:16, the calculated opaque bar height is 0, but setting the LayoutParams' height to zero will indicate it to use all the available space (similar to `match_parent`).

Hence, we should just not set it when the result is zero.

To test:
1. Use a device with a 9:16 screen (I used the original Pixel)
2. create a Story
3. observe the background image for a slide is shown (otherwise without this patch, it'd turn black given the opaque bar height is set to cover the screen)

