### PR TITLE
[Build] Remove Fetch Style Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id "org.jetbrains.kotlin.plugin.serialization"
     id "io.sentry.android.gradle"
 
-    id "com.automattic.android.fetchstyle"
     id "com.automattic.android.configure"
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,10 +26,6 @@ pluginManagement {
     }
     resolutionStrategy {
         eachPlugin {
-            // TODO: Remove this as soon as fetchstyle starts supporting Plugin Marker Artifacts
-            if (requested.id.id == "com.automattic.android.fetchstyle") {
-                useModule("com.automattic.android:fetchstyle:1.1")
-            }
             // TODO: Remove this as soon as configure starts supporting Plugin Marker Artifacts
             if (requested.id.id == "com.automattic.android.configure") {
                 useModule("com.automattic.android:configure:0.6.1")
@@ -42,4 +38,3 @@ include ':app',
         ':mp4compose',
         ':photoeditor',
         ':stories'
-


### PR DESCRIPTION
This PR removes the [fetchstyle](https://github.com/Automattic/style-config-android) plugin from the project.

This `style-config-android` plugin is mostly unused and very outdated.

To the Apps Infra's knowledge and checking GE stats no-one is using the `./gradlew downloadConfigs` task to fetch/update the style config files. For years now, almost all Android engineers depend on the default AS style and such like `.idea` configuration.

PS: For more info please refer to this internal discussion here: `C02QANACA/p1667910471807479`

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could try and run the `./gradlew downloadConfigs` task and verify that it is no longer found in the root project for Stories.