### PR TITLE
Remove synthetics from PhotoEditor

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,7 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+
+# Since the SHA of this file is used to evaluate the cache HASH,
+# changing a bit in a comment is enough to invalidate the cache.
+# Cache version: 1

--- a/photoeditor/build.gradle
+++ b/photoeditor/build.gradle
@@ -17,6 +17,10 @@ android {
 
     }
 
+    viewBinding {
+        enabled = true
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -55,7 +59,7 @@ dependencies {
     kapt 'com.github.bumptech.glide:compiler:4.10.0'
 
     implementation 'jp.wasabeef:glide-transformations:4.3.0'
-    
+
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 
     implementation project(path: ':mp4compose')

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -475,7 +475,7 @@ class PhotoEditor private constructor(builder: Builder) :
         var rootView: View? = null
         when (viewType) {
             ViewType.TEXT -> {
-                with (ViewPhotoEditorTextBinding.inflate(layoutInflater)) {
+                with(ViewPhotoEditorTextBinding.inflate(layoutInflater)) {
                     rootView = root
                     tvPhotoEditorText.gravity = Gravity.CENTER
                     if (mDefaultTextTypeface != null) {
@@ -484,12 +484,12 @@ class PhotoEditor private constructor(builder: Builder) :
                 }
             }
             ViewType.IMAGE -> {
-                with (ViewPhotoEditorImageBinding.inflate(layoutInflater)) {
+                with(ViewPhotoEditorImageBinding.inflate(layoutInflater)) {
                     rootView = root
                 }
             }
             ViewType.EMOJI -> {
-                with (ViewPhotoEditorEmojiBinding.inflate(layoutInflater)) {
+                with(ViewPhotoEditorEmojiBinding.inflate(layoutInflater)) {
                     rootView = root
                     TextViewCompat.setAutoSizeTextTypeWithDefaults(
                             tvPhotoEditorEmoji, TextViewCompat.AUTO_SIZE_TEXT_TYPE_UNIFORM)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -25,6 +25,9 @@ import androidx.annotation.RequiresPermission
 import androidx.annotation.UiThread
 import androidx.core.widget.TextViewCompat
 import androidx.emoji.text.EmojiCompat
+import com.automattic.photoeditor.databinding.ViewPhotoEditorEmojiBinding
+import com.automattic.photoeditor.databinding.ViewPhotoEditorImageBinding
+import com.automattic.photoeditor.databinding.ViewPhotoEditorTextBinding
 import com.automattic.photoeditor.gesture.MultiTouchListener
 import com.automattic.photoeditor.gesture.MultiTouchListener.OnMultiTouchListener
 import com.automattic.photoeditor.state.AuthenticationHeadersInterface
@@ -53,8 +56,6 @@ import com.daasuu.mp4compose.filter.GlFilterGroup
 import com.daasuu.mp4compose.filter.GlGifWatermarkFilter
 import com.daasuu.mp4compose.filter.GlWatermarkFilter
 import com.daasuu.mp4compose.filter.ViewPositionInfo
-import kotlinx.android.synthetic.main.view_photo_editor_emoji.view.*
-import kotlinx.android.synthetic.main.view_photo_editor_text.view.*
 import java.io.File
 import java.io.FileInputStream
 import java.lang.ref.WeakReference
@@ -343,7 +344,7 @@ class PhotoEditor private constructor(builder: Builder) :
 
             val multiTouchListenerInstance = getNewMultitouchListener(this) // newMultiTouchListener
             setGestureControlOnMultiTouchListener(this, ViewType.EMOJI, multiTouchListenerInstance)
-            touchableArea.setOnTouchListener(multiTouchListenerInstance)
+            findViewById<View>(R.id.touchableArea)?.setOnTouchListener(multiTouchListenerInstance)
             // setOnTouchListener(multiTouchListenerInstance)
             addViewToParent(this, ViewType.EMOJI)
         }
@@ -392,7 +393,7 @@ class PhotoEditor private constructor(builder: Builder) :
                     if (addTouchListener) {
                         val multiTouchListenerInstance = getNewMultitouchListener(it) // newMultiTouchListener
                         setGestureControlOnMultiTouchListener(it, viewType, multiTouchListenerInstance)
-                        it.touchableArea?.setOnTouchListener(multiTouchListenerInstance)
+                        it.findViewById<TextView>(R.id.touchableArea)?.setOnTouchListener(multiTouchListenerInstance)
                     }
                 }
             }
@@ -446,7 +447,7 @@ class PhotoEditor private constructor(builder: Builder) :
             }
 
             viewType == TEXT -> {
-                val textInputTv = rootView.tvPhotoEditorText
+                val textInputTv = rootView.findViewById<PhotoEditorTextView>(R.id.tvPhotoEditorText)
                 multiTouchListener.setOnGestureControl(object :
                         MultiTouchListener.OnGestureControl {
                     override fun onClick() {
@@ -474,35 +475,37 @@ class PhotoEditor private constructor(builder: Builder) :
         var rootView: View? = null
         when (viewType) {
             ViewType.TEXT -> {
-                rootView = layoutInflater.inflate(R.layout.view_photo_editor_text, null)
-                if (rootView.tvPhotoEditorText != null) {
-                    rootView.tvPhotoEditorText.gravity = Gravity.CENTER
+                with (ViewPhotoEditorTextBinding.inflate(layoutInflater)) {
+                    rootView = root
+                    tvPhotoEditorText.gravity = Gravity.CENTER
                     if (mDefaultTextTypeface != null) {
-                        rootView.tvPhotoEditorText.identifiableTypeface = mDefaultTextTypeface
+                        tvPhotoEditorText.identifiableTypeface = mDefaultTextTypeface
                     }
                 }
             }
-            ViewType.IMAGE -> rootView = layoutInflater.inflate(R.layout.view_photo_editor_image, null)
+            ViewType.IMAGE -> {
+                with (ViewPhotoEditorImageBinding.inflate(layoutInflater)) {
+                    rootView = root
+                }
+            }
             ViewType.EMOJI -> {
-                rootView = layoutInflater.inflate(R.layout.view_photo_editor_emoji, null)
-                val txtTextEmoji = rootView.tvPhotoEditorEmoji
-                if (txtTextEmoji != null) {
+                with (ViewPhotoEditorEmojiBinding.inflate(layoutInflater)) {
+                    rootView = root
                     TextViewCompat.setAutoSizeTextTypeWithDefaults(
-                        txtTextEmoji, TextViewCompat.AUTO_SIZE_TEXT_TYPE_UNIFORM)
+                            tvPhotoEditorEmoji, TextViewCompat.AUTO_SIZE_TEXT_TYPE_UNIFORM)
                     if (mDefaultEmojiTypeface != null) {
-                        txtTextEmoji.typeface = mDefaultEmojiTypeface
+                        tvPhotoEditorEmoji.typeface = mDefaultEmojiTypeface
                     }
-                    txtTextEmoji.gravity = Gravity.CENTER
-                    txtTextEmoji.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+                    tvPhotoEditorEmoji.gravity = Gravity.CENTER
+                    tvPhotoEditorEmoji.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
                 }
             }
         }
 
-        if (rootView != null) {
-            // We are setting tag as ViewType to identify what type of the view it is
-            // when we remove the view from stack i.e onRemoveViewListener(ViewType viewType, int numberOfAddedViews);
-            rootView.tag = viewType
-        }
+        // We are setting tag as ViewType to identify what type of the view it is
+        // when we remove the view from stack i.e onRemoveViewListener(ViewType viewType, int numberOfAddedViews);
+        rootView?.tag = viewType
+
         return rootView
     }
 


### PR DESCRIPTION
This PR only removes the use of synthetics from PhotoEditor (last place where it was being used in the Stories library), and only implements [view binding](https://developer.android.com/topic/libraries/view-binding) in the `getLayout()`  method when new added views get created.

In the rest of places where a reference to a view was needed, I intentionally left it using `findViewById()` because it would otherwise mean a bigger refactor: when we create and when we re-create views we need a reference to them to be able to attach a gesture listener to it, so in this sense the PhotoEditor doesn't work like a regular Fragment or custom view in that it makes sense to keep a reference to binding and take it from there. Given Views in PhotoEditor are much more dynamic than the layout representation of a regular application screen, a migration to using View binding deserves some more, deeper thought.

To test:
- smoke test the app and add some views, verify these get added and are shown correctly
- WPAndroid: verify you can create and publish a Story, and also edit it once saved.
