### PR TITLE
Update minSdk to 24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ ext {
     compileSdkVersion = 28
     buildToolVersion = '28.0.3'
 
-    minSdkVersion = 21
+    minSdkVersion = 24
     targetSdkVersion = 28
 
     lifecycleVersion = '2.2.0'

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/MediaCodecBufferCompatWrapper.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/MediaCodecBufferCompatWrapper.kt
@@ -17,14 +17,10 @@ internal class MediaCodecBufferCompatWrapper(private val mediaCodec: MediaCodec)
     private val outputBuffers: Array<ByteBuffer>? = null
 
     fun getInputBuffer(index: Int): ByteBuffer? {
-        return if (Build.VERSION.SDK_INT >= 21) {
-            mediaCodec.getInputBuffer(index)
-        } else inputBuffers!![index]
+        return mediaCodec.getInputBuffer(index)
     }
 
     fun getOutputBuffer(index: Int): ByteBuffer? {
-        return if (Build.VERSION.SDK_INT >= 21) {
-            mediaCodec.getOutputBuffer(index)
-        } else outputBuffers!![index]
+        return mediaCodec.getOutputBuffer(index)
     }
 }

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/MediaCodecBufferCompatWrapper.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/MediaCodecBufferCompatWrapper.kt
@@ -1,7 +1,6 @@
 package com.daasuu.mp4compose.composer
 
 import android.media.MediaCodec
-import android.os.Build
 
 import java.nio.ByteBuffer
 

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngineBasic.java
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngineBasic.java
@@ -128,10 +128,6 @@ class Mp4ComposerEngineBasic {
                     outputResolution,
                     iFrameInterval
             );
-            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP) {
-                // Only LOLLIPOP sets KEY_FRAME_RATE here.
-                actualVideoOutputFormat.setInteger(MediaFormat.KEY_FRAME_RATE, 30);
-            }
 
             // setup video composer
             videoComposer = new VideoComposer(

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
@@ -124,13 +124,8 @@ class PermissionUtils {
             return true
         }
 
-        fun anyVideoNeededPermissionPermanentlyDenied(activity: Activity): String? {
-            if (Build.VERSION.SDK_INT >= VERSION_CODES.M) {
-                return checkPermanentDenyForPermissions(activity, REQUIRED_PERMISSIONS_WITH_AUDIO)
-            } else {
-                return null
-            }
-        }
+        fun anyVideoNeededPermissionPermanentlyDenied(activity: Activity): String? =
+                checkPermanentDenyForPermissions(activity, REQUIRED_PERMISSIONS_WITH_AUDIO)
 
         @RequiresApi(VERSION_CODES.M)
         private fun checkPermanentDenyForPermissions(activity: Activity, permissions: Array<String>): String? {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
@@ -5,7 +5,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Build.VERSION_CODES
 import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -1866,17 +1866,6 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     private fun sendNewStoryFrameReadyBroadcast(mediaFile: File) {
-        // Implicit broadcasts will be ignored for devices running API
-        // level >= 24, so if you only target 24+ you can remove this statement
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            @Suppress("DEPRECATION")
-            if (mediaFile.extension == "jpg") {
-                sendBroadcast(Intent(Camera.ACTION_NEW_PICTURE, Uri.fromFile(mediaFile)))
-            } else {
-                sendBroadcast(Intent(Camera.ACTION_NEW_VIDEO, Uri.fromFile(mediaFile)))
-            }
-        }
-
         // If the folder selected is an external media directory, this is unnecessary
         // but otherwise other apps will not be able to access our images unless we
         // scan them using [MediaScannerConnection]
@@ -1888,20 +1877,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     private fun sendNewStoryReadyBroadcast(rawMediaFileList: List<File?>) {
-        // Implicit broadcasts will be ignored for devices running API
-        // level >= 24, so if you only target 24+ you can remove this statement
         val mediaFileList = rawMediaFileList.filterNotNull()
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            @Suppress("DEPRECATION")
-            for (mediaFile in mediaFileList) {
-                if (mediaFile.extension == "jpg") {
-                    sendBroadcast(Intent(Camera.ACTION_NEW_PICTURE, Uri.fromFile(mediaFile)))
-                } else {
-                    sendBroadcast(Intent(Camera.ACTION_NEW_VIDEO, Uri.fromFile(mediaFile)))
-                }
-            }
-        }
-
         val arrayOfmimeTypes = arrayOfNulls<String>(mediaFileList.size)
         val arrayOfPaths = arrayOfNulls<String>(mediaFileList.size)
         for ((index, mediaFile) in mediaFileList.withIndex()) {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -13,7 +13,6 @@ import android.graphics.drawable.Drawable
 import android.graphics.Rect
 import android.graphics.drawable.ColorDrawable
 import android.graphics.Matrix
-import android.hardware.Camera
 import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Build

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -4,11 +4,8 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.hardware.Camera
 import android.media.MediaScannerConnection
-import android.net.Uri
 import android.os.Binder
-import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.util.Log

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveService.kt
@@ -240,19 +240,6 @@ class FrameSaveService : Service() {
     }
 
     private fun sendNewMediaReadyBroadcast(mediaFileList: List<File>) {
-        // Implicit broadcasts will be ignored for devices running API
-        // level >= 24, so if you only target 24+ you can remove this statement
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            @Suppress("DEPRECATION")
-            for (mediaFile in mediaFileList) {
-                if (mediaFile.extension == "jpg") {
-                    sendBroadcast(Intent(Camera.ACTION_NEW_PICTURE, Uri.fromFile(mediaFile)))
-                } else {
-                    sendBroadcast(Intent(Camera.ACTION_NEW_VIDEO, Uri.fromFile(mediaFile)))
-                }
-            }
-        }
-
         val arrayOfmimeTypes = arrayOfNulls<String>(mediaFileList.size)
         val arrayOfPaths = arrayOfNulls<String>(mediaFileList.size)
         for ((index, mediaFile) in mediaFileList.withIndex()) {


### PR DESCRIPTION
After an internal discussion, we decided to upgrade minSdk to for WordPress-Android to 24 as we have less than 5% of our users on the earlier versions of Android.

Besides upgrading the `minSdk`, it removes obsolete checks for the earlier versions of sdk. I suggest turning on the `hide whitespaces` option to review these changes.

**To test:**
* I think we should smoke test the app and then smoke test the [WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/15135)? I am not sure if this change can have any effect in the app to be honest.