### PR TITLE
Drop jetifier

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     implementation project(path: ':stories')
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
-    implementation('org.wordpress:utils:1.26')
+    implementation('org.wordpress:utils:trunk-1ed207c03d2242b6fc3d74f9e388e9163cbc82a6')
 
     debugImplementation "com.facebook.flipper:flipper:$flipperVersion"
     debugImplementation 'com.facebook.soloader:soloader:0.9.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.10.0'
     kapt 'com.github.bumptech.glide:compiler:4.10.0'
 
-    implementation 'org.greenrobot:eventbus:3.2.0'
+    implementation 'org.greenrobot:eventbus:3.3.1'
 
     implementation 'io.sentry:sentry-android:5.0.1'
     // this dependency is not required if you are already using your own

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ allprojects {
             content {
                 includeGroup "com.automattic"
                 includeGroup "com.automattic.stories"
+                includeGroup "org.wordpress"
             }
         }
         google()

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 
 # Stories properties
 

--- a/stories/build.gradle
+++ b/stories/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
     implementation 'jp.wasabeef:glide-transformations:4.3.0'
 
-    implementation 'org.greenrobot:eventbus:3.2.0'
+    implementation 'org.greenrobot:eventbus:3.3.1'
 
     implementation photoEditorProjectDependency
 


### PR DESCRIPTION
This PR is part of [an effort of dropping Jetifier from WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/pull/15675).

Changes
- Updates EventBus to v3.3.1 which is migrated to AndroidX - v3.3.1 is already being used in WPAndroid so it's technically tested already
- Updates Utils to the latest version which is migrated to AndroidX
- Disables Jetifier in example gradle properties

To Test:
Make sure to disable Jetifier in your local gradle.properties => Smoke test the example app