### PR TITLE
Updates: compile sdk version and target sdk version to 31 for Android 12 Migration 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,8 @@
                 android:name="com.automattic.loop.MainActivity"
                 android:label="@string/app_name"
                 android:screenOrientation="portrait"
-                android:theme="@style/AppTheme.NoActionBar">
+                android:theme="@style/AppTheme.NoActionBar"
+                android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,8 +78,8 @@ subprojects {
 
 ext {
     minSdkVersion = 24
-    compileSdkVersion = 30
-    targetSdkVersion = 30
+    compileSdkVersion = 31
+    targetSdkVersion = 31
 
     lifecycleVersion = '2.2.0'
     coroutinesVersion = '1.3.9'


### PR DESCRIPTION
Closes #723 

This PR updates the target SDK version to 31 for the Android 12 migration

Test Instructions
- Install the app from the Parent PR
- Make sure the functionalities provided by the library work as expected