### PR TITLE
Fix: using actualColor.background to change background

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextColorPickerAdapter.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextColorPickerAdapter.kt
@@ -23,7 +23,7 @@ class TextColorPickerAdapter internal constructor(private val context: Context, 
     private var selectedPosition = colorPickerColors.indexOf(startColor)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        return ViewHolder(ColorPickerListItemBinding.inflate(LayoutInflater.from(context)))
+        return ViewHolder(ColorPickerListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false))
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -34,7 +34,7 @@ class TextColorPickerAdapter internal constructor(private val context: Context, 
             holder.binding.colorPickerSelectedCheckmarkView.visibility = View.GONE
         } else {
             holder.binding.colorPickerViewActualColor.setBackgroundResource(R.drawable.ic_color_picker_filler)
-            val background = holder.binding.colorPickerSelectedCheckmarkView.background
+            val background = holder.binding.colorPickerViewActualColor.background
             if (background is GradientDrawable) {
                 background.setColor(colorPickerColors[position])
             } else if (background is ColorDrawable) {


### PR DESCRIPTION
Originally spotted in #634 and fixed in a temporary branch as indicated in https://github.com/Automattic/stories-android/pull/634#issuecomment-845355859 (see section `Smoke test`), cherry picked the commit here to make background color selection for text work again on the color picker.

Before:
![Screenshot_20210521-111109](https://user-images.githubusercontent.com/6597771/119113989-0dd6a500-b9fc-11eb-8f9a-2891ef4a0b13.png)




After:
![Screenshot_20210521-111443](https://user-images.githubusercontent.com/6597771/119114000-10d19580-b9fc-11eb-99fa-ea055dcb0544.png)
