### PR TITLE
Address WPAndroid ClickableViewAccessibility lint errors

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -1,6 +1,81 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
+    <!-- INFO -->
+    <issue id="IconMissingDensityFolder" severity="info" />
+
+    <!-- WARNING -->
+    <issue id="RtlSymmetry" severity="warning" />
+    <issue id="UseSparseArrays" severity="warning" />
+
+    <!-- ERROR -->
+    <issue id="SimpleDateFormat" severity="error" />
+    <issue id="RtlCompat" severity="error" />
+    <issue id="DefaultLocale" severity="error" />
+    <issue id="RtlHardcoded" severity="error" />
+    <issue id="InconsistentArrays" severity="error" />
+    <issue id="HardcodedText" severity="error" />
+    <issue id="IconDuplicates" severity="error" />
+    <issue id="IconDipSize" severity="error" />
+    <issue id="InconsistentArrays" severity="error" />
+    <issue id="StringFormatCount" severity="error" />
+    <issue id="ScrollViewSize" severity="error" />
+    <issue id="ApplySharedPref" severity="error" />
+    <issue id="CustomViewStyleable" severity="error" />
+    <issue id="DuplicateIncludedIds" severity="error" />
+    <issue id="InconsistentLayout" severity="error" />
+    <issue id="InlinedApi" severity="error" />
+    <issue id="InconsistentLayout" severity="error" />
+    <issue id="InlinedApi" severity="error" />
+    <issue id="UnknownIdInLayout" severity="error" />
+    <issue id="GradleOverrides" severity="error" />
+    <issue id="ExtraText" severity="error" />
+    <issue id="SpUsage" severity="error" />
+    <issue id="SwitchIntDef" severity="error" />
+    <issue id="Typos" severity="error" />
+    <issue id="AddJavascriptInterface" severity="error" />
+    <issue id="DrawAllocation" severity="error" />
+    <issue id="Recycle" severity="error" />
+    <issue id="ObsoleteLayoutParam" severity="error" />
+    <issue id="ObsoleteSdkInt" severity="error" />
+    <issue id="ViewHolder" severity="error" />
+    <issue id="DuplicateDivider" severity="error" />
+    <issue id="InefficientWeight" severity="error" />
+    <issue id="UnusedResources" severity="error" />
+    <issue id="UselessParent" severity="error" />
+    <issue id="UnusedNamespace" severity="error" />
+    <issue id="TypographyDashes" severity="error" />
+    <issue id="TypographyEllipsis" severity="error" />
+    <issue id="IconLocation" severity="error" />
+    <issue id="TextFields" severity="error" />
+    <issue id="SmallSp" severity="error" />
+    <issue id="StaticFieldLeak" severity="error" />
+    <issue id="SetTextI18n" severity="error" />
+    <issue id="RelativeOverlap" severity="error" />
+    <issue id="PrivateResource" severity="error" />
+    <issue id="StaticFieldLeak" severity="error" />
+    <issue id="ContentDescription" severity="error" />
+    <issue id="ClickableViewAccessibility" severity="error" />
+    <issue id="KeyboardInaccessibleWidget" severity="error" />
+    <issue id="UnusedAttribute" severity="error" />
+    <issue id="UnusedAttribute" severity="error" />
+    <issue id="IconXmlAndPng" severity="error" />
+    <issue id="RtlSymmetry" severity="error" />
+    <issue id="ExportedReceiver" severity="error" />
+    <issue id="ExportedService" severity="error" />
+
+    <!-- IGNORE -->
+    <issue id="MissingTranslation" severity="ignore" />
+    <issue id="ExtraTranslation" severity="ignore" />
+    <issue id="PluralsCandidate" severity="ignore" /> <!-- GlotPress doesn't support plurals -->
+    <issue id="LabelFor" severity="ignore" /> <!-- Severity should be increased to error when minSdk >= 17 -->
+    <issue id="OldTargetApi" severity="ignore" /> <!-- We are aware of down sides of having an old targetApi -->
+    <issue id="UseAppTint" severity="ignore" /> <!-- android:tint attribute had a problem on API<=21, but our minSdk is 21, ignore -->
     <issue id="InvalidPackage">
         <ignore path="**/sentry*.jar"/>
+    </issue>
+
+    <issue id="UnusedResources" severity="error">
+        <ignore path="**/.gradle/caches/**" />
+        <ignore path="**/generated/**" />
     </issue>
 </lint>

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -34,6 +34,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    lintOptions{
+        lintConfig file("${project.rootDir}/lint.xml")
+    }
 }
 
 dependencies {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -951,6 +951,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         onStoryFrameSelected(-1, storyFrameIndex)
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private fun addClickListeners() {
         contentComposerBinding.run {
             cameraCaptureButton
@@ -1281,6 +1282,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         storyViewModel.setSelectedFrameByUser(storyViewModel.getSelectedFrameIndex())
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private fun addCurrentViewsToFrameAtIndex(index: Int) {
         // first, remember the currently added views
         val currentStoryFrameItem = storyViewModel.getCurrentStoryFrameAt(index)
@@ -1916,6 +1918,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         )
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private fun blockTouchOnPhotoEditor(touchBlockMode: ScreenTouchBlockMode, message: String? = null) {
         contentComposerBinding.run {
             when (touchBlockMode) {
@@ -1974,6 +1977,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         }
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private fun releaseTouchOnPhotoEditor(touchBlockMode: ScreenTouchBlockMode) {
         contentComposerBinding.run {
             when (touchBlockMode) {


### PR DESCRIPTION
It looks like the view binding update (#688) created a few cases of the `ClickableViewAccessibility` lint check. Nothing changed feature-wise, I'm guessing the check just parses view binding based code differently and recognized something where it didn't before. I noticed this in https://github.com/wordpress-mobile/WordPress-Android/pull/14928, which is trying to pull the view binding changes from this library into WPAndroid.

`ClickableViewAccessibility` is a warning by default, but WPAndroid has promoted this to an error.

We have an open issue (#499) to eventually try to address some `ClickableViewAccessiblity` suppressions we already have, which I believe were imported with the original photoeditor library. (It may in fact be a true false positive in some cases due to how we're handling clicks.)

For now, to unblock that PR, I'm suppressing the lint check in the areas where it's now being flagged. I've also imported the `lint.xml` file from WPAndroid to make this less likely to happen in the future (I removed a few obvious WPAndroid-specific things). Ideally this will be part of better tooling in the future allowing us to share the `lint.xml` between projects with local custom rules.

### To test
* Check out ce3fe2f, run lint, confirm you get 11 errors (same as the WPAndroid PR)
* Check out the branch, run lint, confirm no errors
* The above two should also be verifiable by looking at CI, I'm pushing the PR early on purpose so CI runs lint on ce3fe2f
* Build this branch in WPAndroid, run `lintWordpressVanillaRelease`, make sure there are no errors