### PR TITLE
Move deleteCapturedMedia() to OK listener for frame removal dialog

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -613,9 +613,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private fun setupStoryViewModelObservers() {
         storyViewModel.uiState.observe(this, Observer {
             // if no frames in Story, finish
-            // note momentarily there will be times when this LiveData is triggered while permissions are
-            // being requested so, don't proceed if that is the case
-            deleteCaptureMediaAndFinishWhenEmptyStory()
+            finishWhenEmptyStory()
         })
 
         storyViewModel.onSelectedFrameIndex.observe(this, Observer { selectedFrameIndexChange ->
@@ -631,11 +629,9 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         })
     }
 
-    private fun deleteCaptureMediaAndFinishWhenEmptyStory() {
+    private fun finishWhenEmptyStory() {
         if (storyViewModel.getCurrentStorySize() == 0 &&
                 firstIntentLoaded && !permissionsRequestForCameraInProgress) {
-            // finally, delete the captured media
-            deleteCapturedMedia()
             finish()
         }
     }
@@ -892,7 +888,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             } else if (intent.hasExtra(requestCodes.EXTRA_LAUNCH_WPSTORIES_MEDIA_PICKER_REQUESTED)) {
                 // if coming from the PHOTO_PICKER with a cancel action, and we launched with
                 // EXTRA_LAUNCH_WPSTORIES_MEDIA_PICKER_REQUESTED to start the Story with, we should cancel.
-                deleteCaptureMediaAndFinishWhenEmptyStory()
+                finishWhenEmptyStory()
             }
         }
     }

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -617,8 +617,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             // being requested so, don't proceed if that is the case
             if (storyViewModel.getCurrentStorySize() == 0 &&
                     firstIntentLoaded && !permissionsRequestForCameraInProgress) {
-                // finally, delete the captured media
-                deleteCapturedMedia()
                 finish()
             }
         })
@@ -1085,6 +1083,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                     listener = object : FrameSaveErrorDialogOk {
                         override fun OnOkClicked(dialog: DialogFragment) {
                             dialog.dismiss()
+                            // first of all, delete the backing captured media for this slide
+                            deleteCapturedMedia()
                             if (storyViewModel.getCurrentStorySize() == 1) {
                                 // discard the whole story
                                 safelyDiscardCurrentStoryAndCleanUpIntent()


### PR DESCRIPTION
Fix #680, #678

### Getting to the cause
What was happening here is that, in the case we left the Story composer with a locally captured file as the last Story frame visited, we were actually deleting the original captured file. Hence, the next time we visited it, it would be lacking the background file, leading to 2 problems:
1. "Limited Story Editing" dialog appearing, because we couldn't [validate we had all the background files](https://github.com/wordpress-mobile/WordPress-Android/blob/70ce7de8817020d29768074bb408688436320220/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/LoadStoryFromStoriesPrefsUseCase.kt#L46-L61) for this Story (#678) - _a note on the issue listed there, when I wrote the issue I described what I thought was happening but it's not exactly that it would become available later (I haven't been able to reproduce it since I've been able to wrap my head around this one)_
2. Video files not being found when the video slide was captured with the phone so, getting the spinning wheel altogether. (#680)


### History
This was fist introduced in the early days when we didn't even have a slide selector
https://github.com/Automattic/stories-android/commit/ddab8bedee4ed0c020542d5103327e51f77041b6

There's a change introduced in this commit https://github.com/Automattic/stories-android/commit/4145288e3148aa4bdd21309a7643206682a5b363 where we were setting the `currentOriginalCapturedFile` to be the background file path for the selected slide. Then, if the user decided to discard a frame we would be able to delete it's backing captured file.

Later on, we moved the "discard frame?" Dialog code elsewhere when implementing the "tap to delete" behavior (see https://github.com/Automattic/stories-android/commit/427f1bc3ddb3c3252520010d2d7fd5e3d5d4b51e, PR https://github.com/Automattic/stories-android/pull/562). I think in order to keep the same behavior as before, we should be also able to delete the original captured media file there, as it was being done previously.

### Solution
As said above, this PR just moves the calls to `deleteCapturedMedia()` to the OK listener of the "Delete frame" confirmation dialog. This way, we'll make sure to only discard a captured image / video File for which a slide won't exist anymore.

### Next
Idea: it may be better to just leave any captured file live and let the user clean it up later if they wanted to do so. With that, we would also avoid bugs like this and would make the code simpler.

### To test
1. create a Story using the media picker
2. edit it from Gutenberg
3. add a new video slide using capture mode (this will create a local File)
4. observe you can switch slides and see the background image ok for all slides (including the last one)
5. let the last slide (the one right before the video added in step 3) be the one you're looking at before exiting
6. exit the editor (tap back and discard changes). At this point in time, we'd delete the file in `develop` as of now.
7. edit the Story again
8. observe you can tap on the last slide and it will be showing up correctly, and also no "Limited story editing" dialog shows up.

