### PR TITLE
[Fix] Update targetSdk to 34 and fixed a few issues along the way.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ subprojects {
 ext {
     minSdkVersion = 24
     compileSdkVersion = 34
-    targetSdkVersion = 33
+    targetSdkVersion = 34
 }
 
 ext {
@@ -111,7 +111,7 @@ ext {
     googleMaterialVersion = '1.2.1'
     kotlinxCoroutinesVersion = '1.3.9'
     kotlinxSerializationVersion = '1.0-M1-1.4.0-rc'
-    sentryAndroidVersion = "5.0.1"
+    sentryAndroidVersion = "6.32.0"
     slf4jVersion = '1.7.25'
 
     // test

--- a/stories/src/main/AndroidManifest.xml
+++ b/stories/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application>
         <activity
@@ -14,7 +15,8 @@
         <!-- Services -->
         <service
             android:name="com.wordpress.stories.compose.frame.FrameSaveService"
-            android:label="Frame Save Service" />
+            android:label="Frame Save Service"
+            android:foregroundServiceType="dataSync"/>
         <meta-data
             android:name="preloaded_fonts"
             android:resource="@array/preloaded_fonts" />


### PR DESCRIPTION
Issue: https://github.com/Automattic/stories-android/issues/744
Parent: https://github.com/orgs/wordpress-mobile/projects/223

This PR updates the `targetSdk` version to 34. During testing, two issues were found:

1. Services now **require** a `foregroundServiceType`.
2. Sentry needed to be updated. Found an [issue](https://github.com/getsentry/sentry-java/issues/2986) on Sentry's repo and the [corresponding fix](https://github.com/getsentry/sentry-java/pull/2990). It was [released in 6.32.0](https://github.com/getsentry/sentry-java/releases/tag/6.32.0). I realize this increases risk, so I only updated Sentry to the lowest possible version that avoided the crash.

Something to note. I used [datasync](https://developer.android.com/about/versions/14/changes/fgs-types-required#data-sync) as the foreground service type. This makes sense as we are processing the image and the camera does not need to be open for this. But feel free to make sure I chose the right foreground service type as a second pair of eyes.

Note:

I tested this with the sample app and Wordpress Android. Worked fine on both.