### PR TITLE
Don't overwrite or fetch font when already loaded

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/text/FontRequester.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/FontRequester.kt
@@ -27,11 +27,15 @@ object FontRequester {
 
     fun registerFont(context: Context, @FontRes fontRes: Int, fallback: Typeface) {
         // Set the font to the fallback right away in case it's requested before getFont completes.
-        fontMap[fontRes] = fallback
-        try {
-            ResourcesCompat.getFont(context, fontRes, fontCallbackFor(context, fontRes), null)
-        } catch (e: NotFoundException) {
-            Log.e(TAG, "Font ${context.resources.getResourceEntryName(fontRes)} not found")
+        if (fontMap[fontRes] == null) {
+            fontMap[fontRes] = fallback
+        }
+        if (fontMap[fontRes] == fallback) {
+            try {
+                ResourcesCompat.getFont(context, fontRes, fontCallbackFor(context, fontRes), null)
+            } catch (e: NotFoundException) {
+                Log.e(TAG, "Font ${context.resources.getResourceEntryName(fontRes)} not found")
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/676

Related WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/14774

Steps to test:

1. use WPAndroid and create a Story from the My Site screen -> FAB -> Add new Story post
2. select one back ground image to add to your Story slide
3. once in the composer, add a Text by tapping the "A" button
4. in the Text Editor, choose a font other than the default one. For example, use STRONG.
5. add some text, optionally resize it if you'd like to make it more manageable. Finally tap on the checkmark on the top-right corner of the screen.
6. Now tap on the -> arrow on the top-right of the screen. The pre-publishing bottom sheet will appear. Optionally give your Story post a title, and tap on PUBLISH NOW
7. After your Story is published, go to Posts list (Published) and find it first in the list
8. tap to open
9. once Gutenberg is loaded and shows the Story block, tap on it twice (one to select the block, one to trigger the Story composer)
10. observe the added text does not respect the font you chose in step 4 above.
11. tapping the text to edit will however show the right font selection, and tapping on the checkmark will now correctly update the added view with the originally selected font. 