### PR TITLE
Remove zero-frame finisher observer

### DIFF
--- a/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
@@ -60,9 +60,9 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         get() = Dispatchers.Main + job
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
         setSnackbarProvider(this)
         setMediaPickerProvider(this)
+        super.onCreate(savedInstanceState)
         setNotificationExtrasLoader(this)
         setMetadataProvider(this)
         setStoryDiscardListener(this) // optionally listen to discard events

--- a/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
@@ -166,6 +166,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     override fun onStoryDiscarded() {
         // example: do any cleanup you may need here
         Toast.makeText(this, "Story has been discarded!", Toast.LENGTH_SHORT).show()
+        finish()
     }
 
     override fun onFrameRemove(storyIndex: StoryIndex, storyFrameIndex: Int) {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -611,13 +611,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     private fun setupStoryViewModelObservers() {
-        storyViewModel.uiState.observe(this, Observer {
-            // if no frames in Story, finish
-            // note momentarily there will be times when this LiveData is triggered while permissions are
-            // being requested so, don't proceed if that is the case
-            deleteCaptureMediaAndFinishWhenEmptyStory()
-        })
-
         storyViewModel.onSelectedFrameIndex.observe(this, Observer { selectedFrameIndexChange ->
             updateSelectedFrameControls(selectedFrameIndexChange.first, selectedFrameIndexChange.second)
         })


### PR DESCRIPTION
Fix #682 

The problem described in the issue here comes from attempting to show a Dialog when the Activity has already been finished. This was due to the `uiState` observer (removed in this PR) attempting to finish the activity in the case of the model having a zero-frame Story, and then later on the StoryEditorMedia would try and add new media items to the Story (and at that point we present the progress dialog indicating that media is being added to the Story).

1. the media picker would be presented, and the user made their choice
2. the ComposeLoopFrameActivity would run its onLoadFromIntent, but no items would be added (they're added later using `appendMediaFiles`)
3. the observer would get called (this is where the Activity would be finished)
4. the [`handleMediaPickerIntentData`](https://github.com/wordpress-mobile/WordPress-Android/blob/3383d56c8856f8b0899b7d46a07da36898b4efce/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt#L280) method from StoryComposerActivity would call the `StoryEditorMedia` class' `addMediaExistingInRemoteToEditorAsync` coroutine, which would try adding the selected media items and use the progress dialog, provoking the crash at this point.

The sequence here was wrong (we'd want step 3 out of the way), and ultimately I realized we don't really need to be observing the uiState for a zero-frame model (that was all that observer cared about actually). So even if a Story momentarily would have no frames, it made more sense to act according to real actions and only allow the Activity to be finished in cases where expressly noted by the user of the library in `onStoryDIscarded()`, typically called on these moments:
- on the user tapping on the X and accepting the "Discard Story?" Dialog
- on removal of the last frame
- on back pressed

To test:
1. use WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/14622
2. run the app
3. create a new Story (tap on FAB, new Story)
4. select one ore more items from the media picker
5. observe these get added correctly to the Story composer

- [x] Also test that you can add views, save them, publish
- [x] also test you can discard the Story and remove frames til none are left, and the Story composer gets correctly finished
- [x] also test editing from Gutenberg (editing and removing all the frames will have no effect on the Story block being edited, this is known and expected, you can delete a Story block from Gutenberg entirely though).
- [x] Also verify the demo app in the Stories library works alright (run it, create a story, verify saving or discarding work alright).

