### PR TITLE
Fix EmojiPicker crash when getting LayoutParams

### DIFF
--- a/stories/src/main/java/com/wordpress/stories/compose/emoji/EmojiPickerFragment.kt
+++ b/stories/src/main/java/com/wordpress/stories/compose/emoji/EmojiPickerFragment.kt
@@ -78,9 +78,8 @@ class EmojiPickerFragment : BottomSheetDialogFragment() {
         super.setupDialog(dialog, style)
         activity?.let { activity ->
             val binding = FragmentBottomStickerEmojiDialogBinding.inflate(LayoutInflater.from(context))
-//            val contentView = View.inflate(context, R.layout.fragment_bottom_sticker_emoji_dialog, null)
             dialog.setContentView(binding.root)
-            val params = binding.root.layoutParams as CoordinatorLayout.LayoutParams
+            val params = (binding.root.parent as View).layoutParams as CoordinatorLayout.LayoutParams
 
             @Suppress("DEPRECATION")
             (params.behavior as? BottomSheetBehavior)?.setBottomSheetCallback(bottomSheetBehaviorCallback)


### PR DESCRIPTION
This crash was happening when flinging upwards in the Stories Compose screen, which should open the Emoji picker, because it was trying to get a Coordinator LayoutParams from a RelativeLayout (as it was using the wrong view).

Testing steps:
1. Install the demo app
2. Select / record a video
3. Swipe up from the bottom of the screen
4. **Verify** app doesn't crash and emojis are shown