### PR TITLE
Android 12: Security and privacy - Pending intents mutability (Stories)

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveNotifier.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveNotifier.kt
@@ -297,7 +297,7 @@ class FrameSaveNotifier(private val context: Context, private val service: Frame
             context,
             notificationId,
             notificationIntent,
-            PendingIntent.FLAG_ONE_SHOT
+            PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
         )
 
         notificationBuilder.setSmallIcon(android.R.drawable.stat_notify_error)


### PR DESCRIPTION
Sets `PendingIntent` mutability as part of `Android 12` migration changes.

Corresponding `WPAndroid` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/16082

### How I tested?

- Checked out referenced `WPAndroid` PR branch.
- Enabled stories lib from `WPAndroid`'s `local-builds.gradle`.
- With stories lib branch for this PR checked out, commented if condition inside `FrameSaveService.prepareStorySaveResult` so that `handleErrors` gets executed:

```
//        if (!noErrors) {
            // let's handle these errors
            handleErrors(storySaveProcessor.storySaveResult)
//        }
```
- Installed the app and published a story.
- Noticed that the error notification shown and `FrameSaveNotifier.updateNotificationErrorForStoryFramesSave` is executed properly with the new pending intent mutability.

<img width="320" src="https://user-images.githubusercontent.com/1405144/157819552-09107078-b4f0-4543-8de0-727155e83acf.jpg"/>

