### PR TITLE
Fail Fast - Replace usages of binding?. with binding!!. 

### DIFF
--- a/app/src/main/java/com/automattic/loop/MainActivity.kt
+++ b/app/src/main/java/com/automattic/loop/MainActivity.kt
@@ -25,7 +25,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 
 class MainActivity : AppCompatActivity(), MainFragment.OnFragmentInteractionListener {
-    private var binding: ActivityMainBinding? = null
+    private lateinit var binding: ActivityMainBinding
 
     override fun onFragmentInteraction(uri: Uri) {
         // TODO: change OnFragmentInteractionListener for something relevant to our needs
@@ -67,7 +67,7 @@ class MainActivity : AppCompatActivity(), MainFragment.OnFragmentInteractionList
 
     override fun onResume() {
         super.onResume()
-        binding?.fab?.isEnabled = true
+        binding.fab.isEnabled = true
     }
 
     override fun onSupportNavigateUp() =

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryFrameSelectorFragment.kt
@@ -27,7 +27,10 @@ interface OnStoryFrameSelectorTappedListener {
 }
 
 class StoryFrameSelectorFragment : Fragment(R.layout.fragment_story_frame_selector) {
-    private var binding: FragmentStoryFrameSelectorBinding? = null
+    private var _binding: FragmentStoryFrameSelectorBinding? = null
+    // This property is only valid between onCreateView and onDestroyView.
+    private val binding get() = _binding!!
+
     private lateinit var plusIconBinding: FragmentStoryFrameItemPlusBinding
 
     lateinit var storyViewModel: StoryViewModel
@@ -87,7 +90,7 @@ class StoryFrameSelectorFragment : Fragment(R.layout.fragment_story_frame_select
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         with(FragmentStoryFrameSelectorBinding.bind(view)) {
-            binding = this
+            _binding = this
             plusIconBinding = plusIcon
             storyFramesView.adapter = StoryFrameSelectorAdapter()
             // disable animations on selected border visibility changes so users can see the selection
@@ -109,21 +112,21 @@ class StoryFrameSelectorFragment : Fragment(R.layout.fragment_story_frame_select
     }
 
     private fun updateContentUiState(contentState: StoryFrameListUiState) {
-        (binding?.storyFramesView?.adapter as StoryFrameSelectorAdapter).addAllItems(contentState.items)
+        (binding.storyFramesView.adapter as StoryFrameSelectorAdapter).addAllItems(contentState.items)
     }
 
     private fun updateContentUiStateSelection(oldSelection: Int, newSelection: Int) {
-        (binding?.storyFramesView?.adapter as StoryFrameSelectorAdapter)
+        (binding.storyFramesView.adapter as StoryFrameSelectorAdapter)
             .updateContentUiStateSelection(oldSelection, newSelection)
     }
 
     private fun updateContentUiStateMovedIndex(oldPosition: Int, newPosition: Int) {
-        (binding?.storyFramesView?.adapter as StoryFrameSelectorAdapter)
+        (binding.storyFramesView.adapter as StoryFrameSelectorAdapter)
             .updateContentUiStateMovedIndex(oldPosition, newPosition)
     }
 
     private fun updateContentUiStateItem(position: Int) {
-        (binding?.storyFramesView?.adapter as StoryFrameSelectorAdapter)
+        (binding.storyFramesView.adapter as StoryFrameSelectorAdapter)
             .updateContentUiStateItem(position)
     }
 
@@ -191,11 +194,11 @@ class StoryFrameSelectorFragment : Fragment(R.layout.fragment_story_frame_select
     }
 
     fun show() {
-        binding?.root?.visibility = View.VISIBLE
+        binding.root.visibility = View.VISIBLE
     }
 
     fun hide() {
-        binding?.root?.visibility = View.INVISIBLE
+        binding.root.visibility = View.INVISIBLE
     }
 
     fun hideAddFrameControl() {
@@ -207,16 +210,16 @@ class StoryFrameSelectorFragment : Fragment(R.layout.fragment_story_frame_select
     }
 
     fun setBottomOffset(offset: Int) {
-        val params = binding?.root?.layoutParams as ConstraintLayout.LayoutParams
+        val params = binding.root.layoutParams as ConstraintLayout.LayoutParams
         val hasChanged = params.bottomMargin != offset
         if (hasChanged) {
             params.bottomMargin = offset
-            binding?.root?.requestLayout()
+            binding.root.requestLayout()
         }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 }

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -29,7 +29,9 @@ import com.wordpress.stories.databinding.AddTextDialogBinding
  */
 
 class TextEditorDialogFragment : DialogFragment() {
-    private var binding: AddTextDialogBinding? = null
+    private var _binding: AddTextDialogBinding? = null
+    // This property is only valid between onCreateView and onDestroyView.
+    private val binding get() = _binding!!
 
     @ColorInt private var colorCode: Int = 0
     @ColorInt private var backgroundColorCode: Int = Color.TRANSPARENT
@@ -70,8 +72,8 @@ class TextEditorDialogFragment : DialogFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        binding = AddTextDialogBinding.inflate(inflater)
-        return binding?.root
+        _binding = AddTextDialogBinding.inflate(inflater)
+        return binding.root
     }
 
     override fun onStop() {
@@ -84,7 +86,7 @@ class TextEditorDialogFragment : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         arguments?.let {
-            binding?.addTextEditText?.setText(it.getString(EXTRA_INPUT_TEXT))
+            binding.addTextEditText.setText(it.getString(EXTRA_INPUT_TEXT))
             colorCode = it.getInt(EXTRA_TEXT_COLOR_CODE)
             backgroundColorCode = it.getInt(EXTRA_TEXT_BACKGROUND_COLOR_CODE)
             textAlignment = TextAlignment.valueOf(it.getInt(EXTRA_TEXT_ALIGNMENT))
@@ -95,7 +97,7 @@ class TextEditorDialogFragment : DialogFragment() {
             ColorPickerBottomSheetHandler(it, view)
         }
 
-        binding?.let {
+        binding.let {
             // Hide the bottom sheet if the user taps in the EditText
             it.addTextEditText.setOnClickListener {
                 bottomSheetHandler?.hideBottomSheet()
@@ -152,11 +154,9 @@ class TextEditorDialogFragment : DialogFragment() {
     }
 
     override fun onDismiss(dialog: DialogInterface) {
-        binding?.let {
-            val inputText = it.addTextEditText.text.toString()
-            textEditor?.onDone(inputText, TextStyler.from(it.addTextEditText, typefaceId, backgroundColorCode))
-            textEditorAnalyticsHandler?.report()
-        }
+        val inputText = binding.addTextEditText.text.toString()
+        textEditor?.onDone(inputText, TextStyler.from(binding.addTextEditText, typefaceId, backgroundColorCode))
+        textEditorAnalyticsHandler?.report()
         super.onDismiss(dialog)
     }
 
@@ -264,7 +264,7 @@ class TextEditorDialogFragment : DialogFragment() {
     }
 
     override fun onDestroyView() {
-        binding = null
+        _binding = null
         super.onDestroyView()
     }
 

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextEditorDialogFragment.kt
@@ -264,8 +264,8 @@ class TextEditorDialogFragment : DialogFragment() {
     }
 
     override fun onDestroyView() {
-        _binding = null
         super.onDestroyView()
+        _binding = null
     }
 
     companion object {


### PR DESCRIPTION
This PR replaces usages of "binding?" with
- a non-nullable lateinit var in Activites
- "binding!!." in Fragments

This is a recommended practice by google and was discussed [here](https://github.com/Automattic/stories-android/pull/698#discussion_r649364186).

I also updated one place where we were setting `binding = null` in `onDestroyView` before `super.onDestroyView`.  This lead to a NPE as "dialog's onDismiss" was getting called when the binding was already null. (update: this introduced another issue, read the inline comment)

To Test:
1. Smoke test the app