### PR TITLE
Temporarily remove fetchstyle & configure plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
 
 jobs:
   Lint:
-    executor: 
+    executor:
       name: android/default
       api-version: "29"
     steps:
@@ -35,7 +35,7 @@ jobs:
       - android/save-gradle-cache
       - android/save-lint-results
   Unit Tests:
-    executor: 
+    executor:
       name: android/default
       api-version: "29"
     steps:
@@ -47,42 +47,42 @@ jobs:
           command: ./gradlew --stacktrace -PtestsMaxHeapSize=1536m testRelease
       - android/save-gradle-cache
       - android/save-test-results
-  Installable Build:
-    executor: 
-      name: android/default
-      api-version: "29"
-    steps:
-      - checkout
-      - run:
-          name: Apply Configuration
-          command: ./gradlew applyConfiguration
-      - android/restore-gradle-cache
-      - run:
-          name: Build APK
-          command: |
-            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
-              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-              PREFIX="pr-${PR_NUMBER}"
-            else
-              PREFIX="$CIRCLE_BRANCH"
-            fi
-            VERSION_NAME="${PREFIX}-build-${CIRCLE_BUILD_NUM}"
-            echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
-
-            ./gradlew --stacktrace app:assembleRelease -PversionName="$VERSION_NAME"
-      - android/save-gradle-cache
-      - run:
-          name: Prepare APK
-          command: |
-            mkdir -p Artifacts
-            mv app/build/outputs/apk/release/app-release.apk "Artifacts/Loop-${VERSION_NAME}.apk"
-      - store_artifacts:
-          path: Artifacts
-          destination: Artifacts
+#  Installable Build:
+#    executor:
+#      name: android/default
+#      api-version: "29"
+#    steps:
+#      - checkout
+#      - run:
+#          name: Apply Configuration
+#          command: ./gradlew applyConfiguration
+#      - android/restore-gradle-cache
+#      - run:
+#          name: Build APK
+#          command: |
+#            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+#              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+#              PREFIX="pr-${PR_NUMBER}"
+#            else
+#              PREFIX="$CIRCLE_BRANCH"
+#            fi
+#            VERSION_NAME="${PREFIX}-build-${CIRCLE_BUILD_NUM}"
+#            echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
+#
+#            ./gradlew --stacktrace app:assembleRelease -PversionName="$VERSION_NAME"
+#      - android/save-gradle-cache
+#      - run:
+#          name: Prepare APK
+#          command: |
+#            mkdir -p Artifacts
+#            mv app/build/outputs/apk/release/app-release.apk "Artifacts/Loop-${VERSION_NAME}.apk"
+#      - store_artifacts:
+#          path: Artifacts
+#          destination: Artifacts
 
 workflows:
   loop:
     jobs:
       - Lint
       - Unit Tests
-      - Installable Build
+#      - Installable Build

--- a/build.gradle
+++ b/build.gradle
@@ -6,24 +6,23 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven { url "https://dl.bintray.com/automattic/maven/" }
         maven { url "https://jitpack.io" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlinVersion"
-        classpath 'com.automattic.android:fetchstyle:1.1'
+        //classpath 'com.automattic.android:fetchstyle:1.1'
         classpath 'io.sentry:sentry-android-gradle-plugin:1.7.27'
-        classpath 'com.automattic.android:configure:0.3.0'
+        //classpath 'com.automattic.android:configure:0.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
-apply plugin: 'com.automattic.android.fetchstyle'
-apply plugin: 'com.automattic.android.configure'
+//apply plugin: 'com.automattic.android.fetchstyle'
+//apply plugin: 'com.automattic.android.configure'
 
 allprojects {
     apply plugin: 'checkstyle'


### PR DESCRIPTION
We have to temporarily disable installable builds because configure plugin is necessary to build them.