### PR TITLE
Allow ComposeLoopFrameActivity to start with media picker launcher when Story is empty

### DIFF
--- a/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
@@ -120,6 +120,8 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         requestCodes.PHOTO_PICKER = RequestCodes.PHOTO_PICKER
         requestCodes.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED =
             PhotoPickerActivity.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED
+        requestCodes.EXTRA_LAUNCH_WPSTORIES_MEDIA_PICKER_REQUESTED =
+                PhotoPickerActivity.EXTRA_LAUNCH_WPSTORIES_MEDIA_PICKER_REQUESTED
         requestCodes.EXTRA_MEDIA_URIS = PhotoPickerActivity.EXTRA_MEDIA_URIS
     }
 

--- a/app/src/main/java/com/automattic/loop/photopicker/PhotoPickerActivity.java
+++ b/app/src/main/java/com/automattic/loop/photopicker/PhotoPickerActivity.java
@@ -44,6 +44,8 @@ public class PhotoPickerActivity extends AppCompatActivity
     public static final String EXTRA_MEDIA_SOURCE = "media_source";
     public static final String EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED
             = "launch_wpstories_camera_requested";
+    public static final String EXTRA_LAUNCH_WPSTORIES_MEDIA_PICKER_REQUESTED
+            = "launch_wpstories_media_picker_requested";
 
     public static final String LOCAL_POST_ID = "local_post_id";
 

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -771,6 +771,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             )
             addFramesToStoryFromMediaUriList(uriList)
             setDefaultSelectionAndUpdateBackgroundSurfaceUI(uriList)
+        } else if (intent.hasExtra(requestCodes.EXTRA_LAUNCH_WPSTORIES_MEDIA_PICKER_REQUESTED)) {
+            showMediaPicker()
         }
     }
 
@@ -2313,6 +2315,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         // if not properly initialized)
         lateinit var EXTRA_MEDIA_URIS: String
         lateinit var EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED: String
+        lateinit var EXTRA_LAUNCH_WPSTORIES_MEDIA_PICKER_REQUESTED: String
     }
 
     companion object {


### PR DESCRIPTION
This PR prepares the ground to accept a `EXTRA_LAUNCH_WPSTORIES_MEDIA_PICKER_REQUESTED` flag passed by intent extra to call `showMediaPicker()` if passed, as provided by the media picker provider if one is set.

To test:
Use WPAndroid
1. create a regular Blog Post on Gutenberg mobile
2. from the block picker, select a Story block to be added
3. tap on the `ADD MEDIA` button in the Story block placeholder
4. observe the Story composer is launched and the media picker is presented.
5. select some media items and the checkmark, then observe these media items get properly added to the Story.
6. alternatively to step 5, when the media picker appears, tap on the camera FAB icon to launch the camera mode in ComposerLoopFrameActivity. Capture an image with the camera and observe it gets added as a slide to the Story.
