### PR TITLE
Fix/15322 upgrade Stories-Android to android 11 api level 30

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-permission android:name="android.permission.CAMERA" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-permission android:name="android.permission.CAMERA" />

--- a/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
@@ -79,8 +79,8 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         if (resultCode == Activity.RESULT_OK && data != null) {
             if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)) {
                 val mediaUris = data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)
-                if (mediaUris != null) {
-                    val uriList: List<Uri> = convertStringArrayIntoUrisList(mediaUris)
+                mediaUris?.let {
+                    val uriList: List<Uri> = convertStringArrayIntoUrisList(it)
                     // if there are any external Uris in this list, copy them locally before trying to use them
                     processExternalUris(uriList)
                 }

--- a/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
@@ -78,8 +78,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == Activity.RESULT_OK && data != null) {
             if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)) {
-                val mediaUris = data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)
-                mediaUris?.let {
+                data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)?.let {
                     val uriList: List<Uri> = convertStringArrayIntoUrisList(it)
                     // if there are any external Uris in this list, copy them locally before trying to use them
                     processExternalUris(uriList)

--- a/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
@@ -78,11 +78,12 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == Activity.RESULT_OK && data != null) {
             if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)) {
-                val uriList: List<Uri> = convertStringArrayIntoUrisList(
-                        data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)
-                )
-                // if there are any external Uris in this list, copy them locally before trying to use them
-                processExternalUris(uriList)
+                val mediaUris = data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)
+                if (mediaUris != null) {
+                    val uriList: List<Uri> = convertStringArrayIntoUrisList(mediaUris)
+                    // if there are any external Uris in this list, copy them locally before trying to use them
+                    processExternalUris(uriList)
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -91,10 +91,8 @@ subprojects {
 }
 
 ext {
-    compileSdkVersion = 30
-    buildToolVersion = '28.0.3'
-
     minSdkVersion = 24
+    compileSdkVersion = 30
     targetSdkVersion = 30
 
     lifecycleVersion = '2.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -91,11 +91,11 @@ subprojects {
 }
 
 ext {
-    compileSdkVersion = 28
+    compileSdkVersion = 30
     buildToolVersion = '28.0.3'
 
     minSdkVersion = 24
-    targetSdkVersion = 28
+    targetSdkVersion = 30
 
     lifecycleVersion = '2.2.0'
     coroutinesVersion = '1.3.9'

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/Camera2BasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/Camera2BasicHandling.kt
@@ -483,7 +483,7 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
             val texture = textureView.surfaceTexture
 
             // We configure the size of default buffer to be the size of camera preview we want.
-            texture.setDefaultBufferSize(previewSize.width, previewSize.height)
+            texture?.setDefaultBufferSize(previewSize.width, previewSize.height)
 
             // This is the output Surface we need to start preview.
             val surface = Surface(texture)
@@ -771,7 +771,7 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
             val texture = textureView.surfaceTexture
 
             // We configure the size of default buffer to be the size of camera preview we want.
-            texture.setDefaultBufferSize(previewSize.width, previewSize.height)
+            texture?.setDefaultBufferSize(previewSize.width, previewSize.height)
 
             // This is the output Surface we need to start preview.
             val surface = Surface(texture)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt
@@ -150,7 +150,7 @@ class CameraXBasicHandling : VideoRecorderFragment() {
             val parent = textureView.parent as ViewGroup
             parent.removeView(textureView)
             parent.addView(textureView, 0)
-            textureView.surfaceTexture = it.surfaceTexture
+            textureView.setSurfaceTexture(it.surfaceTexture)
         }
 
         // we used to bind all use cases to lifecycle on start

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
@@ -141,7 +141,7 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
     private fun startUp() {
         if (textureView.isAvailable && active) {
             CoroutineScope(Dispatchers.Main).launch {
-                startVideoPlay(textureView.surfaceTexture)
+                textureView.surfaceTexture?.let { startVideoPlay(it) }
             }
         }
     }
@@ -270,10 +270,10 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
             videoOrientation = rotation
         } catch (e: IOException) {
             playerPreparedListener?.onPlayerError()
-            Log.d(TAG, e.message)
+            Log.d(TAG, e.message.toString())
         } catch (e: NumberFormatException) {
             playerPreparedListener?.onPlayerError()
-            Log.d(TAG, e.message)
+            Log.d(TAG, e.message.toString())
         } catch (e: IllegalArgumentException) {
             playerPreparedListener?.onPlayerError()
             Log.e(TAG, "Can't read duration of the video.", e)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/PhotoEditorView.kt
@@ -274,7 +274,7 @@ class PhotoEditorView : RelativeLayout {
             })
         } else if (autoFitTextureView.visibility == View.VISIBLE) {
             // this saves just a snapshot of whatever is being displayed on the TextureSurface
-            backgroundImage.setImageBitmap(autoFitTextureView.bitmap)
+            autoFitTextureView.bitmap?.let { backgroundImage.setImageBitmap(it) }
             toggleTextureView()
             onSaveBitmap.onBitmapReady(backgroundImage.bitmap!!)
         } else {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -795,11 +795,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                 finish()
             }
         } else if (intent.hasExtra(requestCodes.EXTRA_MEDIA_URIS)) {
-            val uriList: List<Uri> = convertStringArrayIntoUrisList(
-                intent.getStringArrayExtra(requestCodes.EXTRA_MEDIA_URIS)
-            )
-            addFramesToStoryFromMediaUriList(uriList)
-            setDefaultSelectionAndUpdateBackgroundSurfaceUI(uriList)
+            setMediaUris(intent)
             // dispatch StoryLoadEnd event
             EventBus.getDefault().post(StoryLoadEnd(storyIndexToSelect))
         } else if (intent.hasExtra(requestCodes.EXTRA_LAUNCH_WPSTORIES_MEDIA_PICKER_REQUESTED)) {
@@ -900,11 +896,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             requestCodes.PHOTO_PICKER -> if (resultCode == Activity.RESULT_OK && data != null) {
                 val providerHandlesMediaPickerResult = mediaPickerProvider?.providerHandlesOnActivityResult() ?: false
                 if (data.hasExtra(requestCodes.EXTRA_MEDIA_URIS) && !providerHandlesMediaPickerResult) {
-                    val uriList: List<Uri> = convertStringArrayIntoUrisList(
-                        data.getStringArrayExtra(requestCodes.EXTRA_MEDIA_URIS)
-                    )
-                    addFramesToStoryFromMediaUriList(uriList)
-                    setDefaultSelectionAndUpdateBackgroundSurfaceUI(uriList)
+                    setMediaUris(data)
                 } else if (data.hasExtra(requestCodes.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED)) {
                     if (!PermissionUtils.allRequiredPermissionsGranted(this)) {
                         // at this point, the user wants to launch the camera
@@ -922,6 +914,15 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                 // EXTRA_LAUNCH_WPSTORIES_MEDIA_PICKER_REQUESTED to start the Story with, we should cancel.
                 finishWhenEmptyStory()
             }
+        }
+    }
+
+    private fun setMediaUris(intent: Intent) {
+        val mediaUris = intent.getStringArrayExtra(requestCodes.EXTRA_MEDIA_URIS)
+        if (mediaUris != null) {
+            val uriList: List<Uri> = convertStringArrayIntoUrisList(mediaUris)
+            addFramesToStoryFromMediaUriList(uriList)
+            setDefaultSelectionAndUpdateBackgroundSurfaceUI(uriList)
         }
     }
 

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -919,8 +919,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     private fun setMediaUris(intent: Intent) {
         val mediaUris = intent.getStringArrayExtra(requestCodes.EXTRA_MEDIA_URIS)
-        if (mediaUris != null) {
-            val uriList: List<Uri> = convertStringArrayIntoUrisList(mediaUris)
+        mediaUris?.let {
+            val uriList: List<Uri> = convertStringArrayIntoUrisList(it)
             addFramesToStoryFromMediaUriList(uriList)
             setDefaultSelectionAndUpdateBackgroundSurfaceUI(uriList)
         }

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -918,8 +918,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     private fun setMediaUris(intent: Intent) {
-        val mediaUris = intent.getStringArrayExtra(requestCodes.EXTRA_MEDIA_URIS)
-        mediaUris?.let {
+        intent.getStringArrayExtra(requestCodes.EXTRA_MEDIA_URIS)?.let {
             val uriList: List<Uri> = convertStringArrayIntoUrisList(it)
             addFramesToStoryFromMediaUriList(uriList)
             setDefaultSelectionAndUpdateBackgroundSurfaceUI(uriList)


### PR DESCRIPTION
Fixes [WordPress-Android#15339](https://github.com/wordpress-mobile/WordPress-Android/issues/15339)

Upgrade to Android 11 (API level 30)

Please see paqN3M-mr-p2 for details on mandatory requirement to upgrade to Android 11 by November 2021.  Also this paqN3M-n4-p2, for details on planned approach to upgrade

- upgrade targetSdkVersion and compileSdkVersion to 30
- fix and tweak a few files
- remove redundant permission WRITE_EXTERNAL_STORAGE

NOTE: Stories is first cab off the rank for upgrade as a dependency for WPAndroid upgrade