### PR TITLE
Trigger onFrameSaveCompleted when saving unmodified recorded video

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt
@@ -162,6 +162,7 @@ class FrameSaveManager(
                 } else {
                     // don't process the video but return the original file if no added views in this Story frame
                     frameFile = (frame.source as FileBackgroundSource).file
+                    saveProgressListener?.onFrameSaveCompleted(frameIndex, frame)
                 }
                 frame.composedFrameFile = frameFile
             }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/14787.

I'm pretty sure this used to work and this must be a regression, though I haven't narrowed down when exactly it happened.

The problem starts here:

https://github.com/Automattic/stories-android/blob/a8a068f5307a1d44df2c8128604a022bc8a7a7ba/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveManager.kt#L156-L166

The `else` arm is only run when there are no views added to the video, _and_ when the source is a Uri (which is the case when selecting an existing local video from the picker rather than recording one). (This explains why the bug doesn't accur when the video is added from device or has had views added.)

Since it doesn't call `saveVideoFrame()`, we never end up adding success data to the `FrameSaveResult` as we do for the other case:

https://github.com/Automattic/stories-android/blob/a8a068f5307a1d44df2c8128604a022bc8a7a7ba/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt#L330

This doesn't immediately break anything, however there are a few places where we check that the number of frames in `FrameSaveResult` matches the overall number of frames for the story, to confirm that saving is complete. The specific case that caused the bug I think is [here](https://github.com/wordpress-mobile/WordPress-Android/blob/70ce7de8817020d29768074bb408688436320220/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt#L243). `isStorySavingComplete()` compares the `frameSaveResult` size to the size of the story, and if they don't match assumes saving isn't complete yet. The result is that the two never match, so we never end up [triggering the media upload](https://github.com/wordpress-mobile/WordPress-Android/blob/70ce7de8817020d29768074bb408688436320220/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt#L249).

Triggering `onFrameSaveCompleted()` in the unmodified recorded video case updates the `FrameSaveResult` and allows the story save to be recognized as completed.

### To test

1. Use the corresponding WPAndroid PR
2. Create a story post by recording a video
3. Don't add any text to the story
4. Publish
5. Confirm that the story publishes and contains the video as expected
6. Try the above with a story with multiple slides, one of which is a video recorded on the spot
7. Confirm that story publishes correctly as well