### PR TITLE
Remove synthetics from PhotoEditor 

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -53,8 +53,6 @@ import com.daasuu.mp4compose.filter.GlFilterGroup
 import com.daasuu.mp4compose.filter.GlGifWatermarkFilter
 import com.daasuu.mp4compose.filter.GlWatermarkFilter
 import com.daasuu.mp4compose.filter.ViewPositionInfo
-import kotlinx.android.synthetic.main.view_photo_editor_emoji.view.*
-import kotlinx.android.synthetic.main.view_photo_editor_text.view.*
 import java.io.File
 import java.io.FileInputStream
 import java.lang.ref.WeakReference
@@ -343,7 +341,7 @@ class PhotoEditor private constructor(builder: Builder) :
 
             val multiTouchListenerInstance = getNewMultitouchListener(this) // newMultiTouchListener
             setGestureControlOnMultiTouchListener(this, ViewType.EMOJI, multiTouchListenerInstance)
-            touchableArea.setOnTouchListener(multiTouchListenerInstance)
+            findViewById<View>(R.id.touchableArea)?.setOnTouchListener(multiTouchListenerInstance)
             // setOnTouchListener(multiTouchListenerInstance)
             addViewToParent(this, ViewType.EMOJI)
         }
@@ -392,7 +390,7 @@ class PhotoEditor private constructor(builder: Builder) :
                     if (addTouchListener) {
                         val multiTouchListenerInstance = getNewMultitouchListener(it) // newMultiTouchListener
                         setGestureControlOnMultiTouchListener(it, viewType, multiTouchListenerInstance)
-                        it.touchableArea?.setOnTouchListener(multiTouchListenerInstance)
+                        it.findViewById<TextView>(R.id.touchableArea)?.setOnTouchListener(multiTouchListenerInstance)
                     }
                 }
             }
@@ -446,7 +444,7 @@ class PhotoEditor private constructor(builder: Builder) :
             }
 
             viewType == TEXT -> {
-                val textInputTv = rootView.tvPhotoEditorText
+                val textInputTv = rootView.findViewById<PhotoEditorTextView>(R.id.tvPhotoEditorText)
                 multiTouchListener.setOnGestureControl(object :
                         MultiTouchListener.OnGestureControl {
                     override fun onClick() {
@@ -475,34 +473,33 @@ class PhotoEditor private constructor(builder: Builder) :
         when (viewType) {
             ViewType.TEXT -> {
                 rootView = layoutInflater.inflate(R.layout.view_photo_editor_text, null)
-                if (rootView.tvPhotoEditorText != null) {
-                    rootView.tvPhotoEditorText.gravity = Gravity.CENTER
+
+                rootView.findViewById<PhotoEditorTextView>(R.id.tvPhotoEditorText)?.let {
+                    it.gravity = Gravity.CENTER
                     if (mDefaultTextTypeface != null) {
-                        rootView.tvPhotoEditorText.identifiableTypeface = mDefaultTextTypeface
+                        it.identifiableTypeface = mDefaultTextTypeface
                     }
                 }
             }
             ViewType.IMAGE -> rootView = layoutInflater.inflate(R.layout.view_photo_editor_image, null)
             ViewType.EMOJI -> {
                 rootView = layoutInflater.inflate(R.layout.view_photo_editor_emoji, null)
-                val txtTextEmoji = rootView.tvPhotoEditorEmoji
-                if (txtTextEmoji != null) {
+                rootView.findViewById<TextView>(R.id.tvPhotoEditorText)?.let {
                     TextViewCompat.setAutoSizeTextTypeWithDefaults(
-                        txtTextEmoji, TextViewCompat.AUTO_SIZE_TEXT_TYPE_UNIFORM)
+                        it, TextViewCompat.AUTO_SIZE_TEXT_TYPE_UNIFORM)
                     if (mDefaultEmojiTypeface != null) {
-                        txtTextEmoji.typeface = mDefaultEmojiTypeface
+                        it.typeface = mDefaultEmojiTypeface
                     }
-                    txtTextEmoji.gravity = Gravity.CENTER
-                    txtTextEmoji.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+                    it.gravity = Gravity.CENTER
+                    it.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
                 }
             }
         }
 
-        if (rootView != null) {
-            // We are setting tag as ViewType to identify what type of the view it is
-            // when we remove the view from stack i.e onRemoveViewListener(ViewType viewType, int numberOfAddedViews);
-            rootView.tag = viewType
-        }
+        // We are setting tag as ViewType to identify what type of the view it is
+        // when we remove the view from stack i.e onRemoveViewListener(ViewType viewType, int numberOfAddedViews);
+        rootView?.tag = viewType
+
         return rootView
     }
 


### PR DESCRIPTION
After a brief discussion with @aforcier we decided it was best to remove the last trace of synthetics from the PhotoEditor class (which is removed in [Kotlin 1.4.20](https://youtrack.jetbrains.com/issue/KT-42121)) without half-introducing view binding, leaving things in a better place for a proper refactor using [ `viewbinding` ](https://developer.android.com/topic/libraries/view-binding/migration)to be analyzed in the future.

WordPress Android uses Kotlin 1.4.10 so, once it gets bumped there the Stories library will likely get a bump in Kotlin version here (for which the [`kotlin-parcelize`](https://developer.android.com/kotlin/parcelize) plugin will have to be introduced as well when that time comes)

This PR then only removes synthetics and falls back to using good old `findViewById`.

To test:
1. open the demo app
2. create a slide or two
3. add some views
4. verify you can drag them around, resize, rotate, edit, etc.

