### PR TITLE
Remove kotlin android extensions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'io.sentry.android.gradle'
 apply from: "../stories-common.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         maven { url "https://jitpack.io" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlinVersion"
         //classpath 'com.automattic.android:fetchstyle:1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlinVersion = '1.4.10'
+    ext.kotlinVersion = '1.4.20'
     ext.serializationVersion = '1.0-M1-1.4.0-rc'
     repositories {
         google()

--- a/mp4compose/build.gradle
+++ b/mp4compose/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/photoeditor/build.gradle
+++ b/photoeditor/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlinx-serialization'
 

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlinx-serialization'
+apply plugin: 'kotlin-parcelize'
 apply from: "../stories-common.gradle"
 
 android {

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlinx-serialization'
 apply from: "../stories-common.gradle"

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
@@ -9,9 +9,9 @@ import com.wordpress.stories.compose.story.StoryIndex
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
+@SuppressLint("ParcelCreator")
 class StorySaveEvents {
     @Parcelize
-    @SuppressLint("ParcelCreator")
     data class StorySaveResult(
         var storyIndex: StoryIndex = 0,
         val frameSaveResult: MutableList<FrameSaveResult> = mutableListOf(),
@@ -25,19 +25,16 @@ class StorySaveEvents {
         }
     }
     @Parcelize
-    @SuppressLint("ParcelCreator")
     data class FrameSaveResult(val frameIndex: FrameIndex, val resultReason: SaveResultReason) : Parcelable
 
     @Serializable
     sealed class SaveResultReason : Parcelable {
         @Serializable
         @Parcelize
-        @SuppressLint("ParcelCreator")
         object SaveSuccess : SaveResultReason()
 
         @Serializable
         @Parcelize
-        @SuppressLint("ParcelCreator")
         data class SaveError(
             var reason: String? = null
         ) : SaveResultReason()

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
@@ -1,5 +1,6 @@
 package com.wordpress.stories.compose.frame
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Parcelable
 import com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason.SaveError
@@ -10,6 +11,7 @@ import kotlinx.serialization.Serializable
 
 class StorySaveEvents {
     @Parcelize
+    @SuppressLint("ParcelCreator")
     data class StorySaveResult(
         var storyIndex: StoryIndex = 0,
         val frameSaveResult: MutableList<FrameSaveResult> = mutableListOf(),
@@ -23,16 +25,19 @@ class StorySaveEvents {
         }
     }
     @Parcelize
+    @SuppressLint("ParcelCreator")
     data class FrameSaveResult(val frameIndex: FrameIndex, val resultReason: SaveResultReason) : Parcelable
 
     @Serializable
     sealed class SaveResultReason : Parcelable {
         @Serializable
         @Parcelize
+        @SuppressLint("ParcelCreator")
         object SaveSuccess : SaveResultReason()
 
         @Serializable
         @Parcelize
+        @SuppressLint("ParcelCreator")
         data class SaveError(
             var reason: String? = null
         ) : SaveResultReason()

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/StorySaveEvents.kt
@@ -5,7 +5,7 @@ import android.os.Parcelable
 import com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason.SaveError
 import com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason.SaveSuccess
 import com.wordpress.stories.compose.story.StoryIndex
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
 class StorySaveEvents {


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/stories-android/pull/688. It removes no longer necessary "kotlin-android-extensions" which has been preventing us from updating to a newer gradle version.

**This PR needs to be merged after https://github.com/Automattic/stories-android/pull/688 gets merged.**

This is still a draft since I haven't tested the changes in WPAndroid.

Changes in this PR
- Removes kotlin-android-extensions'
- Updates kotlin from 1.4.1 to 1.4.2 so `kotlin-parcelize` plugin is available ([release notes](https://github.com/JetBrains/kotlin/releases/tag/v1.4.20) - AFAICT there are no changes which would affect us - We might need to update other repos to this kotlin version, but I assume we'll need to do that anyway)
- Adds `kotlin-parcelize` plugin to keep support for @Parcelize annotation which used to be part of `kotlin-android-extensions` but now lives in a standalone plugin (`kotlin-parcelize`)
- Suppresses "ParcelCreator" lint error - it's a false positive. Classes which use @Parcelize don't need to [manually implement Creator](https://developer.android.com/kotlin/parcelize).


To test:
Smoke test the app 