### PR TITLE
Fixes attaching images taken with camera on Story posts

### DIFF
--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/FileUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/FileUtils.kt
@@ -25,7 +25,7 @@ class FileUtils {
         /** Use external media if it is available, our app's file directory otherwise */
         fun getOutputDirectory(context: Context): File {
             val appContext = context.applicationContext
-            val mediaDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)?.let {
+            val mediaDir = appContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES)?.let {
                 File(it, appContext.resources.getString(R.string.app_name)).apply { mkdirs() }
             }
             return if (mediaDir != null && mediaDir.exists())


### PR DESCRIPTION
This issue is due to using deprecated api and recent upgrade to android 11 (API 30) has probably exposed the issue.

https://developer.android.com/reference/android/content/Context.html#getExternalFilesDir(java.lang.String)

Fixed by updating getExternalStorageDirectory to getExternalFilesDir

To test:

- This needs to be tested from WordPress app using the related [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/15832) and steps there