### PR TITLE
[Compile Warnings As Errors] Resolve Warnings & Enable All Warnings as Errors

### DIFF
--- a/app/src/main/java/com/automattic/loop/MainActivity.kt
+++ b/app/src/main/java/com/automattic/loop/MainActivity.kt
@@ -112,7 +112,7 @@ class MainActivity : AppCompatActivity(), MainFragment.OnFragmentInteractionList
                 errorText
             )
             val snackbar = Snackbar.make(findViewById(android.R.id.content), snackbarMessage, Snackbar.LENGTH_LONG)
-            snackbar.setAction(R.string.story_saving_failed_quick_action_manage) { view ->
+            snackbar.setAction(R.string.story_saving_failed_quick_action_manage) {
                 // here go to the StoryComposerActivity, passing the SaveResult
                 val intent = Intent(this@MainActivity, StoryComposerActivity::class.java)
                 intent.putExtra(KEY_STORY_SAVE_RESULT, event)

--- a/app/src/main/java/com/automattic/loop/MainActivity.kt
+++ b/app/src/main/java/com/automattic/loop/MainActivity.kt
@@ -42,6 +42,7 @@ class MainActivity : AppCompatActivity(), MainFragment.OnFragmentInteractionList
             root.setOnApplyWindowInsetsListener { view, insets ->
                 // remember the insetTop as margin to all controls appearing at the top of the screen for full screen
                 // screens (i.e. ComposeLoopFrameActivity)
+                @Suppress("DEPRECATION")
                 (application as Loop).setStatusBarHeight(insets.systemWindowInsetTop)
                 view.onApplyWindowInsets(insets)
             }

--- a/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
+++ b/app/src/main/java/com/automattic/loop/StoryComposerActivity.kt
@@ -129,6 +129,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         val intent = Intent(this, PhotoPickerActivity::class.java)
         intent.putExtra(PhotoPickerFragment.ARG_BROWSER_TYPE, MediaBrowserType.LOOP_PICKER)
 
+        @Suppress("DEPRECATION")
         startActivityForResult(
             intent,
             RequestCodes.PHOTO_PICKER,

--- a/app/src/main/java/com/automattic/loop/intro/IntroPagerAdapter.kt
+++ b/app/src/main/java/com/automattic/loop/intro/IntroPagerAdapter.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.automattic.loop.intro
 
 import androidx.fragment.app.Fragment
@@ -5,6 +7,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import com.automattic.loop.R
 
+@Suppress("DEPRECATION")
 class IntroPagerAdapter(
     supportFragmentManager: FragmentManager
 ) : FragmentPagerAdapter(supportFragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id "com.android.application" apply false
     id "org.jetbrains.kotlin.android" apply false
@@ -37,6 +39,12 @@ allprojects {
         checkstyle {
             toolVersion = '8.3'
             configFile file("${project.rootDir}/config/checkstyle.xml")
+        }
+    }
+
+    tasks.withType(KotlinCompile).all {
+        kotlinOptions {
+            allWarningsAsErrors = true
         }
     }
 }

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
@@ -283,7 +283,7 @@ class Mp4Composer : ComposerInterface {
                 )
             }
             val orientation = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)
-            return Integer.valueOf(orientation)
+            return orientation?.let { Integer.valueOf(it) } ?: 0
         } catch (e: IllegalArgumentException) {
             Log.e("MediaMetadataRetriever", "getVideoRotation IllegalArgumentException")
             return 0
@@ -322,10 +322,14 @@ class Mp4Composer : ComposerInterface {
                 )
             }
 
-            val width = Integer.valueOf(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH))
-            val height = Integer.valueOf(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT))
+            val width = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+            val height = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
 
-            return Size(width, height)
+            return if (width != null && height != null) {
+                Size(Integer.valueOf(width), Integer.valueOf(height))
+            } else {
+                defaultResolution
+            }
         } catch (e: IllegalArgumentException) {
             Log.e("MediaMetadataRetriever", "getVideoResolution IllegalArgumentException")
             return defaultResolution

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
@@ -236,7 +236,7 @@ class Mp4Composer : ComposerInterface {
                         mute,
                         Rotation.fromInt(rotation.rotation), // FIXME assume portrait for now
                         staticImageResolution,
-                        fillMode!!,
+                        fillMode,
                         fillModeCustomItem!!,
                         timeScale,
                         flipVertical,

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.kt
@@ -273,16 +273,14 @@ class Mp4Composer : ComposerInterface {
         var mediaMetadataRetriever: MediaMetadataRetriever? = null
         try {
             mediaMetadataRetriever = MediaMetadataRetriever()
-            videoUri?.let { uri ->
-                context?.let {
-                    DataSourceUtil.setDataSource(
-                        it,
-                        uri,
-                        mediaExtractor = null,
-                        mediaMetadataRetriever = mediaMetadataRetriever,
-                        addedRequestHeaders = addedRequestHeaders
-                    )
-                }
+            context?.let {
+                DataSourceUtil.setDataSource(
+                    it,
+                    videoUri,
+                    mediaExtractor = null,
+                    mediaMetadataRetriever = mediaMetadataRetriever,
+                    addedRequestHeaders = addedRequestHeaders
+                )
             }
             val orientation = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)
             return Integer.valueOf(orientation)

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.kt
@@ -137,10 +137,8 @@ internal class Mp4ComposerEngine {
                 }
 
                 try {
-                    durationUs =
-                        java.lang.Long.parseLong(
-                            mediaMetadataRetriever!!.extractMetadata(
-                                MediaMetadataRetriever.METADATA_KEY_DURATION)) * 1000
+                    val duration = mediaMetadataRetriever?.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                    durationUs = duration?.let { java.lang.Long.parseLong(it) * 1000 } ?: 0
                 } catch (e: NumberFormatException) {
                     durationUs = -1
                 }

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.kt
@@ -211,6 +211,7 @@ internal class Mp4ComposerEngine {
                 videoOutputFormat.setInteger(MediaFormat.KEY_BIT_RATE, BIT_RATE)
                 videoOutputFormat.setInteger(MediaFormat.KEY_FRAME_RATE, FRAME_RATE)
                 videoOutputFormat.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, I_FRAME_INTERVAL)
+                @Suppress("DEPRECATION")
                 videoOutputFormat.setInteger(MediaFormat.KEY_COLOR_FORMAT, COLOR_FormatYUV420SemiPlanar)
 
                 // setup video composer for static background image

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/RemixAudioComposer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/RemixAudioComposer.kt
@@ -117,6 +117,7 @@ internal class RemixAudioComposer(
         if (isDecoderEOS) return DRAIN_STATE_NONE
 
         val result = decoder!!.dequeueOutputBuffer(bufferInfo, timeoutUs)
+        @Suppress("DEPRECATION")
         when (result) {
             MediaCodec.INFO_TRY_AGAIN_LATER -> return DRAIN_STATE_NONE
             MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
@@ -140,6 +141,7 @@ internal class RemixAudioComposer(
         if (isFinished) return DRAIN_STATE_NONE
 
         val result = encoder!!.dequeueOutputBuffer(bufferInfo, timeoutUs)
+        @Suppress("DEPRECATION")
         when (result) {
             MediaCodec.INFO_TRY_AGAIN_LATER -> return DRAIN_STATE_NONE
             MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/VideoComposer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/VideoComposer.kt
@@ -290,7 +290,6 @@ internal class VideoComposer {
                 return DRAIN_STATE_SHOULD_RETRY_IMMEDIATELY
             }
             MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED -> {
-                encoderOutputBuffer = encoder!!.getOutputBuffer(result)
                 return DRAIN_STATE_SHOULD_RETRY_IMMEDIATELY
             }
             else -> {

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/VideoComposer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/VideoComposer.kt
@@ -167,7 +167,7 @@ internal class VideoComposer {
                 // byte[] input = BitmapEncodingUtils.getNV12(bkgBitmap.getWidth(), bkgBitmap.getHeight(), bkgBitmap);
                 val inputBuffer = encoder!!.getInputBuffer(inputBufIdx)
                 inputBuffer!!.clear()
-                inputBuffer.put(bkgBitmapBytesNV12)
+                inputBuffer.put(bkgBitmapBytesNV12!!)
                 encoder!!.queueInputBuffer(
                     inputBufIdx, 0, bkgBitmapBytesNV12!!.size,
                     getPresentationTimeUsec(addedFrameCount), 0

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/VideoComposer.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/VideoComposer.kt
@@ -249,6 +249,7 @@ internal class VideoComposer {
     private fun drainDecoder(): Int {
         if (isDecoderEOS) return DRAIN_STATE_NONE
         val result = decoder!!.dequeueOutputBuffer(bufferInfo, 0)
+        @Suppress("DEPRECATION")
         when (result) {
             MediaCodec.INFO_TRY_AGAIN_LATER -> return DRAIN_STATE_NONE
             MediaCodec.INFO_OUTPUT_FORMAT_CHANGED, MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED ->
@@ -276,6 +277,7 @@ internal class VideoComposer {
         if (isFinished) return DRAIN_STATE_NONE
         val result = encoder!!.dequeueOutputBuffer(bufferInfo, 0)
         var encoderOutputBuffer: ByteBuffer? = null
+        @Suppress("DEPRECATION")
         when (result) {
             MediaCodec.INFO_TRY_AGAIN_LATER -> return DRAIN_STATE_NONE
             MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/filter/GlGifWatermarkFilter.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/filter/GlGifWatermarkFilter.kt
@@ -36,7 +36,7 @@ class GlGifWatermarkFilter(
     init {
         val glide = Glide.get(context)
         val sourceData = inputStreamToBytes(gifAsInputStream)
-        byteBuffer = ByteBuffer.wrap(sourceData)
+        byteBuffer = ByteBuffer.wrap(sourceData!!)
 
         val parser = GifHeaderParser()
         parser.setData(byteBuffer)

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/filter/GlToneCurveFilter.kt
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/filter/GlToneCurveFilter.kt
@@ -87,7 +87,6 @@ class GlToneCurveFilter(input: InputStream) : GlFilter(GlFilter.DEFAULT_VERTEX_S
 
     private fun setFromCurveFileInputStream(input: InputStream) {
         try {
-            val version = readShort(input).toInt()
             val totalCurves = readShort(input).toInt()
 
             val curves = ArrayList<Array<PointF>?>(totalCurves)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -931,7 +931,6 @@ class PhotoEditor private constructor(builder: Builder) :
     /**
      * Produce a new video with a static background image
      *
-     * @param saveSettings builder for multiple save options [SaveSettings]
      * @param onSaveListener callback for saving video
      * @see OnSaveListener
      */
@@ -939,7 +938,6 @@ class PhotoEditor private constructor(builder: Builder) :
     @RequiresPermission(allOf = [Manifest.permission.WRITE_EXTERNAL_STORAGE])
     fun saveVideoFromStaticBackgroundAsFile(
         videoOutputPath: String,
-        saveSettings: SaveSettings,
         onSaveListener: OnSaveWithCancelListener
     ) {
         val widthParent = parentView.width

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -36,8 +36,6 @@ import com.automattic.photoeditor.util.BitmapUtil
 import com.automattic.photoeditor.util.FileUtils
 import com.automattic.photoeditor.views.PhotoEditorView
 import com.automattic.photoeditor.views.ViewType
-import com.automattic.photoeditor.views.ViewType.EMOJI
-import com.automattic.photoeditor.views.ViewType.TEXT
 import com.automattic.photoeditor.views.added.AddedView
 import com.automattic.photoeditor.views.added.AddedViewInfo
 import com.automattic.photoeditor.views.added.AddedViewList
@@ -381,7 +379,7 @@ class PhotoEditor private constructor(builder: Builder) :
     ): View? {
         var view: View? = null
         when (viewType) {
-            EMOJI -> {
+            ViewType.EMOJI -> {
                 // create emoji view layout
                 view = addEmoji(addedViewInfo.addedViewTextInfo.text)
                 view?.let {
@@ -397,7 +395,7 @@ class PhotoEditor private constructor(builder: Builder) :
                     }
                 }
             }
-            TEXT -> {
+            ViewType.TEXT -> {
                 // create TEXT view layout
                 val textStyler = TextStyler.from(addedViewInfo.addedViewTextInfo)
                 view = addText(
@@ -407,6 +405,9 @@ class PhotoEditor private constructor(builder: Builder) :
                         addTouchListener = addTouchListener
                 )
             }
+            ViewType.BRUSH_DRAWING -> Unit // Do nothing
+            ViewType.IMAGE -> Unit // Do nothing
+            ViewType.STICKER_ANIMATED -> Unit // Do nothing
         }
 
         // now apply all common parameters to newly created view object
@@ -433,7 +434,7 @@ class PhotoEditor private constructor(builder: Builder) :
         multiTouchListener: MultiTouchListener
     ) {
         when {
-            viewType == EMOJI -> {
+            viewType == ViewType.EMOJI -> {
                 multiTouchListener.setOnGestureControl(object :
                         MultiTouchListener.OnGestureControl {
                     override fun onClick() {
@@ -446,7 +447,7 @@ class PhotoEditor private constructor(builder: Builder) :
                 })
             }
 
-            viewType == TEXT -> {
+            viewType == ViewType.TEXT -> {
                 val textInputTv = rootView.findViewById<PhotoEditorTextView>(R.id.tvPhotoEditorText)
                 multiTouchListener.setOnGestureControl(object :
                         MultiTouchListener.OnGestureControl {
@@ -497,6 +498,9 @@ class PhotoEditor private constructor(builder: Builder) :
                     it.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
                 }
             }
+
+            ViewType.BRUSH_DRAWING -> Unit // Do nothing
+            ViewType.STICKER_ANIMATED -> Unit // Do nothing
         }
 
         // We are setting tag as ViewType to identify what type of the view it is
@@ -1088,7 +1092,7 @@ class PhotoEditor private constructor(builder: Builder) :
         val reorderedAddedViewList = AddedViewList()
         for (oneView in parentView.zIndexOrderedAddedViews) {
             when (oneView.tag) {
-                TEXT, EMOJI, ViewType.STICKER_ANIMATED -> {
+                ViewType.TEXT, ViewType.EMOJI, ViewType.STICKER_ANIMATED -> {
                     addedViews.getAddedViewForNativeView(oneView)?.let {
                         reorderedAddedViewList.add(it)
                     }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/PhotoEditor.kt
@@ -565,6 +565,7 @@ class PhotoEditor private constructor(builder: Builder) :
                 if (removedViewWithData != null && addToRedoList) {
                     redoViews.add(removedViewWithData)
                 }
+                @Suppress("DEPRECATION")
                 mOnPhotoEditorListener?.onRemoveViewListener(addedViews.size)
                 mOnPhotoEditorListener?.onRemoveViewListener(viewType, addedViews.size)
             }
@@ -586,6 +587,7 @@ class PhotoEditor private constructor(builder: Builder) :
                 parentView.removeView(removeView.view)
                 redoViews.add(removeView)
             }
+            @Suppress("DEPRECATION")
             mOnPhotoEditorListener?.onRemoveViewListener(addedViews.size)
             val viewTag = removeView.view?.tag
             (viewTag as? ViewType)?.let {
@@ -1064,6 +1066,7 @@ class PhotoEditor private constructor(builder: Builder) :
             }
             redoViews.add(removeView)
         }
+        @Suppress("DEPRECATION")
         mOnPhotoEditorListener?.onRemoveViewListener(addedViews.size)
         mOnPhotoEditorListener?.onRemoveViewListener(ViewType.BRUSH_DRAWING, addedViews.size)
     }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/Camera2BasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/Camera2BasicHandling.kt
@@ -200,6 +200,7 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
     /*
     * Media recorder
     * */
+    @Suppress("DEPRECATION")
     private var mediaRecorder: MediaRecorder = MediaRecorder()
 
     /**
@@ -347,12 +348,14 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
 
                     // Find out if we need to swap dimension to get the preview size relative to sensor
                     // coordinate.
-                    val displayRotation = activity.windowManager.defaultDisplay.rotation
+                    @Suppress("DEPRECATION") val displayRotation = activity.windowManager.defaultDisplay.rotation
 
                     sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION) ?: continue
                     val swappedDimensions = areDimensionsSwapped(displayRotation, sensorOrientation)
 
-                    val metrics = DisplayMetrics().also { textureView.display.getRealMetrics(it) }
+                    @Suppress("DEPRECATION") val metrics = DisplayMetrics().also {
+                        textureView.display.getRealMetrics(it)
+                    }
                     val displaySize = Point(metrics.widthPixels, metrics.heightPixels)
 
                     val rotatedPreviewWidth = if (swappedDimensions) height else width
@@ -494,6 +497,7 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
                 previewRequestBuilder.addTarget(surface)
 
                 // Here, we create a CameraCaptureSession for camera preview.
+                @Suppress("DEPRECATION")
                 camera.createCaptureSession(listOf(surface, imageReader?.surface),
                     object : CameraCaptureSession.StateCallback() {
                         override fun onConfigured(cameraCaptureSession: CameraCaptureSession) {
@@ -539,7 +543,7 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
      */
     private fun configureTransform(viewWidth: Int, viewHeight: Int) {
         activity?.let { activity ->
-            val rotation = activity.windowManager.defaultDisplay.rotation
+            @Suppress("DEPRECATION") val rotation = activity.windowManager.defaultDisplay.rotation
             val matrix = Matrix()
             val viewRect = RectF(0f, 0f, viewWidth.toFloat(), viewHeight.toFloat())
             val bufferRect = RectF(0f, 0f, previewSize.height.toFloat(), previewSize.width.toFloat())
@@ -605,7 +609,7 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
      */
     private fun captureStillPicture() {
         try {
-            val rotation = activity?.windowManager?.defaultDisplay?.rotation ?: return
+            @Suppress("DEPRECATION") val rotation = activity?.windowManager?.defaultDisplay?.rotation ?: return
 
             // This is the CaptureRequest.Builder that we use to take a picture.
             cameraDevice?.let { cameraDevice ->
@@ -740,7 +744,7 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
             mediaRecorder.setAudioEncodingBitRate(profile.audioBitRate)
             mediaRecorder.setAudioSamplingRate(profile.audioSampleRate)
 
-            val rotation = activity.windowManager.defaultDisplay.rotation
+            @Suppress("DEPRECATION") val rotation = activity.windowManager.defaultDisplay.rotation
             when (sensorOrientation) {
                 SENSOR_ORIENTATION_DEFAULT_DEGREES ->
                     mediaRecorder.setOrientationHint(ORIENTATIONS.get(rotation))
@@ -751,6 +755,7 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun findCamcorderProfile(): CamcorderProfile {
         for (quality in CAMCORDER_QUALITIES) {
             if (CamcorderProfile.hasProfile(cameraId.toInt(), quality)) {
@@ -785,6 +790,7 @@ class Camera2BasicHandling : VideoRecorderFragment(), View.OnClickListener {
                 previewRequestBuilder.addTarget(recorderSurface)
 
                 // Here, we create a CameraCaptureSession for camera recording + preview.
+                @Suppress("DEPRECATION")
                 camera.createCaptureSession(listOf(surface, recorderSurface),
                     object : CameraCaptureSession.StateCallback() {
                         override fun onConfigured(cameraCaptureSession: CameraCaptureSession) {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/CameraXBasicHandling.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.automattic.photoeditor.camera
 
 import android.annotation.SuppressLint
@@ -82,7 +84,7 @@ class CameraXBasicHandling : VideoRecorderFragment() {
     @SuppressLint("RestrictedApi")
     private fun startCamera() {
         // Get screen metrics used to setup camera for full screen resolution
-        val metrics = DisplayMetrics().also { textureView.display.getRealMetrics(it) }
+        @Suppress("DEPRECATION") val metrics = DisplayMetrics().also { textureView.display.getRealMetrics(it) }
         screenAspectRatio = Rational(metrics.widthPixels, metrics.heightPixels)
 
         // retrieve flash availability for this camera
@@ -190,7 +192,7 @@ class CameraXBasicHandling : VideoRecorderFragment() {
                 videoCapture?.clear()
             }
 
-            val metrics = DisplayMetrics().also { textureView.display.getRealMetrics(it) }
+            @Suppress("DEPRECATION") val metrics = DisplayMetrics().also { textureView.display.getRealMetrics(it) }
 
             val videoCaptureConfig = VideoCaptureConfig.Builder().apply {
                 setLensFacing(lensFacing)
@@ -202,6 +204,7 @@ class CameraXBasicHandling : VideoRecorderFragment() {
             // video capture only
             CameraX.bindToLifecycle(activity, videoCapture)
 
+            @Suppress("DEPRECATION")
             videoCapture?.startRecording(
                 it,
                 AsyncTask.THREAD_POOL_EXECUTOR,
@@ -249,6 +252,7 @@ class CameraXBasicHandling : VideoRecorderFragment() {
                 }
 
                 // Setup image capture listener which is triggered after photo has been taken
+                @Suppress("DEPRECATION")
                 imageCapture?.takePicture(
                     it,
                     metadata,

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
@@ -170,6 +170,7 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
 
                 mediaPlayer?.apply {
                     setSurface(s)
+                    @Suppress("DEPRECATION")
                     setAudioStreamType(AudioManager.STREAM_MUSIC)
                     setLooping(true)
                     setOnPreparedListener {
@@ -201,6 +202,7 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
 
                 mediaPlayer?.apply {
                     setSurface(s)
+                    @Suppress("DEPRECATION")
                     setAudioStreamType(AudioManager.STREAM_MUSIC)
                     setLooping(true)
                     setOnPreparedListener {

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
@@ -261,15 +261,12 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
                 )
             }
 
-            val height = metadataRetriever
-            .extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
-            val width = metadataRetriever
-                .extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
-            var rotation = Integer.valueOf(metadataRetriever
-                .extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION))
-            videoHeight = java.lang.Float.parseFloat(height)
-            videoWidth = java.lang.Float.parseFloat(width)
-            videoOrientation = rotation
+            val height = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+            val width = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+            val orientation = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)
+            videoHeight = height?.let { java.lang.Float.parseFloat(it) } ?: 0f
+            videoWidth = width?.let { java.lang.Float.parseFloat(it) } ?: 0f
+            videoOrientation = orientation?.let { Integer.valueOf(it) } ?: 0
         } catch (e: IOException) {
             playerPreparedListener?.onPlayerError()
             Log.d(TAG, e.message.toString())

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/VideoPlayingBasicHandling.kt
@@ -208,7 +208,7 @@ class VideoPlayingBasicHandling : Fragment(), SurfaceFragmentHandler, VideoPlaye
                         it.start()
                         it.setLooping(true)
                     }
-                    setOnErrorListener { mp, what, extra ->
+                    setOnErrorListener { _, _, _ ->
                         playerPreparedListener?.onPlayerError()
                         true
                     }

--- a/photoeditor/src/main/java/com/automattic/photoeditor/camera/interfaces/VideoRecorderFragment.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/camera/interfaces/VideoRecorderFragment.kt
@@ -24,7 +24,7 @@ abstract class VideoRecorderFragment : Fragment(),
     protected var flashSupported: Boolean by Delegates.observable(
         initialValue = false,
         onChange = {
-            prop, old, new -> flashSupportChangeListener.onFlashSupportChanged(new)
+            _, _, new -> flashSupportChangeListener.onFlashSupportChanged(new)
         }
     )
     var useTempCaptureFile = true

--- a/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/gesture/MultiTouchListener.kt
@@ -53,6 +53,7 @@ internal class MultiTouchListener(
 
     init {
         mScaleGestureDetector = ScaleGestureDetector(ScaleGestureListener())
+        @Suppress("DEPRECATION")
         mGestureListener = GestureDetector(GestureListener())
         if (deleteView != null) {
             outRect = Rect(

--- a/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
@@ -269,7 +269,7 @@ class BackgroundSurfaceManager(
             // This is to circumvent an issue in CameraX that should be solved in the beta version.
             // TODO: implement this in the saveFile listener so we're sure to only change to the option
             // wanted (video player) once we're sure video has been successfully saved
-            val handler = Handler()
+            @Suppress("DEPRECATION") val handler = Handler()
             handler.postDelayed({
                 videoPlayerHandling.currentFile = cameraBasicHandler.currentFile
                 doDeactivateReactivateSurfaceAndPlay()

--- a/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/state/BackgroundSurfaceManager.kt
@@ -68,7 +68,7 @@ class BackgroundSurfaceManager(
     private var isVideoPlayerVisible: Boolean = false
     private var isCameraRecording: Boolean = false
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @OnLifecycleEvent(ON_CREATE)
     fun onCreate(source: LifecycleOwner) {
         // clear surfaceTexture listeners
@@ -105,7 +105,7 @@ class BackgroundSurfaceManager(
         if (isCameraVisible || isVideoPlayerVisible) { photoEditorView.toggleTextureView() }
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @OnLifecycleEvent(ON_DESTROY)
     fun onDestroy(source: LifecycleOwner) {
         if (lifeCycle.currentState.isAtLeast(Lifecycle.State.DESTROYED)) {
@@ -121,7 +121,7 @@ class BackgroundSurfaceManager(
         lifeCycle.removeObserver(this)
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @OnLifecycleEvent(ON_START)
     fun onStart(source: LifecycleOwner) {
         // TODO: get state and restart fragments / camera preview?
@@ -130,19 +130,19 @@ class BackgroundSurfaceManager(
         }
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @OnLifecycleEvent(ON_STOP)
     fun onStop(source: LifecycleOwner) {
         // TODO: save state and pause fragments / camera preview?
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @OnLifecycleEvent(ON_RESUME)
     fun onResume(source: LifecycleOwner) {
         // TODO: get state and restart fragments / camera preview?
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @OnLifecycleEvent(ON_PAUSE)
     fun onPause(source: LifecycleOwner) {
         // TODO: save state and pause fragments / camera preview?

--- a/photoeditor/src/main/java/com/automattic/photoeditor/util/CameraUtils.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/util/CameraUtils.kt
@@ -116,7 +116,7 @@ class CameraUtils {
             cameraId: String
         ): Size {
             // Get screen metrics used to setup camera for full screen resolution
-            val metrics = DisplayMetrics().also { textureView.display.getRealMetrics(it) }
+            @Suppress("DEPRECATION") val metrics = DisplayMetrics().also { textureView.display.getRealMetrics(it) }
             val displaySize = Point(metrics.widthPixels, metrics.heightPixels)
             val optimalPreviewSize: Size
             Log.d(TAG, "Screen metrics: ${metrics.widthPixels} x ${metrics.heightPixels}")
@@ -129,7 +129,7 @@ class CameraUtils {
 
             // Find out if we need to swap dimension to get the preview size relative to sensor
             // coordinate.
-            val displayRotation = activity.windowManager.defaultDisplay.rotation
+            @Suppress("DEPRECATION") val displayRotation = activity.windowManager.defaultDisplay.rotation
 
             val sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION) ?: 0
             val swappedDimensions = areDimensionsSwapped(displayRotation, sensorOrientation)

--- a/photoeditor/src/main/java/com/automattic/photoeditor/views/filter/ImageFilterView.kt
+++ b/photoeditor/src/main/java/com/automattic/photoeditor/views/filter/ImageFilterView.kt
@@ -36,30 +36,6 @@ import android.util.AttributeSet
 import android.util.Log
 import com.automattic.photoeditor.OnSaveBitmap
 import com.automattic.photoeditor.util.BitmapUtil
-import com.automattic.photoeditor.views.filter.PhotoFilter.AUTO_FIX
-import com.automattic.photoeditor.views.filter.PhotoFilter.BLACK_WHITE
-import com.automattic.photoeditor.views.filter.PhotoFilter.BRIGHTNESS
-import com.automattic.photoeditor.views.filter.PhotoFilter.CONTRAST
-import com.automattic.photoeditor.views.filter.PhotoFilter.CROSS_PROCESS
-import com.automattic.photoeditor.views.filter.PhotoFilter.DOCUMENTARY
-import com.automattic.photoeditor.views.filter.PhotoFilter.DUE_TONE
-import com.automattic.photoeditor.views.filter.PhotoFilter.FILL_LIGHT
-import com.automattic.photoeditor.views.filter.PhotoFilter.FISH_EYE
-import com.automattic.photoeditor.views.filter.PhotoFilter.FLIP_HORIZONTAL
-import com.automattic.photoeditor.views.filter.PhotoFilter.FLIP_VERTICAL
-import com.automattic.photoeditor.views.filter.PhotoFilter.GRAIN
-import com.automattic.photoeditor.views.filter.PhotoFilter.GRAY_SCALE
-import com.automattic.photoeditor.views.filter.PhotoFilter.LOMISH
-import com.automattic.photoeditor.views.filter.PhotoFilter.NEGATIVE
-import com.automattic.photoeditor.views.filter.PhotoFilter.NONE
-import com.automattic.photoeditor.views.filter.PhotoFilter.POSTERIZE
-import com.automattic.photoeditor.views.filter.PhotoFilter.ROTATE
-import com.automattic.photoeditor.views.filter.PhotoFilter.SATURATE
-import com.automattic.photoeditor.views.filter.PhotoFilter.SEPIA
-import com.automattic.photoeditor.views.filter.PhotoFilter.SHARPEN
-import com.automattic.photoeditor.views.filter.PhotoFilter.TEMPERATURE
-import com.automattic.photoeditor.views.filter.PhotoFilter.TINT
-import com.automattic.photoeditor.views.filter.PhotoFilter.VIGNETTE
 import javax.microedition.khronos.egl.EGLConfig
 import javax.microedition.khronos.opengles.GL10
 
@@ -99,7 +75,7 @@ internal class ImageFilterView : GLSurfaceView, GLSurfaceView.Renderer {
         setEGLContextClientVersion(2)
         setRenderer(this)
         renderMode = GLSurfaceView.RENDERMODE_WHEN_DIRTY
-        setFilterEffect(NONE)
+        setFilterEffect(PhotoFilter.NONE)
     }
 
     fun setSourceBitmap(sourceBitmap: Bitmap?) {
@@ -122,7 +98,7 @@ internal class ImageFilterView : GLSurfaceView, GLSurfaceView.Renderer {
             loadTextures()
             mInitialized = true
         }
-        if (mCurrentEffect != NONE || mCustomEffect != null) {
+        if (mCurrentEffect != PhotoFilter.NONE || mCustomEffect != null) {
             // if an effect is chosen initialize it and apply it to the texture
             initEffect()
             applyEffect()
@@ -189,93 +165,95 @@ internal class ImageFilterView : GLSurfaceView, GLSurfaceView.Renderer {
         } ?: run {
             // Initialize the correct effect based on the selected menu/action item
             when (mCurrentEffect) {
-                AUTO_FIX -> {
+                PhotoFilter.AUTO_FIX -> {
                     mEffect = effectFactory.createEffect(EFFECT_AUTOFIX).apply {
                         setParameter("scale", 0.5f)
                     }
                 }
-                BLACK_WHITE -> {
+                PhotoFilter.BLACK_WHITE -> {
                     mEffect = effectFactory.createEffect(EFFECT_BLACKWHITE).apply {
                         setParameter("black", .1f)
                         setParameter("white", .7f)
                     }
                 }
-                BRIGHTNESS -> {
+                PhotoFilter.BRIGHTNESS -> {
                     mEffect = effectFactory.createEffect(EFFECT_BRIGHTNESS).apply {
                         setParameter("brightness", 2.0f)
                     }
                 }
-                CONTRAST -> {
+                PhotoFilter.CONTRAST -> {
                     mEffect = effectFactory.createEffect(EFFECT_CONTRAST).apply {
                         setParameter("contrast", 1.4f)
                     }
                 }
-                CROSS_PROCESS -> mEffect = effectFactory.createEffect(EFFECT_CROSSPROCESS)
-                DOCUMENTARY -> mEffect = effectFactory.createEffect(EFFECT_DOCUMENTARY)
-                DUE_TONE -> {
+                PhotoFilter.CROSS_PROCESS -> mEffect = effectFactory.createEffect(EFFECT_CROSSPROCESS)
+                PhotoFilter.DOCUMENTARY -> mEffect = effectFactory.createEffect(EFFECT_DOCUMENTARY)
+                PhotoFilter.DUE_TONE -> {
                     mEffect = effectFactory.createEffect(EFFECT_DUOTONE).apply {
                         setParameter("first_color", Color.YELLOW)
                         setParameter("second_color", Color.DKGRAY)
                     }
                 }
-                FILL_LIGHT -> {
+                PhotoFilter.FILL_LIGHT -> {
                     mEffect = effectFactory.createEffect(EFFECT_FILLLIGHT).apply {
                         setParameter("strength", .8f)
                     }
                 }
-                FISH_EYE -> {
+                PhotoFilter.FISH_EYE -> {
                     mEffect = effectFactory.createEffect(EFFECT_FISHEYE).apply {
                         setParameter("scale", .5f)
                     }
                 }
-                FLIP_HORIZONTAL -> {
+                PhotoFilter.FLIP_HORIZONTAL -> {
                     mEffect = effectFactory.createEffect(EFFECT_FLIP).apply {
                         setParameter("horizontal", true)
                     }
                 }
-                FLIP_VERTICAL -> {
+                PhotoFilter.FLIP_VERTICAL -> {
                     mEffect = effectFactory.createEffect(EFFECT_FLIP).apply {
                         setParameter("vertical", true)
                     }
                 }
-                GRAIN -> {
+                PhotoFilter.GRAIN -> {
                     mEffect = effectFactory.createEffect(EFFECT_GRAIN).apply {
                         setParameter("strength", 1.0f)
                     }
                 }
-                GRAY_SCALE -> mEffect = effectFactory.createEffect(EFFECT_GRAYSCALE)
-                LOMISH -> mEffect = effectFactory.createEffect(EFFECT_LOMOISH)
-                NEGATIVE -> mEffect = effectFactory.createEffect(EFFECT_NEGATIVE)
-                NONE -> {
+                PhotoFilter.GRAY_SCALE -> mEffect = effectFactory.createEffect(EFFECT_GRAYSCALE)
+                PhotoFilter.LOMISH -> mEffect = effectFactory.createEffect(EFFECT_LOMOISH)
+                PhotoFilter.NEGATIVE -> mEffect = effectFactory.createEffect(EFFECT_NEGATIVE)
+                PhotoFilter.NONE -> {
                 }
-                POSTERIZE -> mEffect = effectFactory.createEffect(EFFECT_POSTERIZE)
-                ROTATE -> {
+                PhotoFilter.POSTERIZE -> mEffect = effectFactory.createEffect(EFFECT_POSTERIZE)
+                PhotoFilter.ROTATE -> {
                     mEffect = effectFactory.createEffect(EFFECT_ROTATE).apply {
                         setParameter("angle", 180)
                     }
                 }
-                SATURATE -> {
+                PhotoFilter.SATURATE -> {
                     mEffect = effectFactory.createEffect(EFFECT_SATURATE).apply {
                         setParameter("scale", .5f)
                     }
                 }
-                SEPIA -> mEffect = effectFactory.createEffect(EFFECT_SEPIA)
-                SHARPEN -> mEffect = effectFactory.createEffect(EFFECT_SHARPEN)
-                TEMPERATURE -> {
+                PhotoFilter.SEPIA -> mEffect = effectFactory.createEffect(EFFECT_SEPIA)
+                PhotoFilter.SHARPEN -> mEffect = effectFactory.createEffect(EFFECT_SHARPEN)
+                PhotoFilter.TEMPERATURE -> {
                     mEffect = effectFactory.createEffect(EFFECT_TEMPERATURE).apply {
                         setParameter("scale", .9f)
                     }
                 }
-                TINT -> {
+                PhotoFilter.TINT -> {
                     mEffect = effectFactory.createEffect(EFFECT_TINT).apply {
                         setParameter("tint", Color.MAGENTA)
                     }
                 }
-                VIGNETTE -> {
+                PhotoFilter.VIGNETTE -> {
                     mEffect = effectFactory.createEffect(EFFECT_VIGNETTE).apply {
                         setParameter("scale", .5f)
                     }
                 }
+
+                null -> Unit // Do nothing
             }
         }
     }
@@ -285,7 +263,7 @@ internal class ImageFilterView : GLSurfaceView, GLSurfaceView.Renderer {
     }
 
     private fun renderResult() {
-        if (mCurrentEffect != NONE || mCustomEffect != null) {
+        if (mCurrentEffect != PhotoFilter.NONE || mCustomEffect != null) {
             // if no effect is chosen, just render the original bitmap
             mTexRenderer.renderTexture(mTextures[1])
         } else {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -80,11 +80,6 @@ import com.wordpress.stories.BuildConfig
 import com.wordpress.stories.R
 import com.wordpress.stories.compose.ComposeLoopFrameActivity.ExternalMediaPickerRequestCodesAndExtraKeys
 import com.wordpress.stories.compose.FinishButton.FinishButtonMode.DONE
-import com.wordpress.stories.compose.ScreenTouchBlockMode.BLOCK_TOUCH_MODE_DELETE_SLIDE
-import com.wordpress.stories.compose.ScreenTouchBlockMode.BLOCK_TOUCH_MODE_FULL_SCREEN
-import com.wordpress.stories.compose.ScreenTouchBlockMode.BLOCK_TOUCH_MODE_NONE
-import com.wordpress.stories.compose.ScreenTouchBlockMode.BLOCK_TOUCH_MODE_PHOTO_EDITOR_ERROR_PENDING_RESOLUTION
-import com.wordpress.stories.compose.ScreenTouchBlockMode.BLOCK_TOUCH_MODE_PHOTO_EDITOR_READY
 import com.wordpress.stories.compose.emoji.EmojiPickerFragment
 import com.wordpress.stories.compose.emoji.EmojiPickerFragment.EmojiListener
 import com.wordpress.stories.compose.frame.FrameIndex
@@ -1663,12 +1658,12 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     protected fun showLoading() {
         editModeHideAllUIControls(true)
-        blockTouchOnPhotoEditor(BLOCK_TOUCH_MODE_FULL_SCREEN)
+        blockTouchOnPhotoEditor(ScreenTouchBlockMode.BLOCK_TOUCH_MODE_FULL_SCREEN)
     }
 
     protected fun hideLoading() {
         editModeRestoreAllUIControls()
-        releaseTouchOnPhotoEditor(BLOCK_TOUCH_MODE_FULL_SCREEN)
+        releaseTouchOnPhotoEditor(ScreenTouchBlockMode.BLOCK_TOUCH_MODE_FULL_SCREEN)
     }
 
     private fun showSnackbar(message: String, actionLabel: String? = null, listener: OnClickListener? = null) {
@@ -1795,21 +1790,21 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                 // if we were in an error-handling situation but now all pages are OK we're ready to go
                 // don't allow editing or adding new frames but do allow publishing the Story
                 originallyErrored && !currentlyErrored -> {
-                    blockTouchOnPhotoEditor(BLOCK_TOUCH_MODE_PHOTO_EDITOR_READY)
+                    blockTouchOnPhotoEditor(ScreenTouchBlockMode.BLOCK_TOUCH_MODE_PHOTO_EDITOR_READY)
                     editModeControls.visibility = View.INVISIBLE
                     soundButton.visibility = View.INVISIBLE
                     nextButton.isEnabled = true
                     storyFrameSelectorFragment?.hideAddFrameControl()
                 }
                 currentlyErrored -> {
-                    blockTouchOnPhotoEditor(BLOCK_TOUCH_MODE_PHOTO_EDITOR_ERROR_PENDING_RESOLUTION)
+                    blockTouchOnPhotoEditor(ScreenTouchBlockMode.BLOCK_TOUCH_MODE_PHOTO_EDITOR_ERROR_PENDING_RESOLUTION)
                     editModeControls.visibility = View.INVISIBLE
                     soundButton.visibility = View.INVISIBLE
                     nextButton.isEnabled = false
                     storyFrameSelectorFragment?.hideAddFrameControl()
                 }
                 else -> { // no errors here! this is the normal creation situation: release touch block, enable editing
-                    releaseTouchOnPhotoEditor(BLOCK_TOUCH_MODE_NONE)
+                    releaseTouchOnPhotoEditor(ScreenTouchBlockMode.BLOCK_TOUCH_MODE_NONE)
                     editModeControls.visibility = View.VISIBLE
                     updateSoundControl()
                     nextButton.isEnabled = true
@@ -1912,7 +1907,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private fun blockTouchOnPhotoEditor(touchBlockMode: ScreenTouchBlockMode, message: String? = null) {
         contentComposerBinding.run {
             when (touchBlockMode) {
-                BLOCK_TOUCH_MODE_FULL_SCREEN -> {
+                ScreenTouchBlockMode.BLOCK_TOUCH_MODE_FULL_SCREEN -> {
                     translucentView.visibility = View.VISIBLE
                     translucentErrorView.visibility = View.INVISIBLE
                     operationText.text = message
@@ -1921,7 +1916,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                         true
                     }
                 }
-                BLOCK_TOUCH_MODE_PHOTO_EDITOR_ERROR_PENDING_RESOLUTION -> {
+                ScreenTouchBlockMode.BLOCK_TOUCH_MODE_PHOTO_EDITOR_ERROR_PENDING_RESOLUTION -> {
                     translucentView.visibility = View.GONE
                     translucentErrorView.visibility = View.VISIBLE
                     translucentErrorView.background = ColorDrawable(
@@ -1933,7 +1928,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                     }
                 }
                 // do block touch but don't show scrim (make it transparent)
-                BLOCK_TOUCH_MODE_PHOTO_EDITOR_READY -> {
+                ScreenTouchBlockMode.BLOCK_TOUCH_MODE_PHOTO_EDITOR_READY -> {
                     translucentView.visibility = View.GONE
                     translucentErrorView.visibility = View.VISIBLE
                     translucentErrorView.background = ColorDrawable(
@@ -1945,7 +1940,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                     }
                 }
                 // block touch, no scrim, tapping releases block
-                BLOCK_TOUCH_MODE_DELETE_SLIDE -> {
+                ScreenTouchBlockMode.BLOCK_TOUCH_MODE_DELETE_SLIDE -> {
                     translucentView.visibility = View.GONE
                     translucentErrorView.visibility = View.VISIBLE
                     translucentErrorView.background = ColorDrawable(
@@ -1959,7 +1954,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                     }
                 }
                 // just don't block touch
-                BLOCK_TOUCH_MODE_NONE -> {
+                ScreenTouchBlockMode.BLOCK_TOUCH_MODE_NONE -> {
                     translucentView.visibility = View.GONE
                     translucentErrorView.visibility = View.GONE
                 }
@@ -1971,17 +1966,18 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private fun releaseTouchOnPhotoEditor(touchBlockMode: ScreenTouchBlockMode) {
         contentComposerBinding.run {
             when (touchBlockMode) {
-                BLOCK_TOUCH_MODE_FULL_SCREEN -> {
+                ScreenTouchBlockMode.BLOCK_TOUCH_MODE_FULL_SCREEN -> {
                     translucentView.visibility = View.GONE
                     operationText.text = null
                     translucentView.setOnTouchListener(null)
                 }
-                BLOCK_TOUCH_MODE_PHOTO_EDITOR_ERROR_PENDING_RESOLUTION,
-                BLOCK_TOUCH_MODE_PHOTO_EDITOR_READY,
-                BLOCK_TOUCH_MODE_NONE -> {
+                ScreenTouchBlockMode.BLOCK_TOUCH_MODE_PHOTO_EDITOR_ERROR_PENDING_RESOLUTION,
+                ScreenTouchBlockMode.BLOCK_TOUCH_MODE_PHOTO_EDITOR_READY,
+                ScreenTouchBlockMode.BLOCK_TOUCH_MODE_NONE -> {
                     translucentErrorView.visibility = View.GONE
                     translucentErrorView.setOnTouchListener(null)
                 }
+                ScreenTouchBlockMode.BLOCK_TOUCH_MODE_DELETE_SLIDE -> Unit // Do nothing
             }
         }
     }
@@ -2266,13 +2262,13 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private fun enableDeleteSlideMode() {
         contentComposerBinding.deleteSlideView.visibility = View.VISIBLE
         editModeHideAllUIControls(hideNextButton = true, hideFrameSelector = false)
-        blockTouchOnPhotoEditor(BLOCK_TOUCH_MODE_DELETE_SLIDE)
+        blockTouchOnPhotoEditor(ScreenTouchBlockMode.BLOCK_TOUCH_MODE_DELETE_SLIDE)
     }
 
     private fun disableDeleteSlideMode() {
         contentComposerBinding.deleteSlideView.visibility = View.GONE
         editModeRestoreAllUIControls()
-        releaseTouchOnPhotoEditor(BLOCK_TOUCH_MODE_NONE)
+        releaseTouchOnPhotoEditor(ScreenTouchBlockMode.BLOCK_TOUCH_MODE_NONE)
     }
 
     private fun showPlayVideoWithSurfaceSafeguard(source: BackgroundSource) {

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -48,7 +48,6 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.automattic.photoeditor.OnPhotoEditorListener
 import com.automattic.photoeditor.PhotoEditor
-import com.automattic.photoeditor.SaveSettings
 import com.automattic.photoeditor.camera.interfaces.CameraSelection
 import com.automattic.photoeditor.camera.interfaces.FlashIndicatorState
 import com.automattic.photoeditor.camera.interfaces.ImageCaptureListener
@@ -1629,14 +1628,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                 val file = getLoopFrameFile(this, true, "tmp")
                 file.createNewFile()
 
-                val saveSettings = SaveSettings.Builder()
-                    .setClearViewsEnabled(true)
-                    .setTransparencyEnabled(true)
-                    .build()
-
                 photoEditor.saveVideoFromStaticBackgroundAsFile(
                     file.absolutePath,
-                    saveSettings,
                     object : PhotoEditor.OnSaveWithCancelListener {
                         override fun onCancel(noAddedViews: Boolean) {
                             // TODO not implemented

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -220,6 +220,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     private val timesUpRunnable = Runnable {
         stopRecordingVideo(false) // time's up, it's not a cancellation
     }
+    @Suppress("DEPRECATION")
     private val timesUpHandler = Handler()
     private var launchCameraRequestPending = false
     private var launchVideoPlayerRequestPending = false
@@ -571,6 +572,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         }
 
         if (savedInstanceState != null) {
+            @Suppress("DEPRECATION")
             currentOriginalCapturedFile =
                 savedInstanceState.getSerializable(STATE_KEY_CURRENT_ORIGINAL_CAPTURED_FILE) as File?
             preHookRun = savedInstanceState.getBoolean(STATE_KEY_PREHOOK_RUN)
@@ -773,7 +775,8 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
             launchCameraPreviewWithSurfaceSafeguard()
             checkForLowSpaceAndShowDialog()
         } else if (intent.hasExtra(KEY_STORY_SAVE_RESULT)) {
-            val storySaveResult = intent.getParcelableExtra(KEY_STORY_SAVE_RESULT) as StorySaveResult?
+            @Suppress("DEPRECATION") val storySaveResult =
+                    intent.getParcelableExtra(KEY_STORY_SAVE_RESULT) as StorySaveResult?
             if (storySaveResult != null && StoryRepository.isStoryIndexValid(storySaveResult.storyIndex) &&
                     StoryRepository.getStoryAtIndex(storySaveResult.storyIndex).frames.isNotEmpty()) {
                 // dismiss the error notification
@@ -867,6 +870,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         permissionsRequestForCameraInProgress = false
     }
 
+    @Suppress("DEPRECATION")
     override fun onBackPressed() {
         if (!backgroundSurfaceManager.cameraVisible()) {
             contentComposerBinding.closeButton.performClick()
@@ -1183,7 +1187,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
 
     private fun anyOfOriginalIntentResultsIsError(): Boolean {
         if (intent.hasExtra(KEY_STORY_SAVE_RESULT)) {
-            val storySaveResult =
+            @Suppress("DEPRECATION") val storySaveResult =
                 intent.getParcelableExtra(KEY_STORY_SAVE_RESULT) as StorySaveResult?
             storySaveResult?.let {
                 // where there any errors when we opened the Activity to handle those errors?
@@ -1516,7 +1520,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
     }
 
     private fun vibrate() {
-        val vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        @Suppress("DEPRECATION") val vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
         // Vibrate for 100 milliseconds
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             vibrator.vibrate(
@@ -2106,7 +2110,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
                     .submit(screenWidth, screenHeight) // we're not going to export images greater than the screen size
             val drawable = futureTarget.get()
 
-            val doAfterUse = object : ImageLoadedInterface {
+            @Suppress("DEPRECATION") val doAfterUse = object : ImageLoadedInterface {
                 override fun doAfter() {
                     // here setup the PhotoView support matrix
                     // we use a Handler because we need to set the support matrix only once the drawable

--- a/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ComposeLoopFrameActivity.kt
@@ -664,7 +664,7 @@ abstract class ComposeLoopFrameActivity : AppCompatActivity(), OnStoryFrameSelec
         }
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     private fun updateSelectedFrameControls(oldSelection: Int, newSelection: Int) {
         if (storyViewModel.getCurrentStorySize() > newSelection) {
             val selectedFrame = storyViewModel.getCurrentStoryFrameAt(newSelection)

--- a/stories/src/main/java/com/wordpress/stories/compose/ImmersiveUtils.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/ImmersiveUtils.kt
@@ -8,6 +8,7 @@ import android.view.WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION
 
 const val IMMERSIVE_FLAG_TIMEOUT = 500L
 /** Combination of all flags required to put activity into immersive mode */
+@Suppress("DEPRECATION")
 const val FLAGS_FULLSCREEN =
     View.SYSTEM_UI_FLAG_LOW_PROFILE or
             View.SYSTEM_UI_FLAG_FULLSCREEN or
@@ -16,11 +17,11 @@ const val FLAGS_FULLSCREEN =
             View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
             View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
 
-fun hideSystemUI(window: Window) {
+@Suppress("DEPRECATION") fun hideSystemUI(window: Window) {
     window.decorView.systemUiVisibility = FLAGS_FULLSCREEN
 }
 
-fun hideStatusBar(window: Window) {
+@Suppress("DEPRECATION") fun hideStatusBar(window: Window) {
     window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_FULLSCREEN
             or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
             or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
@@ -32,7 +33,7 @@ fun hideStatusBar(window: Window) {
 
 // Shows the system bars by removing all the flags
 // except for the ones that make the content appear under the system bars.
-fun showSystemUI(window: Window) {
+@Suppress("DEPRECATION") fun showSystemUI(window: Window) {
     window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
             or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
             or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN)

--- a/stories/src/main/java/com/wordpress/stories/compose/PressAndHoldGestureHelper.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/PressAndHoldGestureHelper.kt
@@ -20,6 +20,7 @@ class PressAndHoldGestureHelper(
 ) : View.OnTouchListener {
     private var holding = false
     private var canceled = false
+    @Suppress("DEPRECATION")
     private var handler = Handler()
     private val runnable = Runnable {
         // when this section runs, it means they've been holding the button

--- a/stories/src/main/java/com/wordpress/stories/compose/emoji/EmojiPickerFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/emoji/EmojiPickerFragment.kt
@@ -82,6 +82,7 @@ class EmojiPickerFragment : BottomSheetDialogFragment() {
             dialog.setContentView(binding.root)
             val params = binding.root.layoutParams as CoordinatorLayout.LayoutParams
 
+            @Suppress("DEPRECATION")
             (params.behavior as? BottomSheetBehavior)?.setBottomSheetCallback(bottomSheetBehaviorCallback)
             (params.behavior as? BottomSheetBehavior)?.state = BottomSheetBehavior.STATE_EXPANDED
 

--- a/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveNotifier.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/frame/FrameSaveNotifier.kt
@@ -40,9 +40,10 @@ class FrameSaveNotifier(private val context: Context, private val service: Frame
             context.applicationContext,
             context.getString(R.string.notification_channel_transient_id)
         ).apply {
-                setSmallIcon(android.R.drawable.stat_sys_upload)
-                color = context.resources.getColor(R.color.primary_50)
-                setOnlyAlertOnce(true)
+            setSmallIcon(android.R.drawable.stat_sys_upload)
+            @Suppress("DEPRECATION")
+            color = context.resources.getColor(R.color.primary_50)
+            setOnlyAlertOnce(true)
         }
     }
 
@@ -127,6 +128,7 @@ class FrameSaveNotifier(private val context: Context, private val service: Frame
             // reset the notification id so a new one is generated next time the service is started
             notificationData.notificationId = 0
             resetNotificationCounters()
+            @Suppress("DEPRECATION")
             service.stopForeground(true)
             return true
         }
@@ -323,6 +325,7 @@ class FrameSaveNotifier(private val context: Context, private val service: Frame
         }
 
         // Add MANAGE action and default action
+        @Suppress("DEPRECATION")
         notificationBuilder.addAction(
             0, context.getString(R.string.story_saving_failed_quick_action_manage),
             pendingIntent

--- a/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/story/StoryRepository.kt
@@ -124,11 +124,9 @@ object StoryRepository {
         // iterate over the StorySaveResult, check their indexes, and set the corresponding frame result
         if (isStoryIndexValid(storyIndex)) {
             for (index in 0..saveResult.frameSaveResult.size - 1) {
-                if (saveResult.frameSaveResult[index] != null) {
-                    val frameIdxToSet = saveResult.frameSaveResult[index].frameIndex
-                    stories[storyIndex].frames[frameIdxToSet].saveResultReason =
-                            saveResult.frameSaveResult[index].resultReason
-                }
+                val frameIdxToSet = saveResult.frameSaveResult[index].frameIndex
+                stories[storyIndex].frames[frameIdxToSet].saveResultReason =
+                        saveResult.frameSaveResult[index].resultReason
             }
         }
     }

--- a/stories/src/main/java/com/wordpress/stories/compose/text/TextStyleGroupManager.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/text/TextStyleGroupManager.kt
@@ -162,7 +162,7 @@ class TextStyleGroupManager(val context: Context) {
     }
 
     fun getAnalyticsLabelFor(@TypefaceId typefaceId: Int): String {
-        return supportedTypefaces[typefaceId]?.label?.toLowerCase(Locale.ROOT).orEmpty()
+        return supportedTypefaces[typefaceId]?.label?.lowercase(Locale.ROOT).orEmpty()
     }
 
     private fun adjustTextViewLabelAlignment(@TypefaceId typefaceId: Int, textView: TextView) {

--- a/stories/src/main/java/com/wordpress/stories/util/BundleUtils.kt
+++ b/stories/src/main/java/com/wordpress/stories/util/BundleUtils.kt
@@ -19,7 +19,7 @@ fun getStoryIndexFromIntentOrBundle(savedInstanceState: Bundle?, intent: Intent?
     // if selection could not be obtained as KEY_STORY_INDEX intent extra or savedInstanceState,
     // see if we're getting one from KEY_STORY_SAVE_RESULT.
     if (index == DEFAULT_NONE_SELECTED) {
-        val saveResult = intent?.getParcelableExtra(KEY_STORY_SAVE_RESULT) as StorySaveResult?
+        @Suppress("DEPRECATION") val saveResult = intent?.getParcelableExtra(KEY_STORY_SAVE_RESULT) as StorySaveResult?
         saveResult?.let {
             index = it.storyIndex
         }

--- a/stories/src/main/java/com/wordpress/stories/util/DisplayUtils.kt
+++ b/stories/src/main/java/com/wordpress/stories/util/DisplayUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Point
 import android.view.WindowManager
 
+@Suppress("DEPRECATION")
 fun getDisplayPixelSize(context: Context): Point {
     val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     val display = wm.defaultDisplay

--- a/stories/src/main/java/com/wordpress/stories/util/MediaUtils.kt
+++ b/stories/src/main/java/com/wordpress/stories/util/MediaUtils.kt
@@ -3,7 +3,7 @@ package com.wordpress.stories.util
 import java.util.Locale
 // comes from WPAndroid WordPressUtils
 fun isVideo(rawUrl: String?): Boolean {
-    rawUrl?.toLowerCase(Locale.ROOT)?.let { url ->
+    rawUrl?.lowercase(Locale.ROOT)?.let { url ->
         return (url.endsWith(".ogv") || url.endsWith(".mp4") || url.endsWith(".m4v") ||
                 url.endsWith(".mov") || url.endsWith(".wmv") || url.endsWith(".avi") ||
                 url.endsWith(".mpg") || url.endsWith(".3gp") || url.endsWith(".3g2") ||


### PR DESCRIPTION
This PR resolves/suppresses all warnings for all modules and then enables all warnings as errors as the default for this project (a976caf9c721c7d54c8f4c9e58ca4d92c5af48de).

PS: This is just a follow-up PR of the previous more important #734 PR to restrict further Kotlin related warnings to creep into this repo and with it to also enable future Kotlin updates, for example see below warning that would have made the Kotlin `1.7` update a bit more in the future:

`Non exhaustive 'when' statements on enum will be prohibited in 1.7, add 'XYZ' branches or 'else' branch instead`

-----

Warnings Resolution List:

- `mp4compose`:
    1. [Resolve unnecessary assertion type warning for mp4compose](https://github.com/Automattic/stories-android/commit/53a0c011f2cfec508406f99cdca1ee19cc32b99f)
    2. [Resolve unnecessary safe call type warning for mp4compose](https://github.com/Automattic/stories-android/commit/f1ebd698131594e06379aec7751f2b41b1c0eed8)
    3. [Resolve string type mismatch type warnings for mp4compose](https://github.com/Automattic/stories-android/commit/e9dfdee280006b8c4a7c9f6d2f0161c965d9a454)
    4. [Resolve byte array type mismatch type warnings for mp4compose](https://github.com/Automattic/stories-android/commit/9d01c416ec8827544bf9ba03db4d821b0f1d0df6)
    5. [Resolve variable is never used warnings for mp4compose](https://github.com/Automattic/stories-android/commit/d50209563e3200c844bd9dd0037b48902c83345d)
- `photoeditor`
    1. [Resolve non exhaustive when warnings for photoeditor](https://github.com/Automattic/stories-android/commit/21979a84ad576c994e562aa28ae28a8f80445aca)
    2. [Resolve parameter is never used warning for photoeditor](https://github.com/Automattic/stories-android/commit/731a66b9bec8034f635f043ef57cc9dfb2afc052)
    3. [Resolve parameter be renamed to _ warnings for photoeditor](https://github.com/Automattic/stories-android/commit/b0d2a60f7b2886473e883ca93fed488259fecd63)
    4. [Resolve string type mismatch type warnings for photoeditor](https://github.com/Automattic/stories-android/commit/d8936c0256873922e264e03b95b9b87eb9b3c776)
- `stories`
    1. [Resolve non exhaustive when warning for stories](https://github.com/Automattic/stories-android/commit/85d40e3e5496d5c4afc3358af860b4286cddc3fe)
    2. [Resolve condition always true warning for stories](https://github.com/Automattic/stories-android/commit/73e3ac8197b0e9e02f0bbd25530388538daf3d9d)
    3. [Resolve to lower case deprecated warnings for stories](https://github.com/Automattic/stories-android/commit/5b6aa06e5e98840916a35b3ccc0629dc38a18cc2)
- `app`
    1. [Resolve parameter be renamed to _ warnings for app](https://github.com/Automattic/stories-android/commit/da03525a0516d665c7d2c2bf6c65e12dafff81e9)

Warnings Suppression List:

- `mp4compose`
    1. [Suppress all deprecated warnings for mp4compose](https://github.com/Automattic/stories-android/commit/3403c2ad6f9a158adf93fd3adc31ec95571f4a32)
- `photoeditor`
    1. [Suppress listener deprecated warnings for photoeditor](https://github.com/Automattic/stories-android/commit/5cbbb01b1170dda3cd0a86eceeb93c309647fcfe)
    2. [Suppress parameter is never used warning for photoeditor](https://github.com/Automattic/stories-android/commit/77bc1e44839ce95998dafd583005033ad1e82399)
    3. [Suppress all deprecated warnings for photoeditor](https://github.com/Automattic/stories-android/commit/20a53ebf2199f23e52d875a6e8529681925a0347)
- `stories`
    1. [Suppress all deprecated warnings for stories](https://github.com/Automattic/stories-android/commit/8225f3c51e6ac3987fca8057c6abae090197ac8f)
    2. [Suppress parameter is never used warning for stories](https://github.com/Automattic/stories-android/commit/667b2d50dfce872d85703c33e54619424bb8b6f6)
- `app`
    1. [Suppress all deprecated warnings for app](https://github.com/Automattic/stories-android/commit/ba91f2532cc0119937de0f2f74ec8add43b69ef6)

-----

## To test

1. There is nothing much to test here (if not all, most of the deprecated warnings were suppressed).
13. Verifying that all the CI checks are successful should be enough.
14. However, if you want to be thorough about reviewing this change, you could quickly smoke test the example `app` and see if it is working as expected.