### PR TITLE
Crash fix: recursive onLoadFromIntent calls

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -484,7 +484,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                 override fun onBackgroundSurfaceManagerReady() {
                     if (savedInstanceState == null && !firstIntentLoaded) {
                         onLoadFromIntent(intent)
-                        firstIntentLoaded = true
                     }
 
                     if (launchCameraRequestPending) {
@@ -729,6 +728,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     protected open fun onLoadFromIntent(intent: Intent) {
+        firstIntentLoaded = true
         val partialCameraOperationInProgress = intent.hasExtra(requestCodes.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED) ||
                 permissionsRequestForCameraInProgress
 


### PR DESCRIPTION
Fix #677 

The problem was introduced in this commit https://github.com/Automattic/stories-android/commit/c710bfd8f79efaed0fd4f223fc328424774b509d which is part of this PR https://github.com/Automattic/stories-android/pull/655

`onLoadFromIntent()` would be called again in the `onBackgroundSurfaceManagerReady()`, which ends up recursively calling onStoryFrameSelected, and kills the system with UI updates.

It's difficult to tell exactly when (the trace seems to appear after a few times) since the stacktrace doesn't say anything about where in our code things start to deviate, but I was able to narrow it down just by testing previous versions until it worked. Having a 100% reproduceable test case surely made things easier 👍 

This PR moves the firstIntentLoaded flag as first step when onLoadFromIntent gets called to make 100% sure it's set whenever it's called.

To test:

1. Create a Story with 2 slides: the first one should be an image, the second one a video
2. publish it
3. edit it from Gutenberg
4. once it's open, tap on the video slide
5. observe no crash happens

One note on this: on the Pixel 4a, I've observed a video recorded with the CameraX camera is only playable for a few moments, but after publishing it only works the first few times. At some point it just keeps showing the "loading" spinning wheel. Will work on that later - it's unrelated to the original fix, also unrelated to this PR.

