### PR TITLE
Add Logging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,8 +77,8 @@ dependencies {
 
     implementation 'com.google.android.material:material:1.2.1'
 
-    implementation 'com.github.bumptech.glide:glide:4.10.0'
-    kapt 'com.github.bumptech.glide:compiler:4.10.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    kapt 'com.github.bumptech.glide:compiler:4.12.0'
 
     implementation 'org.greenrobot:eventbus:3.2.0'
 


### PR DESCRIPTION
added logging to instrument crash

Fixes: [#15096](https://github.com/wordpress-mobile/WordPress-Android/issues/15096)

Couldn't reproduce the issue.  
- Tried the usual suspects, like Scoped storage.  Sentry is showing that issue is happening on android versions below 10 as well
- Added a try, catch block with logging and also 
- upgraded Glide from 4.10 to 4.12