### PR TITLE
Invalidate cache

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,7 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+
+# Since the SHA of this file is used to evaluate the cache HASH,
+# changing a bit in a comment is enough to invalidate the cache.
+# Cache version: 1


### PR DESCRIPTION
This PR fixes a build error on CI which is due to a bad cache being downloaded and used by the CI machine. 
In our configuration, the [cache version is evaluated from a bunch of different parameters](https://github.com/wordpress-mobile/circleci-orbs/blob/25eee7663ad3d9fc908c7602ae3262379ea33c61/src/android/orb.yml#L45) which include the SHA of some configuration files. 

We should certainly look better in this issue and find a better configuration for the CI cache, but as a temporary solution, this PR adds a comment to define a "cache version"  in `gradle-wrapper.properties` which is the file with the higher priority in the cache algorithm. 
By changing the value in the comment, we change the SHA of the file and, so, we invalidate the cache. 

### To Test
- Verify that CI is green.