### PR TITLE
Updates publish-to-s3 plugin to 0.7.0 and publishes '-sources.jar'

### DIFF
--- a/mp4compose/build.gradle
+++ b/mp4compose/build.gradle
@@ -46,13 +46,9 @@ project.afterEvaluate {
 
                 groupId "com.automattic.stories"
                 artifactId "mp4compose"
+                artifact tasks.named("androidSourcesJar") // This task is added by 'publish-to-s3' plugin
                 // version is set by 'publish-to-s3' plugin
             }
         }
    }
-}
-
-publishToS3Plugin {
-    mavenPublishGroupId "com.automattic.stories"
-    mavenPublishArtifactId "mp4compose"
 }

--- a/photoeditor/build.gradle
+++ b/photoeditor/build.gradle
@@ -80,13 +80,9 @@ project.afterEvaluate {
 
                 groupId "com.automattic.stories"
                 artifactId "photoeditor"
+                artifact tasks.named("androidSourcesJar") // This task is added by 'publish-to-s3' plugin
                 // version is set by 'publish-to-s3' plugin
             }
         }
    }
-}
-
-publishToS3Plugin {
-    mavenPublishGroupId "com.automattic.stories"
-    mavenPublishArtifactId "photoeditor"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,7 @@ pluginManagement {
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
         id "io.sentry.android.gradle" version "2.0.0"
-        id "com.automattic.android.publish-to-s3" version "0.6.1"
+        id "com.automattic.android.publish-to-s3" version "0.7.0"
     }
     repositories {
         maven {

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -120,13 +120,9 @@ project.afterEvaluate {
 
                 groupId "com.automattic"
                 artifactId "stories"
+                artifact tasks.named("androidSourcesJar") // This task is added by 'publish-to-s3' plugin
                 // version is set by 'publish-to-s3' plugin
             }
         }
    }
-}
-
-publishToS3Plugin {
-    mavenPublishGroupId "com.automattic"
-    mavenPublishArtifactId "stories"
 }


### PR DESCRIPTION
This PR updates `publish-to-s3` Gradle plugin to `0.7.0` and uses the newly introduced `androidSourcesJar` task to upload the `-sources.jar` file so it can be used by developers to access the source code from their IDEs. More details can be found in: https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/29

**To test:**
* https://github.com/wordpress-mobile/WordPress-Android/pull/15492 can be used to test the same changes applied to [WordPress-Utils-Android](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/95) & [WordPress-FluxC-Android](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2160) projects.