### PR TITLE
Fixes for Retry button

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -2151,10 +2151,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     override fun onCurrentFrameTapped() {
-        val currentlyErrored = storyViewModel.anyOfCurrentStoryFramesIsErrored()
-        if (!currentlyErrored) {
-            toggleDeleteSlideMode()
-        }
+        toggleDeleteSlideMode()
     }
 
     override fun onStoryFrameLongPressed(oldIndex: Int, newIndex: Int) {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -2177,7 +2177,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             // if we're switching back from delete mode, let's show the retry button if this is an errored frame
             if (isErroredFrame) {
                 showRetryButton()
-                updateEditMode()
             }
         } else {
             enableDeleteSlideMode()
@@ -2186,9 +2185,9 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             // (otherwise they overlap)
             if (isErroredFrame) {
                 hideRetryButton()
-                updateEditMode()
             }
         }
+        updateEditMode()
     }
 
     private fun enableDeleteSlideMode() {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -748,8 +748,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             checkForLowSpaceAndShowDialog()
         } else if (intent.hasExtra(KEY_STORY_SAVE_RESULT)) {
             val storySaveResult = intent.getParcelableExtra(KEY_STORY_SAVE_RESULT) as StorySaveResult?
-            if (storySaveResult != null &&
-                    StoryRepository.getStoryAtIndex(storySaveResult.storyIndex).frames.isNotEmpty()) {
+            if (storySaveResult != null && StoryRepository.isStoryIndexValid(storySaveResult.storyIndex)
+                    && StoryRepository.getStoryAtIndex(storySaveResult.storyIndex).frames.isNotEmpty()) {
                 // dismiss the error notification
                 intent.action?.let {
                     val notificationManager = NotificationManagerCompat.from(this)

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -748,8 +748,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             checkForLowSpaceAndShowDialog()
         } else if (intent.hasExtra(KEY_STORY_SAVE_RESULT)) {
             val storySaveResult = intent.getParcelableExtra(KEY_STORY_SAVE_RESULT) as StorySaveResult?
-            if (storySaveResult != null && StoryRepository.isStoryIndexValid(storySaveResult.storyIndex)
-                    && StoryRepository.getStoryAtIndex(storySaveResult.storyIndex).frames.isNotEmpty()) {
+            if (storySaveResult != null && StoryRepository.isStoryIndexValid(storySaveResult.storyIndex) &&
+                    StoryRepository.getStoryAtIndex(storySaveResult.storyIndex).frames.isNotEmpty()) {
                 // dismiss the error notification
                 intent.action?.let {
                     val notificationManager = NotificationManagerCompat.from(this)

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -2151,7 +2151,10 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     override fun onCurrentFrameTapped() {
-        toggleDeleteSlideMode()
+        val currentlyErrored = storyViewModel.anyOfCurrentStoryFramesIsErrored()
+        if (!currentlyErrored) {
+            toggleDeleteSlideMode()
+        }
     }
 
     override fun onStoryFrameLongPressed(oldIndex: Int, newIndex: Int) {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -2168,10 +2168,26 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     private fun toggleDeleteSlideMode() {
+        val selectedFrame = storyViewModel.getSelectedFrame()
+        val isErroredFrame = selectedFrame?.saveResultReason !is SaveSuccess
+
         if (delete_slide_view.visibility == View.VISIBLE) {
             disableDeleteSlideMode()
+
+            // if we're switching back from delete mode, let's show the retry button if this is an errored frame
+            if (isErroredFrame) {
+                showRetryButton()
+                updateEditMode()
+            }
         } else {
             enableDeleteSlideMode()
+
+            // if we're switching to delete mode, let's hide the retry button if this is an errored frame
+            // (otherwise they overlap)
+            if (isErroredFrame) {
+                hideRetryButton()
+                updateEditMode()
+            }
         }
     }
 

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
@@ -195,7 +195,7 @@ class StoryFrameSelectorFragment : Fragment() {
     }
 
     fun hide() {
-        view?.visibility = View.GONE
+        view?.visibility = View.INVISIBLE
     }
 
     fun hideAddFrameControl() {

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
@@ -54,7 +54,7 @@ object StoryRepository {
         }
     }
 
-    private fun isStoryIndexValid(storyIndex: StoryIndex): Boolean {
+    fun isStoryIndexValid(storyIndex: StoryIndex): Boolean {
         return storyIndex > DEFAULT_NONE_SELECTED && stories.size > storyIndex
     }
 

--- a/stories/src/main/res/drawable/save_button_background_disabled.xml
+++ b/stories/src/main/res/drawable/save_button_background_disabled.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/white_transp" />
+    <solid android:color="@color/white" />
     <corners android:radius="@dimen/save_button_radius" />
 </shape>

--- a/stories/src/main/res/values/colors.xml
+++ b/stories/src/main/res/values/colors.xml
@@ -11,7 +11,6 @@
     <color name="pink_50">#c9356e</color>
 
     <color name="white">#FFFFFF</color>
-    <color name="white_transp">#66FFFFFF</color>
     <color name="black">#000000</color>
     <color name="grey">#888888</color>
     <color name="gray_10">#C3C4C7</color>


### PR DESCRIPTION
Fixes #577 

- make the StoryFrameSelector INVISIBLE instead of GONE so it occupies Screen space and doesn't make the Retry button fall below the navigation buttons. (https://github.com/Automattic/stories-android/pull/671/commits/6b22a5a73a9bb2de736a1abef667743dafd5c9ca)
- make the background plain white so it's clearer when it's behind the block-screen schrim. (https://github.com/Automattic/stories-android/pull/671/commits/6b22a5a73a9bb2de736a1abef667743dafd5c9ca)

Plus:
- ~Only allow slide deletion mode toggling when not in error handling mode (d009dd6c)~
- Show/hide retry button when toggling delete mode, otherwise they overlap (31d673e4 and e3c505cb)
- Check Story index is valid in the StoryRepository when attempting to load from an error notification cd35c1ce (there may be a case when the Story is errored and then an unrelated crash in the app will still allow the notification to persist so, the storyindex won't be valid anymore).

This is the crash that is fixed here:

```
2021-04-29 14:02:40.614 4432-4432/org.wordpress.android D/AndroidRuntime: Shutting down VM
2021-04-29 14:02:40.615 4432-4432/org.wordpress.android E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.wordpress.android, PID: 4432
    java.lang.RuntimeException: Unable to start activity ComponentInfo{org.wordpress.android/org.wordpress.android.ui.stories.StoryComposerActivity}: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3431)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3595)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2066)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7660)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
     Caused by: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.ArrayList.get(ArrayList.java:437)
        at com.wordpress.stories.compose.story.StoryRepository.getStoryAtIndex(StoryRepository.kt:62)
        at com.wordpress.stories.compose.ComposeLoopFrameActivity.onLoadFromIntent(ComposeLoopFrameActivity.kt:752)
        at org.wordpress.android.ui.stories.StoryComposerActivity.onLoadFromIntent(StoryComposerActivity.kt:263)
        at com.wordpress.stories.compose.ComposeLoopFrameActivity.onCreate(ComposeLoopFrameActivity.kt:568)
        at org.wordpress.android.ui.stories.StoryComposerActivity.onCreate(StoryComposerActivity.kt:142)
        at android.app.Activity.performCreate(Activity.java:8000)
        at android.app.Activity.performCreate(Activity.java:7984)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1309)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3404)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3595) 
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85) 
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2066) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:223) 
        at android.app.ActivityThread.main(ActivityThread.java:7660) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947) 
2021-04-29 14:02:40.628 4204-4222/? I/FontLog: Fetch {Nunito, wdth 100.0, wght 700, ital 0.0, bestEffort false} end status St

```

To test:
1. apply this [patch](https://gist.github.com/mzorz/41d6f80f2395105fff6da6328b190ff5) to force an error on video slides
2. create a Story with 1 video slide at least
3. observe it throws an error (see error notification and the snackbar on My Sites screen if on WPandroid)
4. tap on the notification body, on the `MANAGE` quick action or on the `MANAGE` snackbar action 
5. observe the error resolution mode in Composer Activity appears
6. tap the errored frame, tap on RETRY
7. observe the button doesn't go away anymore (fix https://github.com/Automattic/stories-android/pull/671/commits/6b22a5a73a9bb2de736a1abef667743dafd5c9ca)
8. ~tap on an errored frame twice: observe the delete mode doesn't get triggered (d009dd6c)~ tap on errored frame twice: observe the delete mode appears correctly, and the RETRY button disappears. Tap on the errored frame again to bring the RETRY button back.


**Note**: when I retry a video slide more than once, I'm getting a different crash I'm still working on, but decided to leave it out of this PR so the other fixes don't have to wait longer. Tracked separately in https://github.com/Automattic/stories-android/issues/672
