### PR TITLE
Remove build config pre build task

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,27 +104,23 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
-tasks.register('createBuildConfigFieldsFromProperties') {
-    // Add properties named "loop.xxx" to our BuildConfig
-    android.buildTypes.all { buildType ->
-        def inputFile = file("${rootDir}/gradle.properties")
-        def properties = loadGradleProperties(inputFile)
-        properties.any { property ->
-        if (property.key.toLowerCase().startsWith("loop.")) {
-                buildType.buildConfigField "String", property.key.replace("loop.", "").replace(".", "_").toUpperCase(),
-                        "\"${property.value}\""
-            }
-            else if (property.key.toLowerCase().startsWith("sentry.dsn")) {
-                buildType.buildConfigField "String", property.key.replace(".", "_").toUpperCase(),
-                        "\"${property.value}\""
-            }
-            else if (property.key.toLowerCase().startsWith("loop.res.")) {
-                buildType.resValue "string", property.key.replace("loop.res.", "").replace(".", "_").toLowerCase(),
-                        "${property.value}"
-            }
+// Add properties named "loop.xxx" to our BuildConfig
+android.buildTypes.all { buildType ->
+    def inputFile = file("${rootDir}/gradle.properties")
+    def properties = loadGradleProperties(inputFile)
+    properties.any { property ->
+    if (property.key.toLowerCase().startsWith("loop.")) {
+            buildType.buildConfigField "String", property.key.replace("loop.", "").replace(".", "_").toUpperCase(),
+                    "\"${property.value}\""
+        }
+        else if (property.key.toLowerCase().startsWith("sentry.dsn")) {
+            buildType.buildConfigField "String", property.key.replace(".", "_").toUpperCase(),
+                    "\"${property.value}\""
+        }
+        else if (property.key.toLowerCase().startsWith("loop.res.")) {
+            buildType.resValue "string", property.key.replace("loop.res.", "").replace(".", "_").toLowerCase(),
+                    "${property.value}"
         }
     }
 }
-
-preBuild.dependsOn(tasks.named("createBuildConfigFieldsFromProperties"))
 

--- a/stories-common.gradle
+++ b/stories-common.gradle
@@ -1,8 +1,8 @@
 static def loadGradleProperties(inputFile) {
-        if (!inputFile.exists()) {
-            throw new StopActionException("Build configuration file gradle.properties doesn't exist, follow README instructions")
-        }
         def properties = new Properties()
+        if (!inputFile.exists()) {
+            return properties
+        }
         inputFile.withInputStream { stream ->
             properties.load(stream)
         }

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -86,29 +86,25 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
-tasks.register('createBuildConfigFieldsFromProperties') {
-    // Add properties named "loop.xxx" to our BuildConfig
-    android.buildTypes.all { buildType ->
-        def inputFile = file("${rootDir}/gradle.properties")
-        def properties = loadGradleProperties(inputFile)
-        properties.any { property ->
-            if (property.key.toLowerCase().startsWith("wp.stories.use.")) {
-                buildType.buildConfigField "boolean", property.key.replace("wp.stories.", "").replace(".", "_").toUpperCase(), "${property.value}"
-            }
-            else if (property.key.toLowerCase().startsWith("wp.stories.")) {
-                buildType.buildConfigField "String", property.key.replace("wp.stories.", "").replace(".", "_").toUpperCase(), "\"${property.value}\""
-            }
-            else if (property.key.toLowerCase().startsWith("wp.stories.res.")) {
-                buildType.resValue "string", property.key.replace("wp.stories.res.", "").replace(".", "_").toLowerCase(), "${property.value}"
-            }
+// Add properties named "loop.xxx" to our BuildConfig
+android.buildTypes.all { buildType ->
+    def inputFile = file("${rootDir}/gradle.properties")
+    def properties = loadGradleProperties(inputFile)
+    properties.any { property ->
+        if (property.key.toLowerCase().startsWith("wp.stories.use.")) {
+            buildType.buildConfigField "boolean", property.key.replace("wp.stories.", "").replace(".", "_").toUpperCase(), "${property.value}"
         }
-
-        if (properties.getProperty("wp.stories.use.cameraX") == null) {
-            // use cameraX implementation by default if no gradle.properties set
-            buildType.buildConfigField "boolean", "USE_CAMERAX", "true"
+        else if (property.key.toLowerCase().startsWith("wp.stories.")) {
+            buildType.buildConfigField "String", property.key.replace("wp.stories.", "").replace(".", "_").toUpperCase(), "\"${property.value}\""
+        }
+        else if (property.key.toLowerCase().startsWith("wp.stories.res.")) {
+            buildType.resValue "string", property.key.replace("wp.stories.res.", "").replace(".", "_").toLowerCase(), "${property.value}"
         }
     }
-}
 
-preBuild.dependsOn(tasks.named("createBuildConfigFieldsFromProperties"))
+    if (properties.getProperty("wp.stories.use.cameraX") == null) {
+        // use cameraX implementation by default if no gradle.properties set
+        buildType.buildConfigField "boolean", "USE_CAMERAX", "true"
+    }
+}
 


### PR DESCRIPTION
Gradle 7.1.1 or Android Gradle Plugin 4.2.2 does not like the `createBuildConfigFieldsFromProperties` pre-build task we use to generate the build config values. I've [looked back on when we added this](https://github.com/Automattic/stories-android/pull/635) and here is what the goal was:

> The fact that Android doesn't wrap its configuration in a task, but instead has to have everything present during the script evaluation pass means that we need a bunch of early returns in order for ./gradlew applyConfiguration to have a chance to copy gradle.properties into position before errors are emitted. If you know of another solution I'm open to it 😅

We were throwing an error when we tried to load `gradle.properties` before `applyConfiguration` task had a chance to create it. I don't think this error is necessary. If we were to build the app without the `gradle.properties` file, it would fail because the build config fields would be missing. So, I think we should get rid of the extra check and the pre-build tasks and make this project consistent with others.

What do you think @jkmassel?

To test:
* If CI is green - we don't need to test anything

_P.S: It might help to check `Hide whitespace changes` PR setting since the whole code block is shifted._