### PR TITLE
Android 13 fix media permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,13 +4,20 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission-sdk-23 android:name="android.permission.RECORD_AUDIO"/>
+    <!-- Allows for storing and retrieving screenshots, photos, videos and audios -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/app/src/main/java/com/automattic/loop/photopicker/PhotoPickerFragment.java
+++ b/app/src/main/java/com/automattic/loop/photopicker/PhotoPickerFragment.java
@@ -3,6 +3,7 @@ package com.automattic.loop.photopicker;
 import android.Manifest.permission;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.view.LayoutInflater;
@@ -502,8 +503,12 @@ public class PhotoPickerFragment extends Fragment {
     }
 
     private boolean hasStoragePermission() {
-        return ContextCompat.checkSelfPermission(
-            getActivity(), permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return ContextCompat.checkSelfPermission(
+                    requireActivity(), permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+        } else {
+            return true;
+        }
     }
 
 ///*

--- a/photoeditor/src/main/AndroidManifest.xml
+++ b/photoeditor/src/main/AndroidManifest.xml
@@ -2,12 +2,19 @@
           package="com.automattic.photoeditor">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission-sdk-23 android:name="android.permission.RECORD_AUDIO"/>
+    <!-- Allows for storing and retrieving screenshots, photos, videos and audios -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/PermissionUtils.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.os.Build
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 
@@ -15,9 +16,11 @@ class PermissionUtils {
     companion object {
         val PERMISSION_REQUEST_CODE = 5200
         val IS_PERMISSION_REQUESTED_PREFS = "is_permission_requested_prefs"
-        val REQUIRED_PERMISSIONS = arrayOf(
-            Manifest.permission.CAMERA
-        )
+        val REQUIRED_PERMISSIONS = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                    arrayOf(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                } else {
+                    arrayOf(Manifest.permission.CAMERA)
+                }
 
         // Video requires access to recording audio (microphone).
         val REQUIRED_PERMISSIONS_WITH_AUDIO = arrayOf(

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -9,10 +9,10 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
-import android.graphics.drawable.Drawable
+import android.graphics.Matrix
 import android.graphics.Rect
 import android.graphics.drawable.ColorDrawable
-import android.graphics.Matrix
+import android.graphics.drawable.Drawable
 import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Build
@@ -71,8 +71,8 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
-import com.bumptech.glide.load.resource.bitmap.FitCenter
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
+import com.bumptech.glide.load.resource.bitmap.FitCenter
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
@@ -88,12 +88,12 @@ import com.wordpress.stories.compose.ScreenTouchBlockMode.BLOCK_TOUCH_MODE_PHOTO
 import com.wordpress.stories.compose.ScreenTouchBlockMode.BLOCK_TOUCH_MODE_PHOTO_EDITOR_READY
 import com.wordpress.stories.compose.emoji.EmojiPickerFragment
 import com.wordpress.stories.compose.emoji.EmojiPickerFragment.EmojiListener
-import com.wordpress.stories.compose.frame.StoryLoadEvents.StoryLoadEnd
-import com.wordpress.stories.compose.frame.StoryLoadEvents.StoryLoadStart
 import com.wordpress.stories.compose.frame.FrameIndex
 import com.wordpress.stories.compose.frame.FrameSaveManager
 import com.wordpress.stories.compose.frame.FrameSaveNotifier
 import com.wordpress.stories.compose.frame.FrameSaveService
+import com.wordpress.stories.compose.frame.StoryLoadEvents.StoryLoadEnd
+import com.wordpress.stories.compose.frame.StoryLoadEvents.StoryLoadStart
 import com.wordpress.stories.compose.frame.StoryNotificationType
 import com.wordpress.stories.compose.frame.StorySaveEvents
 import com.wordpress.stories.compose.frame.StorySaveEvents.SaveResultReason.SaveError
@@ -1172,7 +1172,9 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             // fresh intent, go fully save the Story
             if (storyViewModel.getCurrentStorySize() > 0) {
                 // save all composed frames
-                if (PermissionUtils.checkAndRequestPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R ||
+                    PermissionUtils.checkAndRequestPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                ) {
                     storyFrameIndexToRetry = StoryRepository.DEFAULT_NONE_SELECTED
                     saveStory()
                 }
@@ -1560,7 +1562,9 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     @SuppressLint("MissingPermission")
     private fun saveVideo(inputFile: Uri) {
-        if (PermissionUtils.checkPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R ||
+            PermissionUtils.checkPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        ) {
             showLoading()
             try {
                 val file = getLoopFrameFile(this, true)
@@ -1617,7 +1621,9 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     @SuppressLint("MissingPermission")
     private fun saveVideoWithStaticBackground() {
-        if (PermissionUtils.checkPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R ||
+            PermissionUtils.checkPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        ) {
             showLoading()
             try {
                 val file = getLoopFrameFile(this, true, "tmp")


### PR DESCRIPTION
Updates media permissions for Android 13

Internal project thread: pbArwn-5IN-p2

Fixes: [#18096](https://github.com/wordpress-mobile/WordPress-Android/issues/18096)

To test

>**Warning**
> This probably needs to wait for [#18183](https://github.com/wordpress-mobile/WordPress-Android/pull/18183) on media permission to be merged first.

- Checkout this branch
- Use this branch through WP (uncomment localStoriesAndroidPath in local-builds.gradle)
- Try out adding a Story post (FAB > Story post) with an image and/or video from WP
- Ensure, no issues or crashes

>**Note**
> Adding an image or video doesn't do anything contrary to expectations from demo app **Loop** in this repo