### PR TITLE
Fixes for Retry button (part 2)

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -1060,12 +1060,14 @@ class PhotoEditor private constructor(builder: Builder) :
         return (addedViews.size > 0)
     }
 
+    @Synchronized
     fun getViewsAdded(): AddedViewList {
         // always make sure to return a freshly z-index-ordered AddedViewList
         reorderAddedViewListAccordingToZIndex()
         return addedViews
     }
 
+    @Synchronized
     private fun reorderAddedViewListAccordingToZIndex() {
         val reorderedAddedViewList = AddedViewList()
         for (oneView in parentView.zIndexOrderedAddedViews) {

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -203,7 +203,8 @@ class FrameSaveService : Service() {
         val frameFileList =
             storySaveProcessor.saveStory(
                 this,
-                frames
+                frames,
+                storySaveProcessor.storySaveResult.isRetry
             )
         storySaveProcessor.timeTracker.end()
         storySaveProcessor.updateStorySaveResultTimeElapsed()
@@ -387,9 +388,10 @@ class FrameSaveService : Service() {
 
         suspend fun saveStory(
             context: Context,
-            frames: List<StoryFrameItem>
+            frames: List<StoryFrameItem>,
+            isRetry: Boolean
         ): List<File> {
-            return frameSaveManager.saveStory(context, frames)
+            return frameSaveManager.saveStory(context, frames, isRetry)
         }
 
         fun onCancel() {


### PR DESCRIPTION
This builds on top of #671 

Fixes #672 and more

This fixes some other issues with retries:

- if an error occurs and the user taps on the Retry button, after a new attempt to save the addedviews will have been gone away, because we need to detach them from the real PhotoEditorView instance to use the ghost PhotoEditor instance for saving in the FrameSaveService, and then re-add these views to the PhotoEditorView on the real screen using the UI thread. For this, we're now passing the `isRetry` flag as a parameter in `saveStory()` in the Service, and reconverting its meaning to `reattachAddedViewsAfterSaving` in the FrameSaveManager. (https://github.com/Automattic/stories-android/pull/673/commits/80d811c247e5bce2bf7ded13487e61355eafc904). This in the end would be worsened after a couple of retries and the crash in #672 would be run into (so, this commit  80d811c247e5bce2bf7ded13487e61355eafc904 fixes that)
- in some strange cases, access to AddedViews could be done concurrently from different coroutines so, marked the methods `@Synchronized`  now (https://github.com/Automattic/stories-android/pull/673/commits/a49a6f39dcfb0228b6b4b34fc0e0e187acd557da)

To test:
1. apply this [patch](https://gist.github.com/mzorz/41d6f80f2395105fff6da6328b190ff5) to force an error when saving, and create a Story
2. observe the error Notification and snackbar appear. Tap on `MANAGE`.
3. Retry the failed slides
4. observe while retrying, the added views may flicker (so these are released and re-added later so these can be properly saved), but they are no longer lost
5. the patch will make things fail every time, but no other side effects should be seen.
