### PR TITLE
Re-enable fetchstyle plugin and request it from s3 repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ jobs:
       - checkout
       - android/restore-gradle-cache
       - copy-gradle-properties
-        #      - run:
-        #          name: Checkstyle
-        #          command: ./gradlew --stacktrace checkstyle
+      - run:
+          name: Checkstyle
+          command: ./gradlew --stacktrace checkstyle
       - run:
           name: ktlint
           command: ./gradlew --stacktrace ciktlint

--- a/build.gradle
+++ b/build.gradle
@@ -4,16 +4,21 @@ buildscript {
     ext.kotlinVersion = '1.4.10'
     ext.serializationVersion = '1.0-M1-1.4.0-rc'
     repositories {
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android' 
+            content {
+                includeGroup "com.automattic.android"
+            }
+        }
         google()
         jcenter()
         maven { url "https://jitpack.io" }
-        maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlinVersion"
-        //classpath 'com.automattic.android:fetchstyle:1.1'
+        classpath 'com.automattic.android:fetchstyle:1.1'
         classpath 'io.sentry:sentry-android-gradle-plugin:1.7.27'
         classpath 'com.automattic.android:configure:0.6.1'
 
@@ -22,7 +27,7 @@ buildscript {
     }
 }
 
-//apply plugin: 'com.automattic.android.fetchstyle'
+apply plugin: 'com.automattic.android.fetchstyle'
 apply plugin: 'com.automattic.android.configure'
 
 allprojects {


### PR DESCRIPTION
Since the [source code for fetchstyle plugin](https://github.com/Automattic/style-config-android) is heavily outdated, I couldn't fully update it in the time I allotted for it. I actually successfully published the plugin to S3, but there was something wrong with the groovy dependency, so it didn't work when I tried to consume it. So, for now, I've manually ported the fetchstyle plugin from jcenter to our s3 repository.

**Edit:**
I realized there was one last thing I forgot to revert from https://github.com/Automattic/stories-android/pull/674 and that's to re-enable the checkstyle task in CI. I've done this in 359ba35f1973912d414996a2dd99c0a60304243c. This task should have never been commented out because it had nothing to do with the fetchstyle plugin, but I didn't recognize this during that day's craziness.

**To test:**
* Run `./gradlew tasks --all | grep downloadConfigs` to verify the fetchstyle plugin tasks are available. Or you can run the `downloadConfigs` with `./gradlew downloadConfigs`.
* Run `./gradlew --scan` and open the scan. In the `Build Dependencies section`, use the search functionality to find the `fetchstyle` dependency and verify it's repository is our s3 repo and not `jcenter`

![Screen Shot 2021-06-13 at 4 44 51 PM](https://user-images.githubusercontent.com/662023/121821431-e4114680-cc66-11eb-8799-49fda91d0ad6.png)
